### PR TITLE
refactor(acp): centralize session/update envelope in one helper

### DIFF
--- a/agentao/acp/_transport_helpers.py
+++ b/agentao/acp/_transport_helpers.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
+from .protocol import METHOD_SESSION_UPDATE
+
 
 # ---------------------------------------------------------------------------
 # Tool name → ACP tool-call kind
@@ -127,3 +129,28 @@ def _tool_content_text(text: str) -> Dict[str, Any]:
     terminal variants we do not use in v1).
     """
     return {"type": "content", "content": _text_block(text)}
+
+
+# ---------------------------------------------------------------------------
+# session/update envelope
+# ---------------------------------------------------------------------------
+
+def write_session_update(server: Any, session_id: str, update: Dict[str, Any]) -> None:
+    """Write one ``session/update`` notification with the standard envelope.
+
+    Centralizes the ``{"sessionId", "update"}`` envelope and the
+    ``METHOD_SESSION_UPDATE`` method constant shared by the live event path
+    (:meth:`ACPTransport.emit`), the history-replay path
+    (:meth:`_ReplayMixin._emit_update`), and the set_mode handler
+    (:func:`agentao.acp.session_set_mode._emit_current_mode_update`) — so a
+    future envelope-shape change is a one-line edit instead of three.
+
+    Deliberately does **not** catch exceptions: each caller owns its own
+    error policy (the live and replay paths log-and-swallow with
+    site-specific messages; set_mode wraps best-effort). A bare write that
+    raises propagates to that caller's handler.
+    """
+    server.write_notification(
+        METHOD_SESSION_UPDATE,
+        {"sessionId": session_id, "update": update},
+    )

--- a/agentao/acp/_transport_replay.py
+++ b/agentao/acp/_transport_replay.py
@@ -14,13 +14,13 @@ import re
 import uuid
 from typing import Any, Dict, Iterable, List
 
-from .protocol import METHOD_SESSION_UPDATE
 from ._transport_helpers import (
     _json_safe,
     _text_block,
     _todo_write_plan,
     _tool_content_text,
     _tool_kind,
+    write_session_update,
 )
 
 logger = logging.getLogger(__name__)
@@ -303,10 +303,7 @@ class _ReplayMixin:
         Errors are logged and swallowed — replay must be best-effort.
         """
         try:
-            self._server.write_notification(
-                METHOD_SESSION_UPDATE,
-                {"sessionId": self._session_id, "update": update},
-            )
+            write_session_update(self._server, self._session_id, update)
         except Exception:
             logger.exception(
                 "acp: failed to write replay session/update for session %s",

--- a/agentao/acp/session_set_mode.py
+++ b/agentao/acp/session_set_mode.py
@@ -30,7 +30,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 from agentao.permissions import PermissionMode
 
 from ._handler_utils import hold_idle_turn_lock, require_active_session
-from .protocol import INVALID_REQUEST, METHOD_SESSION_SET_MODE, METHOD_SESSION_UPDATE
+from ._transport_helpers import write_session_update
+from .protocol import INVALID_REQUEST, METHOD_SESSION_SET_MODE
 from .server import JsonRpcHandlerError
 
 if TYPE_CHECKING:
@@ -68,15 +69,10 @@ def _emit_current_mode_update(
     Best-effort: a notification failure must not fail the set_mode request.
     """
     try:
-        server.write_notification(
-            METHOD_SESSION_UPDATE,
-            {
-                "sessionId": session_id,
-                "update": {
-                    "sessionUpdate": "current_mode_update",
-                    "currentModeId": mode_id,
-                },
-            },
+        write_session_update(
+            server,
+            session_id,
+            {"sessionUpdate": "current_mode_update", "currentModeId": mode_id},
         )
     except Exception:
         logger.exception(

--- a/agentao/acp/transport.py
+++ b/agentao/acp/transport.py
@@ -109,13 +109,13 @@ from typing import TYPE_CHECKING, Any, Dict
 
 from agentao.transport.events import AgentEvent, EventType
 
-from .protocol import METHOD_SESSION_UPDATE
 from ._transport_helpers import (
     _json_safe,
     _text_block,
     _todo_write_plan,
     _tool_content_text,
     _tool_kind,
+    write_session_update,
 )
 from ._transport_interaction import _InteractionMixin, _build_permission_options
 from ._transport_interaction import (  # re-exported for back-compat
@@ -201,10 +201,7 @@ class ACPTransport(_ReplayMixin, _InteractionMixin):
             if update is not None:
                 # Stamp the runtime payload version (independent of ACP_PROTOCOL_VERSION).
                 update["schema_version"] = event.schema_version
-                self._server.write_notification(
-                    METHOD_SESSION_UPDATE,
-                    {"sessionId": self._session_id, "update": update},
-                )
+                write_session_update(self._server, self._session_id, update)
         except Exception:
             logger.exception(
                 "acp: failed to emit session/update for event %s on session %s",


### PR DESCRIPTION
## Summary

Dedups the three copy-pasted `session/update` envelopes into a single
`write_session_update` helper — the last open G4 PR-1 (#101) follow-up.

## What was duplicated

The `{"sessionId", "update"}` envelope + the `METHOD_SESSION_UPDATE`
method constant appeared verbatim at three write sites:

- `ACPTransport.emit` — live event path (`transport.py`)
- `_ReplayMixin._emit_update` — `session/load` history replay
  (`_transport_replay.py`)
- `_emit_current_mode_update` — set_mode handler (`session_set_mode.py`)

A future envelope-shape change would have had to be made in three places.

## Change

- Add `write_session_update(server, session_id, update)` to
  `_transport_helpers`.
- Route all three sites through it; drop the now-dead
  `METHOD_SESSION_UPDATE` imports from the three callers.
- The helper **does not** catch exceptions on purpose — each caller keeps
  its own error policy (live + replay log-and-swallow with site-specific
  messages; set_mode best-effort), so observable behavior is identical.

## Test plan

- Pure refactor: no Pydantic model touched → `host.acp.v1.json` snapshot
  **unchanged** (verified idempotent).
- ACP subset (transport / session_load / set_mode / schema_version /
  resume) — 148 passed.
- Full suite — **3085 passed**, 2 skipped (no regression).
- Host typing gate (`mypy --strict --package agentao.host`) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)