### PR TITLE
chore: open 0.4.13 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+_Targeting 0.4.13. Add entries under the relevant heading as work lands._
+
+### Added
+
+### Changed
+
+### Fixed
+
+---
+
 ## [0.4.12] — 2026-06-19
 
 An **ACP-surface + internal-cleanup** release on top of 0.4.11. The ACP server

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.12"
+__version__ = "0.4.13.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Open the 0.4.13 development cycle after the v0.4.12 release.

- bump `__version__` `0.4.12` → `0.4.13.dev0` (PEP 440 canonical `.dev0`, not the hyphenated `-dev` drift).
- reopen `CHANGELOG.md` `## [Unreleased]` targeting 0.4.13.

No code or behavior change; version-literal + changelog bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)