### PR TITLE
feat(acp): replay todo_write as plan on session/load

### DIFF
--- a/agentao/acp/_transport_replay.py
+++ b/agentao/acp/_transport_replay.py
@@ -15,7 +15,13 @@ import uuid
 from typing import Any, Dict, Iterable, List
 
 from .protocol import METHOD_SESSION_UPDATE
-from ._transport_helpers import _json_safe, _text_block, _tool_content_text, _tool_kind
+from ._transport_helpers import (
+    _json_safe,
+    _text_block,
+    _todo_write_plan,
+    _tool_content_text,
+    _tool_kind,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +104,16 @@ class _ReplayMixin:
                                content=text result)
         ===================  ============================================
 
+        **``todo_write`` is special-cased to ``plan``** (mirroring the live
+        event path): a persisted ``todo_write`` tool call replays as a
+        native ACP ``plan`` update instead of a ``tool_call``, and its
+        matching ``tool`` result is skipped (a ``plan`` has no opening
+        ``tool_call`` to update). So reloading a session shows the task
+        checklist as a plan panel, exactly as it rendered live. ``plan`` is
+        full-replace, so replaying each ``todo_write`` in order leaves the
+        client on the final checklist state. A malformed/empty persisted
+        ``todo_write`` falls back to the normal ``tool_call`` rendering.
+
         Tool calls in the persisted assistant message are emitted as
         ``tool_call`` rather than ``tool_call`` + ``tool_call_update``
         because the historical state is fully resolved — there is no
@@ -122,6 +138,10 @@ class _ReplayMixin:
                 self._session_id,
             )
             return 0
+
+        # Reset the per-load set of tool_call_ids that replay as a ``plan``
+        # (a session loads once, but clearing keeps a re-load self-consistent).
+        self._replay_plan_call_ids.clear()
 
         emitted = 0
         for index, raw in enumerate(messages):
@@ -222,6 +242,20 @@ class _ReplayMixin:
         tool_call_id = str(
             tc.get("id") or f"replay_{uuid.uuid4().hex[:12]}"
         )
+
+        # ``todo_write`` replays as a native ACP ``plan`` (mirroring the live
+        # path), not a generic tool_call — so a reloaded session shows the
+        # task checklist as a plan panel. Record the id so the matching tool
+        # result is skipped below (a ``plan`` opens no ``tool_call`` to close).
+        # A malformed/empty persisted call yields ``None`` → fall through to
+        # the normal tool_call rendering.
+        if tool_name == "todo_write":
+            plan = _todo_write_plan(args)
+            if plan is not None:
+                self._emit_update(plan)
+                self._replay_plan_call_ids.add(tool_call_id)
+                return 1
+
         self._emit_update(
             {
                 "sessionUpdate": "tool_call",
@@ -244,6 +278,11 @@ class _ReplayMixin:
             logger.debug(
                 "acp: replay_history skipping tool message with no tool_call_id"
             )
+            return 0
+        if tool_call_id in self._replay_plan_call_ids:
+            # The assistant call for this id replayed as a ``plan`` — which has
+            # no opening ``tool_call`` — so emitting a ``tool_call_update`` here
+            # would be an orphan. Skip it.
             return 0
         text = _coerce_message_text(msg.get("content", ""))
         update: Dict[str, Any] = {

--- a/agentao/acp/transport.py
+++ b/agentao/acp/transport.py
@@ -182,6 +182,10 @@ class ACPTransport(_ReplayMixin, _InteractionMixin):
         # never renders as if it took effect. Entries are popped on completion;
         # TOOL_START/TOOL_COMPLETE always pair, so this stays bounded.
         self._todo_plan_calls: Dict[str, Dict[str, Any]] = {}
+        # tool_call_ids whose persisted ``todo_write`` replayed as a ``plan``
+        # during ``session/load`` (see _ReplayMixin), so the matching tool
+        # result is skipped — a ``plan`` has no opening ``tool_call`` to close.
+        self._replay_plan_call_ids: set = set()
 
     # -- One-way events ----------------------------------------------------
 

--- a/tests/test_acp_session_load.py
+++ b/tests/test_acp_session_load.py
@@ -486,6 +486,104 @@ class TestReplayHistoryMapping:
         assert "content" not in upd
         assert upd["status"] == "completed"
 
+    # --- todo_write → plan (G4 replay parity) ----------------------------
+
+    def test_todo_write_replays_as_plan_and_skips_result(self):
+        """A persisted todo_write renders as a native `plan` (mirroring the
+        live path), and its matching tool result is skipped so no orphan
+        tool_call_update is emitted."""
+        t, server = self._transport()
+        emitted = t.replay_history(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "p1",
+                            "function": {
+                                "name": "todo_write",
+                                "arguments": '{"todos": [{"content": "A", "status": "in_progress"}, {"content": "B", "status": "pending"}]}',
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "p1", "content": "Todo list updated: 2 task(s)"},
+            ]
+        )
+        assert emitted == 1  # one plan; the tool result is skipped
+        updates = [n[1]["update"] for n in server.notifications]
+        assert updates == [
+            {
+                "sessionUpdate": "plan",
+                "entries": [
+                    {"content": "A", "priority": "medium", "status": "in_progress"},
+                    {"content": "B", "priority": "medium", "status": "pending"},
+                ],
+            }
+        ]
+
+    def test_todo_write_malformed_replays_as_tool_call_with_result(self):
+        """All-or-nothing: a malformed persisted todo_write falls back to the
+        normal tool_call rendering, and its result is NOT skipped."""
+        t, server = self._transport()
+        emitted = t.replay_history(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "p2",
+                            "function": {
+                                "name": "todo_write",
+                                "arguments": '{"todos": [{"content": 123, "status": "pending"}]}',
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "p2", "content": "ok"},
+            ]
+        )
+        assert emitted == 2
+        updates = [n[1]["update"] for n in server.notifications]
+        assert [u["sessionUpdate"] for u in updates] == ["tool_call", "tool_call_update"]
+        assert updates[0]["title"] == "todo_write"
+        assert updates[1]["toolCallId"] == "p2"
+
+    def test_multiple_todo_writes_each_replay_as_plan(self):
+        """plan is full-replace; replaying each todo_write in order leaves the
+        client on the final checklist state, with every result skipped."""
+        t, server = self._transport()
+        t.replay_history(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {"id": "p1", "function": {"name": "todo_write",
+                            "arguments": '{"todos": [{"content": "A", "status": "pending"}]}'}}
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "p1", "content": "1 task"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {"id": "p2", "function": {"name": "todo_write",
+                            "arguments": '{"todos": [{"content": "A", "status": "completed"}, {"content": "B", "status": "in_progress"}]}'}}
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "p2", "content": "2 tasks"},
+            ]
+        )
+        updates = [n[1]["update"] for n in server.notifications]
+        assert [u["sessionUpdate"] for u in updates] == ["plan", "plan"]
+        assert updates[-1]["entries"] == [
+            {"content": "A", "priority": "medium", "status": "completed"},
+            {"content": "B", "priority": "medium", "status": "in_progress"},
+        ]
+
     # --- Full conversation flow ------------------------------------------
 
     def test_full_conversation_replay_order_and_count(self):


### PR DESCRIPTION
## Summary

Closes the live-vs-replay parity gap left open by G4 PR-1 (#101): the
`session/load` history replay now renders a persisted `todo_write` task
checklist as a native ACP `plan` panel, exactly as it rendered live —
instead of replaying it as a generic `tool_call`.

## What changed

- `agentao/acp/_transport_replay.py`
  - `_replay_assistant_tool_call` special-cases `todo_write`: builds a
    `plan` update via the existing all-or-nothing `_todo_write_plan`
    validator and records the call_id; a malformed/empty persisted call
    falls back to the normal `tool_call` rendering.
  - `_replay_tool_result` skips the matching `tool` result for a call
    that replayed as a `plan` — a `plan` opens no `tool_call`, so a
    `tool_call_update` would orphan.
  - `replay_history` clears the per-load id set up front so a re-load
    stays self-consistent; docstring documents the special-case.
- `agentao/acp/transport.py` — adds `self._replay_plan_call_ids: set`.
- `tests/test_acp_session_load.py` — 3 tests: todo_write→plan +
  result-skip, malformed→tool_call fallback, multiple todo_writes→
  final-state-wins.

## Why all-or-nothing / full-replace

`plan` is a full-replace update, so per-entry filtering would silently
drop real tasks; `_todo_write_plan` returns `None` (→ tool_call fallback)
if any entry is malformed. Replaying each `todo_write` in order leaves
the client on the final checklist state — the same convergence the live
path produces.

## Test plan

- `uv run python -m pytest tests/test_acp_session_load.py` — green
- Full suite: **3085 passed**, 2 skipped (PR-1 baseline 3082 + 3 new)
- Schema drift check clean (no schema surface change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)