### PR TITLE
docs(acp): correct replay todo_write→plan fidelity claim; type the skip-set

### DIFF
--- a/agentao/acp/_transport_replay.py
+++ b/agentao/acp/_transport_replay.py
@@ -100,19 +100,33 @@ class _ReplayMixin:
         ``assistant`` text   ``agent_message_chunk`` with text content
         ``assistant``        ``tool_call`` (status="completed", title=
         ``tool_calls``         tool_name, kind=mapped, rawInput=parsed)
+        ``todo_write``       ``plan`` (assistant call); its ``tool`` result
+        ``tool_call``          is skipped — see the special-case note below
         ``tool``             ``tool_call_update`` (status="completed",
                                content=text result)
         ===================  ============================================
 
         **``todo_write`` is special-cased to ``plan``** (mirroring the live
-        event path): a persisted ``todo_write`` tool call replays as a
-        native ACP ``plan`` update instead of a ``tool_call``, and its
-        matching ``tool`` result is skipped (a ``plan`` has no opening
-        ``tool_call`` to update). So reloading a session shows the task
-        checklist as a plan panel, exactly as it rendered live. ``plan`` is
-        full-replace, so replaying each ``todo_write`` in order leaves the
-        client on the final checklist state. A malformed/empty persisted
-        ``todo_write`` falls back to the normal ``tool_call`` rendering.
+        event path's plan rendering): a persisted ``todo_write`` tool call
+        replays as a native ACP ``plan`` update instead of a ``tool_call``,
+        and its matching ``tool`` result is skipped (a ``plan`` has no
+        opening ``tool_call`` to update). So reloading a session shows the
+        task checklist as a plan panel. ``plan`` is full-replace, so
+        replaying each ``todo_write`` in order leaves the client on the
+        final checklist state. A malformed/empty persisted ``todo_write``
+        falls back to the normal ``tool_call`` rendering.
+
+        Fidelity note: replay reconstructs from the persisted *conversation*
+        messages (``{role, tool_call_id, name, content}``), which carry no
+        success/failure status — that lives only on the live
+        ``TOOL_COMPLETE`` event, not in the saved message. So unlike the
+        live path (which suppresses the plan on a denied/failed/cancelled
+        call — e.g. ``todo_write`` denied in plan mode), replay emits the
+        ``plan`` for any well-formed persisted ``todo_write`` regardless of
+        whether it actually applied. This is the same lower fidelity replay
+        already has for every tool — a denied regular tool likewise replays
+        with ``status="completed"`` — not a regression specific to the plan
+        mapping.
 
         Tool calls in the persisted assistant message are emitted as
         ``tool_call`` rather than ``tool_call`` + ``tool_call_update``

--- a/agentao/acp/transport.py
+++ b/agentao/acp/transport.py
@@ -105,7 +105,7 @@ Deterministic failure modes:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Set
 
 from agentao.transport.events import AgentEvent, EventType
 
@@ -185,7 +185,7 @@ class ACPTransport(_ReplayMixin, _InteractionMixin):
         # tool_call_ids whose persisted ``todo_write`` replayed as a ``plan``
         # during ``session/load`` (see _ReplayMixin), so the matching tool
         # result is skipped — a ``plan`` has no opening ``tool_call`` to close.
-        self._replay_plan_call_ids: set = set()
+        self._replay_plan_call_ids: Set[str] = set()
 
     # -- One-way events ----------------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up from the xhigh code review of the replay→plan mapping (#102).
The review's headline finding: the `replay_history` docstring claimed the
checklist renders "exactly as it rendered live" — which is **false** for
denied/failed/cancelled `todo_write` calls.

## The real defect (and why it's a docs fix, not a code fix)

- The **live** path suppresses the `plan` on a denied/failed/cancelled
  `todo_write` by keying on the `status` field of the live
  `TOOL_COMPLETE` event (`transport.py:297`, emits the plan only when
  `status == "ok"`). This is reachable: `permissions.py:233` denies
  `todo_write` in **plan mode**.
- The **replay** path reconstructs from the persisted *conversation*
  messages — `{role, tool_call_id, name, content}`
  (`tool_result_formatter.py:165`). The `status`/`error` fields go to the
  live replay-recorder event, **not** the saved message. So replay has no
  success/failure signal and emits the `plan` for any well-formed
  persisted `todo_write` regardless of whether it applied.
- This is **not cleanly fixable** in replay: the signal isn't in the
  data; replicating live would require fragile parsing of result text.
  And it's the *same* lower fidelity replay already has for every tool — a
  denied regular tool likewise replays as `status="completed"`.

So the honest fix is to correct the overclaim, not bolt on brittle
detection.

## Changes

- `_transport_replay.py` — add the `todo_write`→`plan` row to the
  role→update mapping table (was prose-only), and add a **fidelity note**
  spelling out the live-vs-replay divergence and why it's inherent.
- `transport.py` — type `_replay_plan_call_ids` as `Set[str]` (was a bare
  `set`), matching the neighboring `_todo_plan_calls: Dict[str, Dict[str, Any]]`.

## Review findings explicitly **not** acted on (with rationale)

- **schema_version omitted on replay updates** (CONFIRMED, benign): the
  field is `Optional`, absence is valid; stamping it changes *every*
  replay update shape and breaks many exact-match (`assert upd == {...}`)
  replay tests — disproportionate for a cosmetic divergence. Pre-existing
  for all replay update types; a separate focused change if strict
  live/replay wire-parity is ever wanted.
- **id-correlation fragilities** (skip-set reuse / no-id orphan /
  out-of-order result / emit-failure skip — all PLAUSIBLE): unreachable on
  agentao-produced OpenAI histories (ids are always present & unique via
  `_ensure_tool_call_id`, messages are ordered) and the orphan patterns
  pre-exist for *all* tools, not introduced or worsened by the plan
  mapping. Hardening would add code for inputs that don't occur.

## Test plan

- Docs + annotation only — no behavior change.
- Schema snapshot **unchanged** (verified).
- ACP suite (`test_acp_session_load`, `test_acp_transport`) — 87 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)