### PR TITLE
fix(acp): type session/update schema_version as int, not str

### DIFF
--- a/agentao/acp/schema.py
+++ b/agentao/acp/schema.py
@@ -557,7 +557,7 @@ class AcpSessionUpdateMessageChunk(BaseModel):
         "user_message_chunk",
     ]
     content: AcpSessionUpdateContentBlock
-    schema_version: Optional[str] = None
+    schema_version: Optional[int] = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -576,7 +576,7 @@ class AcpSessionUpdateToolCall(BaseModel):
     kind: Literal["read", "edit", "search", "execute", "fetch", "other"]
     status: Literal["pending", "in_progress", "completed", "failed"]
     rawInput: Optional[Dict[str, Any]] = None
-    schema_version: Optional[str] = None
+    schema_version: Optional[int] = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -588,7 +588,7 @@ class AcpSessionUpdateToolCallUpdate(BaseModel):
     toolCallId: str
     status: Literal["pending", "in_progress", "completed", "failed"]
     content: Optional[List[AcpToolCallContentEntry]] = None
-    schema_version: Optional[str] = None
+    schema_version: Optional[int] = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -613,7 +613,7 @@ class AcpSessionUpdatePlan(BaseModel):
 
     sessionUpdate: Literal["plan"] = "plan"
     entries: List[AcpPlanEntry]
-    schema_version: Optional[str] = None
+    schema_version: Optional[int] = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -626,7 +626,7 @@ class AcpSessionUpdateCurrentMode(BaseModel):
 
     sessionUpdate: Literal["current_mode_update"] = "current_mode_update"
     currentModeId: str
-    schema_version: Optional[str] = None
+    schema_version: Optional[int] = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/docs/schema/host.acp.v1.json
+++ b/docs/schema/host.acp.v1.json
@@ -1391,7 +1391,7 @@
         "schema_version": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "integer"
             },
             {
               "type": "null"
@@ -1423,7 +1423,7 @@
         "schema_version": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "integer"
             },
             {
               "type": "null"
@@ -1511,7 +1511,7 @@
         "schema_version": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "integer"
             },
             {
               "type": "null"
@@ -1565,7 +1565,7 @@
         "schema_version": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "integer"
             },
             {
               "type": "null"
@@ -1630,7 +1630,7 @@
         "schema_version": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "integer"
             },
             {
               "type": "null"

--- a/tests/test_acp_schema.py
+++ b/tests/test_acp_schema.py
@@ -451,7 +451,7 @@ def test_session_update_notification_discriminator():
         "update": {
             "sessionUpdate": "agent_message_chunk",
             "content": {"type": "text", "text": "hello"},
-            "schema_version": "v1",
+            "schema_version": 1,
         },
     })
     assert chunk.update.sessionUpdate == "agent_message_chunk"


### PR DESCRIPTION
## Summary

Fixes a schema-vs-runtime type drift in the ACP `session/update`
contract: the runtime emits an **integer** `schema_version`, but the
published JSON schema advertised a **string**.

## The bug

- `AgentEvent.schema_version` is typed `int = 1` (`transport/events.py`),
  and `ACPTransport.emit` stamps it verbatim onto every live wire payload
  (`transport.py:203`). The event tests pin the integer form
  (`schema_version == 1`, `== 2`).
- But all five `AcpSessionUpdate*` models typed the field `Optional[str]`,
  so the exported `docs/schema/host.acp.v1.json` declared it a string.
- A strict ACP client validating wire payloads against the published
  schema would **reject the real integer** the agent sends.
- `tests/test_acp_schema.py` even pinned the wrong form (`"v1"`),
  encoding the bug.

## Fix

- Narrow `schema_version` to `Optional[int]` across the five
  `AcpSessionUpdate*` models. `Optional` stays — the replay and set_mode
  paths don't stamp the field, so `None` is still valid.
- Regenerate `host.acp.v1.json` (5× `string` → `integer`, no other churn).
- Fix the one schema test to validate `1` instead of `"v1"`.

## Test plan

- `tests/test_acp_schema.py tests/test_event_schema_version.py tests/test_acp_transport.py tests/test_acp_session_load.py` — 124 passed
- Schema snapshot is idempotent under regeneration (drift check clean)
- Full 3.10/3.11/3.12 matrix on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)