### PR TITLE
chore: open 0.4.14 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-_Add entries under the relevant heading as work lands._
+_Targeting 0.4.14. Add entries under the relevant heading as work lands._
 
 ### Added
 

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.13"
+__version__ = "0.4.14.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Post-release housekeeping after **v0.4.13** shipped to PyPI.

- `agentao/__init__.py`: `0.4.13` → `0.4.14.dev0` (PEP 440 `.dev0`)
- `CHANGELOG.md`: reopen `[Unreleased]` targeting 0.4.14

Mirrors #107 (which opened the 0.4.13 cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)