### PR TITLE
feat(acp): G4 PR-1 — surface permission modes + task plan as session/update

### DIFF
--- a/agentao/acp/_transport_helpers.py
+++ b/agentao/acp/_transport_helpers.py
@@ -49,6 +49,46 @@ def _tool_kind(tool_name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# todo_write → ACP ``plan`` update
+# ---------------------------------------------------------------------------
+
+_PLAN_ENTRY_STATUS = frozenset({"pending", "in_progress", "completed"})
+
+
+def _todo_write_plan(raw_args: Any) -> Dict[str, Any] | None:
+    """Map ``todo_write`` tool args to an ACP ``plan`` update, or ``None``.
+
+    The ``todos`` list comes from the LLM and may be malformed, so it is
+    validated rather than trusted: every entry must be a dict with a string
+    ``content`` and a ``status`` in the ACP ``PlanEntryStatus`` set. agentao
+    todos have no priority while ACP requires one, so every entry is emitted
+    as ``"medium"``.
+
+    Validation is **all-or-nothing**: an ACP ``plan`` replaces the *entire*
+    checklist on each update, so silently dropping a malformed entry would
+    make a real task vanish from the client's view. If the list is empty or
+    *any* entry is malformed, return ``None`` so the caller falls back to the
+    normal ``tool_call`` mapping (which carries the full raw args) instead of
+    emitting a truncated or empty plan.
+    """
+    todos = raw_args.get("todos") if isinstance(raw_args, dict) else None
+    if not isinstance(todos, list) or not todos:
+        return None
+    entries = []
+    for t in todos:
+        if not (
+            isinstance(t, dict)
+            and isinstance(t.get("content"), str)
+            and t.get("status") in _PLAN_ENTRY_STATUS
+        ):
+            return None  # any malformed entry → fall back, never truncate
+        entries.append(
+            {"content": t["content"], "priority": "medium", "status": t["status"]}
+        )
+    return {"sessionUpdate": "plan", "entries": entries}
+
+
+# ---------------------------------------------------------------------------
 # JSON safety coercion
 # ---------------------------------------------------------------------------
 

--- a/agentao/acp/schema.py
+++ b/agentao/acp/schema.py
@@ -193,9 +193,38 @@ class AcpSessionNewRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class AcpSessionMode(BaseModel):
+    """One selectable ACP session mode (``SessionMode``).
+
+    agentao surfaces each :class:`~agentao.permissions.PermissionMode`
+    preset as one of these: ``id`` is the preset's string value (the ACP
+    ``modeId`` a client passes to ``session/set_mode``), ``name`` is a
+    human label, ``description`` an optional one-liner.
+    """
+
+    id: str
+    name: str
+    description: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AcpSessionModeState(BaseModel):
+    """``SessionModeState`` — advertised on the ``session/new`` response.
+
+    ``currentModeId`` is the active preset; ``availableModes`` is the full
+    set a client can switch between via ``session/set_mode``.
+    """
+
+    currentModeId: str
+    availableModes: List[AcpSessionMode]
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class AcpSessionNewResponse(BaseModel):
     sessionId: str
-    modes: Optional[Dict[str, Any]] = None
+    modes: Optional[AcpSessionModeState] = None
     models: Optional[Dict[str, Any]] = None
     # Advertised so clients can switch model/provider via
     # ``session/set_config_option`` without a follow-up list call. Default
@@ -564,11 +593,51 @@ class AcpSessionUpdateToolCallUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class AcpPlanEntry(BaseModel):
+    """One entry in a ``plan`` update (``PlanEntry``).
+
+    agentao's ``todo_write`` carries only ``content`` + ``status``; ACP
+    requires ``priority`` too, so the transport synthesizes ``"medium"``.
+    """
+
+    content: str
+    priority: Literal["high", "medium", "low"]
+    status: Literal["pending", "in_progress", "completed"]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AcpSessionUpdatePlan(BaseModel):
+    """``plan`` — the agent's task checklist; the client replaces the whole
+    plan on each update."""
+
+    sessionUpdate: Literal["plan"] = "plan"
+    entries: List[AcpPlanEntry]
+    schema_version: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AcpSessionUpdateCurrentMode(BaseModel):
+    """``current_mode_update`` — the active session mode changed.
+
+    Emitted by the ``session/set_mode`` handler (the ACP standard set_mode
+    response is empty; the change is communicated via this notification)."""
+
+    sessionUpdate: Literal["current_mode_update"] = "current_mode_update"
+    currentModeId: str
+    schema_version: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
 AcpSessionUpdate = Annotated[
     Union[
         AcpSessionUpdateMessageChunk,
         AcpSessionUpdateToolCall,
         AcpSessionUpdateToolCallUpdate,
+        AcpSessionUpdatePlan,
+        AcpSessionUpdateCurrentMode,
     ],
     Field(discriminator="sessionUpdate"),
 ]

--- a/agentao/acp/session_load.py
+++ b/agentao/acp/session_load.py
@@ -407,8 +407,9 @@ def resume_session_on_new(
     loads the history, and reuses the shared loader so the reloaded session
     is indistinguishable from one created by ``session/load``.
 
-    Returns ``{"sessionId", "configOptions"}`` on success — the same shape
-    ``session/new`` returns, so the client transparently continues the
+    Returns ``{"sessionId", "configOptions", "modes"?}`` on success — the
+    same shape ``session/new`` returns (``modes`` advertised when the session
+    has a permission engine), so the client transparently continues the
     restored conversation. Returns ``None`` when there is nothing to resume,
     so the caller falls back to a normal fresh session rather than failing
     the request. ``None`` is returned for any recoverable problem: no
@@ -463,10 +464,20 @@ def resume_session_on_new(
         origin="resume",
     )
 
-    return {
+    # Advertise the permission presets as ACP session modes, exactly as a
+    # fresh session/new does — the resumed session owns an identical engine,
+    # so a --resume client must get the same mode selector. Lazy import to
+    # avoid a module-load cycle (session_new imports this module for resume).
+    from .session_new import _session_modes
+
+    response: Dict[str, Any] = {
         "sessionId": session_id,
         "configOptions": config_options_for_session(server, state),
     }
+    modes = _session_modes(state)
+    if modes is not None:
+        response["modes"] = modes
+    return response
 
 
 # ---------------------------------------------------------------------------

--- a/agentao/acp/session_new.py
+++ b/agentao/acp/session_new.py
@@ -32,6 +32,8 @@ import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
+from agentao.permissions import PermissionMode
+
 from .mcp_translate import translate_acp_mcp_servers
 from .models import AcpSessionState
 from .protocol import METHOD_SESSION_NEW, SERVER_NOT_INITIALIZED
@@ -45,6 +47,41 @@ if TYPE_CHECKING:
     from .server import AcpServer
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# ACP session modes (SessionModeState) from the permission presets
+# ---------------------------------------------------------------------------
+
+# Human labels for the permission presets surfaced as ACP session modes.
+# Keyed by the enum so the advertised list can't drift from PermissionMode.
+_MODE_LABELS: Dict[PermissionMode, tuple] = {
+    PermissionMode.READ_ONLY: ("Read-only", "No writes or shell."),
+    PermissionMode.WORKSPACE_WRITE: ("Workspace write", "Writes + safe shell; asks for web."),
+    PermissionMode.FULL_ACCESS: ("Full access", "All tools, no prompts."),
+    PermissionMode.PLAN: ("Plan", "Plans only; does not execute."),
+}
+
+# The advertised mode catalog is static (only ``currentModeId`` is dynamic),
+# so build it once at import rather than on every session/new.
+_AVAILABLE_MODES: List[Dict[str, str]] = [
+    {"id": mode.value, "name": label, "description": desc}
+    for mode, (label, desc) in _MODE_LABELS.items()
+]
+
+
+def _session_modes(state: AcpSessionState) -> Optional[Dict[str, Any]]:
+    """Build the ACP ``modes`` (``SessionModeState``) for the session/new
+    response from the session's live permission engine.
+
+    Returns ``None`` (field omitted) when the session has no engine — a
+    standard client then simply sees no mode selector.
+    """
+    agent = state.agent
+    engine = getattr(agent, "permission_engine", None) if agent is not None else None
+    if engine is None:
+        return None
+    return {"currentModeId": engine.active_mode.value, "availableModes": _AVAILABLE_MODES}
 
 
 # ---------------------------------------------------------------------------
@@ -418,10 +455,16 @@ def handle_session_new(
     # Advertise the model config option so clients can switch model/provider
     # via the standard ``session/set_config_option`` path. Default catalog is
     # the single current ``provider/model``; richer catalogs are host-injected.
-    return {
+    response: Dict[str, Any] = {
         "sessionId": session_id,
         "configOptions": config_options_for_session(server, state),
     }
+    # Advertise the permission presets as ACP session modes so a client can
+    # render a mode selector and drive ``session/set_mode``.
+    modes = _session_modes(state)
+    if modes is not None:
+        response["modes"] = modes
+    return response
 
 
 # ---------------------------------------------------------------------------

--- a/agentao/acp/session_set_mode.py
+++ b/agentao/acp/session_set_mode.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 from agentao.permissions import PermissionMode
 
 from ._handler_utils import hold_idle_turn_lock, require_active_session
-from .protocol import INVALID_REQUEST, METHOD_SESSION_SET_MODE
+from .protocol import INVALID_REQUEST, METHOD_SESSION_SET_MODE, METHOD_SESSION_UPDATE
 from .server import JsonRpcHandlerError
 
 if TYPE_CHECKING:
@@ -51,6 +51,37 @@ def _as_permission_mode(mode_id: str) -> Optional[PermissionMode]:
         return PermissionMode(mode_id)
     except ValueError:
         return None
+
+
+def _emit_current_mode_update(
+    server: "AcpServer", session_id: str, mode_id: str
+) -> None:
+    """Emit a ``current_mode_update`` session/update for the mode change.
+
+    ACP communicates a mode change via this notification — the standard
+    ``session/set_mode`` response is empty. Nothing else on the ACP path
+    emits it: ``PermissionEngine.set_mode`` is silent and the
+    ``PERMISSION_MODE_CHANGED`` event is CLI-only, so the handler must emit
+    here. ``mode_id`` is echoed verbatim, including non-preset UI modeIds
+    (e.g. DeepChat's ``code``/``ask``) that are not in ``availableModes``.
+
+    Best-effort: a notification failure must not fail the set_mode request.
+    """
+    try:
+        server.write_notification(
+            METHOD_SESSION_UPDATE,
+            {
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": "current_mode_update",
+                    "currentModeId": mode_id,
+                },
+            },
+        )
+    except Exception:
+        logger.exception(
+            "acp: failed to emit current_mode_update for session %s", session_id
+        )
 
 
 def handle_session_set_mode(server: "AcpServer", params: Any) -> Dict[str, Any]:
@@ -83,7 +114,13 @@ def handle_session_set_mode(server: "AcpServer", params: Any) -> Dict[str, Any]:
                 mode_id,
             )
         session.mode_id = mode_id
-        return {"modeId": session.mode_id}
+
+    # Emit ``current_mode_update`` outside the turn lock — write_notification
+    # serializes its own writes, so there's no need to hold turn_lock across
+    # the I/O. Keep returning ``{modeId}`` for DeepChat back-compat; a
+    # standard client reads the notification and ignores the extra field.
+    _emit_current_mode_update(server, session.session_id, mode_id)
+    return {"modeId": mode_id}
 
 
 def register(server: "AcpServer") -> None:

--- a/agentao/acp/transport.py
+++ b/agentao/acp/transport.py
@@ -110,7 +110,13 @@ from typing import TYPE_CHECKING, Any, Dict
 from agentao.transport.events import AgentEvent, EventType
 
 from .protocol import METHOD_SESSION_UPDATE
-from ._transport_helpers import _json_safe, _text_block, _tool_content_text, _tool_kind
+from ._transport_helpers import (
+    _json_safe,
+    _text_block,
+    _todo_write_plan,
+    _tool_content_text,
+    _tool_kind,
+)
 from ._transport_interaction import _InteractionMixin, _build_permission_options
 from ._transport_interaction import (  # re-exported for back-compat
     PERMISSION_ALLOW_ALWAYS,
@@ -140,6 +146,7 @@ __all__ = [
     "PERMISSION_REJECT_ALWAYS",
     "_json_safe",
     "_tool_kind",
+    "_todo_write_plan",
     "_text_block",
     "_tool_content_text",
     "_build_permission_options",
@@ -169,6 +176,12 @@ class ACPTransport(_ReplayMixin, _InteractionMixin):
         self._session_id = session_id
         from ..transport.broadcast import EventBroadcaster
         self._broadcast = EventBroadcaster()
+        # call_id → deferred ACP ``plan`` update for an in-flight ``todo_write``.
+        # The plan is built at TOOL_START but only emitted at TOOL_COMPLETE if
+        # the call applied (status "ok"), so a denied/failed checklist update
+        # never renders as if it took effect. Entries are popped on completion;
+        # TOOL_START/TOOL_COMPLETE always pair, so this stays bounded.
+        self._todo_plan_calls: Dict[str, Dict[str, Any]] = {}
 
     # -- One-way events ----------------------------------------------------
 
@@ -237,6 +250,18 @@ class ACPTransport(_ReplayMixin, _InteractionMixin):
             tool = str(data.get("tool", "unknown"))
             call_id = str(data.get("call_id", ""))
             raw_args = data.get("args", {})
+            if tool == "todo_write":
+                # Surface the task checklist as a native ACP ``plan`` rather
+                # than a ``tool_call`` — but DEFER it to TOOL_COMPLETE so a
+                # denied (read-only mode) or failed call never renders a plan
+                # as if it applied. Stash the validated plan keyed by call_id;
+                # it is emitted from the TOOL_COMPLETE branch on status "ok".
+                # If the todos are empty/malformed, fall through to the normal
+                # tool_call mapping (which then completes normally below).
+                plan = _todo_write_plan(raw_args)
+                if plan is not None:
+                    self._todo_plan_calls[call_id] = plan
+                    return None
             return {
                 "sessionUpdate": "tool_call",
                 "toolCallId": call_id,
@@ -260,6 +285,18 @@ class ACPTransport(_ReplayMixin, _InteractionMixin):
 
         if etype == EventType.TOOL_COMPLETE:
             call_id = str(data.get("call_id", ""))
+            if str(data.get("tool", "")) == "todo_write":
+                plan = self._todo_plan_calls.pop(call_id, None)
+                if plan is not None:
+                    # A deferred plan: emit it only if the call actually
+                    # applied. On a denied/failed/cancelled call, emit nothing
+                    # — the checklist never changed and TOOL_START emitted no
+                    # opening ``tool_call`` to close, so the sequence stays
+                    # consistent.
+                    return plan if data.get("status", "ok") == "ok" else None
+                # No deferred plan for this call_id → TOOL_START emitted a real
+                # ``tool_call`` (the empty/malformed fallback), so let it
+                # complete normally below rather than orphan a pending call.
             status = data.get("status", "ok")
             # Agentao uses "ok" | "error" | "cancelled"; ACP uses
             # "completed" | "failed". Map conservatively — "cancelled"

--- a/docs/schema/host.acp.v1.json
+++ b/docs/schema/host.acp.v1.json
@@ -732,6 +732,41 @@
       "title": "AcpPermissionOption",
       "type": "object"
     },
+    "AcpPlanEntry": {
+      "additionalProperties": false,
+      "description": "One entry in a ``plan`` update (``PlanEntry``).\n\nagentao's ``todo_write`` carries only ``content`` + ``status``; ACP\nrequires ``priority`` too, so the transport synthesizes ``\"medium\"``.",
+      "properties": {
+        "content": {
+          "title": "Content",
+          "type": "string"
+        },
+        "priority": {
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "title": "Priority",
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "pending",
+            "in_progress",
+            "completed"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "priority",
+        "status"
+      ],
+      "title": "AcpPlanEntry",
+      "type": "object"
+    },
     "AcpRequestPermissionCancelled": {
       "additionalProperties": false,
       "properties": {
@@ -977,6 +1012,61 @@
       "title": "AcpSessionLoadResponse",
       "type": "object"
     },
+    "AcpSessionMode": {
+      "additionalProperties": false,
+      "description": "One selectable ACP session mode (``SessionMode``).\n\nagentao surfaces each :class:`~agentao.permissions.PermissionMode`\npreset as one of these: ``id`` is the preset's string value (the ACP\n``modeId`` a client passes to ``session/set_mode``), ``name`` is a\nhuman label, ``description`` an optional one-liner.",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ],
+      "title": "AcpSessionMode",
+      "type": "object"
+    },
+    "AcpSessionModeState": {
+      "additionalProperties": false,
+      "description": "``SessionModeState`` \u2014 advertised on the ``session/new`` response.\n\n``currentModeId`` is the active preset; ``availableModes`` is the full\nset a client can switch between via ``session/set_mode``.",
+      "properties": {
+        "availableModes": {
+          "items": {
+            "$ref": "#/$defs/AcpSessionMode"
+          },
+          "title": "Availablemodes",
+          "type": "array"
+        },
+        "currentModeId": {
+          "title": "Currentmodeid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "currentModeId",
+        "availableModes"
+      ],
+      "title": "AcpSessionModeState",
+      "type": "object"
+    },
     "AcpSessionNewRequest": {
       "additionalProperties": false,
       "properties": {
@@ -1033,15 +1123,13 @@
         "modes": {
           "anyOf": [
             {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/$defs/AcpSessionModeState"
             },
             {
               "type": "null"
             }
           ],
-          "default": null,
-          "title": "Modes"
+          "default": null
         },
         "sessionId": {
           "title": "Sessionid",
@@ -1292,6 +1380,39 @@
       "title": "AcpSessionUpdateContentBlock",
       "type": "object"
     },
+    "AcpSessionUpdateCurrentMode": {
+      "additionalProperties": false,
+      "description": "``current_mode_update`` \u2014 the active session mode changed.\n\nEmitted by the ``session/set_mode`` handler (the ACP standard set_mode\nresponse is empty; the change is communicated via this notification).",
+      "properties": {
+        "currentModeId": {
+          "title": "Currentmodeid",
+          "type": "string"
+        },
+        "schema_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Schema Version"
+        },
+        "sessionUpdate": {
+          "const": "current_mode_update",
+          "default": "current_mode_update",
+          "title": "Sessionupdate",
+          "type": "string"
+        }
+      },
+      "required": [
+        "currentModeId"
+      ],
+      "title": "AcpSessionUpdateCurrentMode",
+      "type": "object"
+    },
     "AcpSessionUpdateMessageChunk": {
       "additionalProperties": false,
       "description": "``agent_message_chunk`` / ``agent_thought_chunk`` /\n``user_message_chunk`` carry a single content block.",
@@ -1341,6 +1462,8 @@
             "mapping": {
               "agent_message_chunk": "#/$defs/AcpSessionUpdateMessageChunk",
               "agent_thought_chunk": "#/$defs/AcpSessionUpdateMessageChunk",
+              "current_mode_update": "#/$defs/AcpSessionUpdateCurrentMode",
+              "plan": "#/$defs/AcpSessionUpdatePlan",
               "tool_call": "#/$defs/AcpSessionUpdateToolCall",
               "tool_call_update": "#/$defs/AcpSessionUpdateToolCallUpdate",
               "user_message_chunk": "#/$defs/AcpSessionUpdateMessageChunk"
@@ -1356,6 +1479,12 @@
             },
             {
               "$ref": "#/$defs/AcpSessionUpdateToolCallUpdate"
+            },
+            {
+              "$ref": "#/$defs/AcpSessionUpdatePlan"
+            },
+            {
+              "$ref": "#/$defs/AcpSessionUpdateCurrentMode"
             }
           ],
           "title": "Update"
@@ -1366,6 +1495,42 @@
         "update"
       ],
       "title": "AcpSessionUpdateParams",
+      "type": "object"
+    },
+    "AcpSessionUpdatePlan": {
+      "additionalProperties": false,
+      "description": "``plan`` \u2014 the agent's task checklist; the client replaces the whole\nplan on each update.",
+      "properties": {
+        "entries": {
+          "items": {
+            "$ref": "#/$defs/AcpPlanEntry"
+          },
+          "title": "Entries",
+          "type": "array"
+        },
+        "schema_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Schema Version"
+        },
+        "sessionUpdate": {
+          "const": "plan",
+          "default": "plan",
+          "title": "Sessionupdate",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entries"
+      ],
+      "title": "AcpSessionUpdatePlan",
       "type": "object"
     },
     "AcpSessionUpdateToolCall": {

--- a/tests/test_acp_resume_on_startup.py
+++ b/tests/test_acp_resume_on_startup.py
@@ -117,6 +117,33 @@ def test_first_session_new_resumes_latest(initialized_server, tmp_path):
     assert initialized_server.resume_directive.consume() is False
 
 
+def test_resume_advertises_modes_like_fresh_session_new(initialized_server, tmp_path):
+    """A --resume client must get the same SessionModeState a fresh
+    session/new advertises — the resumed session owns an identical engine."""
+    from agentao.permissions import PermissionMode
+
+    class _StubEngine:
+        active_mode = PermissionMode.WORKSPACE_WRITE
+
+    _persist(tmp_path, "sess_resume_modes", [{"role": "user", "content": "hi"}])
+    initialized_server.resume_directive = ResumeDirective(session_id=None)
+    agent = FakeAgent()
+    agent.permission_engine = _StubEngine()  # type: ignore[attr-defined]
+
+    result = acp_session_new.handle_session_new(
+        initialized_server,
+        _minimal_params(tmp_path),
+        agent_factory=make_factory(agent),
+    )
+
+    assert result["sessionId"] == "sess_resume_modes"
+    modes = result["modes"]
+    assert modes["currentModeId"] == "workspace-write"
+    assert [m["id"] for m in modes["availableModes"]] == [
+        "read-only", "workspace-write", "full-access", "plan",
+    ]
+
+
 def test_resume_specific_session_by_id(initialized_server, tmp_path):
     _persist(tmp_path, "sess_alpha", [{"role": "user", "content": "alpha"}])
     _persist(tmp_path, "sess_beta", [{"role": "user", "content": "beta"}])

--- a/tests/test_acp_session_new.py
+++ b/tests/test_acp_session_new.py
@@ -32,6 +32,7 @@ from agentao.acp.protocol import (
 from agentao.acp.server import AcpServer
 from agentao.acp.session_manager import DuplicateSessionError
 from agentao.acp.transport import ACPTransport
+from agentao.permissions import PermissionMode
 
 from .support.acp_agents import (
     ExplodingAgent,
@@ -615,3 +616,76 @@ def test_session_new_assigns_session_id_to_agent(initialized_server, abs_tmp_dir
     assert state.agent is calls[0]["transport"]._server.sessions.require(
         session_id
     ).agent
+
+
+# ---------------------------------------------------------------------------
+# Session modes (G4) — typed SessionModeState on the session/new response
+# ---------------------------------------------------------------------------
+
+class _StubEngine:
+    """Minimal permission-engine stand-in exposing ``active_mode``."""
+
+    def __init__(self, mode: PermissionMode = PermissionMode.WORKSPACE_WRITE) -> None:
+        self.active_mode = mode
+
+
+def _moded_factory(mode: PermissionMode = PermissionMode.WORKSPACE_WRITE):
+    """Agent factory whose agent carries a permission engine in ``mode``."""
+
+    def factory(**kwargs):
+        agent = FakeAgent()
+        agent.permission_engine = _StubEngine(mode)  # type: ignore[attr-defined]
+        return agent
+
+    return factory
+
+
+_EXPECTED_MODE_IDS = ["read-only", "workspace-write", "full-access", "plan"]
+
+
+def test_session_new_advertises_typed_modes(initialized_server, abs_tmp_dir):
+    result = acp_session_new.handle_session_new(
+        initialized_server,
+        _minimal_params(abs_tmp_dir),
+        agent_factory=_moded_factory(PermissionMode.WORKSPACE_WRITE),
+    )
+    modes = result["modes"]
+    assert modes["currentModeId"] == "workspace-write"
+    assert [m["id"] for m in modes["availableModes"]] == _EXPECTED_MODE_IDS
+    # Every advertised mode carries id + name (+ description here).
+    for m in modes["availableModes"]:
+        assert set(m) >= {"id", "name", "description"}
+
+
+def test_session_new_current_mode_reflects_engine(initialized_server, abs_tmp_dir):
+    result = acp_session_new.handle_session_new(
+        initialized_server,
+        _minimal_params(abs_tmp_dir),
+        agent_factory=_moded_factory(PermissionMode.READ_ONLY),
+    )
+    assert result["modes"]["currentModeId"] == "read-only"
+
+
+def test_session_new_omits_modes_without_engine(initialized_server, abs_tmp_dir):
+    # The recording factory yields a FakeAgent with no permission_engine.
+    factory, _ = make_recording_factory()
+    result = acp_session_new.handle_session_new(
+        initialized_server, _minimal_params(abs_tmp_dir), agent_factory=factory
+    )
+    assert "modes" not in result
+
+
+def test_session_modes_helper_none_without_engine():
+    state = AcpSessionState(session_id="x")
+    state.agent = FakeAgent()  # type: ignore[assignment]
+    assert acp_session_new._session_modes(state) is None
+
+
+def test_session_modes_helper_shape():
+    state = AcpSessionState(session_id="x")
+    agent = FakeAgent()
+    agent.permission_engine = _StubEngine(PermissionMode.FULL_ACCESS)  # type: ignore[attr-defined]
+    state.agent = agent  # type: ignore[assignment]
+    modes = acp_session_new._session_modes(state)
+    assert modes["currentModeId"] == "full-access"
+    assert [m["id"] for m in modes["availableModes"]] == _EXPECTED_MODE_IDS

--- a/tests/test_acp_session_set_model.py
+++ b/tests/test_acp_session_set_model.py
@@ -7,8 +7,9 @@ Covers ``session/set_model``, ``session/set_mode``, and
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 import pytest
 
@@ -22,6 +23,7 @@ from agentao.acp.protocol import (
     METHOD_SESSION_LIST_MODELS,
     METHOD_SESSION_SET_MODE,
     METHOD_SESSION_SET_MODEL,
+    METHOD_SESSION_UPDATE,
     SERVER_NOT_INITIALIZED,
 )
 from agentao.acp.server import JsonRpcHandlerError
@@ -98,6 +100,22 @@ def _register_session(server, session_id: str, agent: _FakeAgent) -> AcpSessionS
     state.agent = agent  # type: ignore[assignment]
     server.sessions.create(state)
     return state
+
+
+def _current_mode_updates(server) -> List[Dict[str, Any]]:
+    """Return every ``current_mode_update`` payload written to stdout."""
+    out = []
+    for line in server._out.getvalue().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        msg = json.loads(line)
+        if msg.get("method") != METHOD_SESSION_UPDATE:
+            continue
+        update = msg.get("params", {}).get("update", {})
+        if update.get("sessionUpdate") == "current_mode_update":
+            out.append({"sessionId": msg["params"]["sessionId"], **update})
+    return out
 
 
 # ===========================================================================
@@ -321,6 +339,37 @@ class TestSetMode:
         )
         assert engine_a.active_mode == PermissionMode.READ_ONLY
         assert engine_b.active_mode == PermissionMode.WORKSPACE_WRITE
+
+    def test_preset_change_emits_current_mode_update(self, make_engine):
+        """ACP communicates the mode change via a current_mode_update
+        notification (the set_mode response is non-standard back-compat)."""
+        server = make_initialized_server()
+        _register_session(server, "s", _FakeAgent(permission_engine=make_engine()))
+
+        acp_set_mode.handle_session_set_mode(
+            server, {"sessionId": "s", "modeId": "read-only"}
+        )
+        updates = _current_mode_updates(server)
+        assert updates == [
+            {
+                "sessionId": "s",
+                "sessionUpdate": "current_mode_update",
+                "currentModeId": "read-only",
+            }
+        ]
+
+    def test_unknown_mode_id_also_emits_current_mode_update(self, make_engine):
+        """A non-preset UI modeId is echoed in current_mode_update too, even
+        though it is not one of the availableModes."""
+        server = make_initialized_server()
+        _register_session(server, "s", _FakeAgent(permission_engine=make_engine()))
+
+        acp_set_mode.handle_session_set_mode(
+            server, {"sessionId": "s", "modeId": "code"}
+        )
+        updates = _current_mode_updates(server)
+        assert len(updates) == 1
+        assert updates[0]["currentModeId"] == "code"
 
 
 # ===========================================================================

--- a/tests/test_acp_transport.py
+++ b/tests/test_acp_transport.py
@@ -18,7 +18,7 @@ import pytest
 
 from agentao.acp.protocol import METHOD_SESSION_UPDATE
 from agentao.acp.server import AcpServer
-from agentao.acp.transport import ACPTransport, _json_safe, _tool_kind
+from agentao.acp.transport import ACPTransport, _json_safe, _todo_write_plan, _tool_kind
 from agentao.transport.events import AgentEvent, EventType
 
 
@@ -247,6 +247,161 @@ def test_tool_complete_cancelled_maps_to_failed(transport):
         )
     )
     assert _last_update(server)["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# todo_write → plan (G4)
+#
+# The plan is DEFERRED: TOOL_START stashes it and emits nothing; the `plan`
+# update is emitted from TOOL_COMPLETE only when status == "ok". This keeps a
+# denied (read-only) or failed checklist update from rendering as applied, and
+# lets the empty/malformed fallback `tool_call` complete normally (no orphan).
+# ---------------------------------------------------------------------------
+
+_VALID_TODOS = {
+    "tool": "todo_write",
+    "call_id": "uuid-9",
+    "args": {
+        "todos": [
+            {"content": "Investigate", "status": "in_progress"},
+            {"content": "Fix", "status": "pending"},
+        ]
+    },
+}
+_EXPECTED_PLAN = {
+    "sessionUpdate": "plan",
+    "entries": [
+        {"content": "Investigate", "priority": "medium", "status": "in_progress"},
+        {"content": "Fix", "priority": "medium", "status": "pending"},
+    ],
+    "schema_version": 1,
+}
+
+
+def test_todo_write_start_defers_then_complete_emits_plan(transport):
+    t, server = transport
+    # TOOL_START emits nothing — the plan is deferred until the call applies.
+    t.emit(AgentEvent(EventType.TOOL_START, _VALID_TODOS))
+    assert server.notifications == []
+    # TOOL_COMPLETE (ok) emits the deferred plan; no toolCallId leaks through.
+    t.emit(
+        AgentEvent(
+            EventType.TOOL_COMPLETE,
+            {"tool": "todo_write", "call_id": "uuid-9", "status": "ok"},
+        )
+    )
+    upd = _last_update(server)
+    assert upd == _EXPECTED_PLAN
+    assert "toolCallId" not in upd
+
+
+def test_todo_write_denied_or_failed_emits_no_plan(transport):
+    """A todo_write denied (read-only mode → cancelled) or failed must NOT
+    render a plan as if it applied, and must not orphan anything."""
+    for status in ("cancelled", "error"):
+        t, server = transport
+        t.emit(AgentEvent(EventType.TOOL_START, {**_VALID_TODOS, "call_id": status}))
+        t.emit(
+            AgentEvent(
+                EventType.TOOL_COMPLETE,
+                {"tool": "todo_write", "call_id": status, "status": status},
+            )
+        )
+        assert server.notifications == [], f"status={status} should emit nothing"
+
+
+def test_todo_write_malformed_falls_back_to_tool_call_that_completes(transport):
+    """All-or-nothing: any malformed entry → fall back to a normal tool_call
+    (carrying the raw args), and that tool_call MUST complete (no orphan)."""
+    t, server = transport
+    t.emit(
+        AgentEvent(
+            EventType.TOOL_START,
+            {
+                "tool": "todo_write",
+                "call_id": "u",
+                "args": {"todos": [{"content": "ok", "status": "pending"},
+                                    {"content": 123, "status": "pending"}]},
+            },
+        )
+    )
+    start = _last_update(server)
+    assert start["sessionUpdate"] == "tool_call"
+    assert start["title"] == "todo_write"
+    # The fallback tool_call is closed by its TOOL_COMPLETE (the orphan bug).
+    t.emit(
+        AgentEvent(
+            EventType.TOOL_COMPLETE,
+            {"tool": "todo_write", "call_id": "u", "status": "ok"},
+        )
+    )
+    end = _last_update(server)
+    assert end["sessionUpdate"] == "tool_call_update"
+    assert end["status"] == "completed"
+    assert end["toolCallId"] == "u"
+
+
+def test_todo_write_empty_falls_back_to_tool_call(transport):
+    t, server = transport
+    t.emit(
+        AgentEvent(
+            EventType.TOOL_START,
+            {"tool": "todo_write", "call_id": "u", "args": {"todos": []}},
+        )
+    )
+    assert _last_update(server)["sessionUpdate"] == "tool_call"
+
+
+def test_non_todo_write_complete_still_emits(transport):
+    """Guard: the deferral/drop is scoped to todo_write only."""
+    t, server = transport
+    t.emit(
+        AgentEvent(
+            EventType.TOOL_COMPLETE,
+            {"tool": "read_file", "call_id": "u", "status": "ok"},
+        )
+    )
+    assert _last_update(server)["status"] == "completed"
+
+
+# -- _todo_write_plan unit ---------------------------------------------------
+
+def test_todo_write_plan_valid_synthesizes_medium_priority():
+    plan = _todo_write_plan(
+        {"todos": [{"content": "a", "status": "pending"},
+                   {"content": "b", "status": "completed"}]}
+    )
+    assert plan == {
+        "sessionUpdate": "plan",
+        "entries": [
+            {"content": "a", "priority": "medium", "status": "pending"},
+            {"content": "b", "priority": "medium", "status": "completed"},
+        ],
+    }
+
+
+def test_todo_write_plan_all_or_nothing_on_any_invalid_entry():
+    """A single malformed entry voids the whole plan (full-replace semantics
+    mean a truncated plan would silently drop a real task) → None → fallback."""
+    assert _todo_write_plan(
+        {"todos": [{"content": "ok", "status": "pending"},
+                   {"content": 5, "status": "pending"}]}      # non-str content
+    ) is None
+    assert _todo_write_plan(
+        {"todos": [{"content": "ok", "status": "pending"},
+                   {"content": "x", "status": "weird"}]}      # bad status
+    ) is None
+    assert _todo_write_plan(
+        {"todos": [{"content": "ok", "status": "pending"}, "not-a-dict"]}
+    ) is None
+
+
+def test_todo_write_plan_none_on_empty_or_bad_shape():
+    assert _todo_write_plan({"todos": []}) is None
+    assert _todo_write_plan({"todos": [{"content": 1, "status": "x"}]}) is None
+    assert _todo_write_plan({"todos": "nope"}) is None
+    assert _todo_write_plan("nope") is None
+    assert _todo_write_plan({}) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements **G4 PR-1** from the design doc (`docs/design/acp-g4-plan-modes-commands`, see companion docs PR #100): expose two internal Agentao concepts as standard ACP `session/update` surfaces a chat client renders natively.

## Modes
- Typed `AcpSessionMode` / `AcpSessionModeState` (replacing the loose `modes: Optional[Dict]` placeholder on the session/new response); new `AcpSessionUpdateCurrentMode` union variant.
- `session/new` advertises `modes` built from the live `PermissionEngine` (4 presets, ids from `PermissionMode`; omitted when no engine).
- `session/set_mode` emits `current_mode_update` from the handler (the engine's `set_mode` is silent and `PERMISSION_MODE_CHANGED` is CLI-only), keeping `{modeId}` for DeepChat back-compat.
- **Resume parity:** `resume_session_on_new` advertises the same typed `modes`.

## Plan
- `AcpPlanEntry` + `AcpSessionUpdatePlan` variant. `todo_write` is surfaced as an ACP `plan`.
- The plan is **deferred to `TOOL_COMPLETE` and emitted only on `status=="ok"`** — so a denied (read-only mode) or failed checklist update never renders as applied; empty/malformed todos fall back to a normal `tool_call` that completes normally (no orphaned pending call).
- `_todo_write_plan` validates **all-or-nothing** (a `plan` is full-replace, so a partially-validated list would silently drop real tasks); `priority` synthesized as `"medium"` — no runtime/tool-schema change.

## Review-driven corrections
This branch was run through `/code-review` (10 angles → verify → sweep). The review found the originally-converged "emit plan at `TOOL_START` + drop `TOOL_COMPLETE`" timing was itself buggy (pre-permission-decision emission → phantom plan on denial; orphaned fallback `tool_call`). Fixed by the deferred-on-`TOOL_COMPLETE` design above; the design doc (#100) was reconciled to match. Also fixed: all-or-nothing validation, resume-modes parity, hoisted static `availableModes` catalog.

## Tests
`todo_write` defer/denial/fallback-completion + plan validation, typed `modes` on session/new and resume, `current_mode_update` emission. **Full suite green (3082 passed, 2 skipped).** Schema snapshot regenerated; drift check clean.

## Out of scope / follow-ups
- session/load **replay** still re-emits `todo_write` as `tool_call` not `plan` (separate mechanism in `_transport_replay.py`).
- `schema_version` is typed `Optional[str]` but stamped as int across **all** update models (pre-existing convention).
- A shared `write_session_update` helper would dedup the 3 envelope copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)