### PR TITLE
fix(subagent): correlate tool_complete with its tool_call via real call_id

### DIFF
--- a/agentao/tooling/agent_tools.py
+++ b/agentao/tooling/agent_tools.py
@@ -27,11 +27,6 @@ def register_agent_tools(agent: "Agentao") -> None:
     if agent.agent_manager is None:
         return
 
-    # Maps sub-agent tool_name → call_id so TOOL_OUTPUT and TOOL_COMPLETE
-    # events carry the same stable key as their matching TOOL_START.
-    # Keyed by name — works for serial and different-named parallel calls.
-    _subagent_call_ids: dict = {}
-
     def _agent_step_cb(name, args):
         if name is None:
             agent.transport.emit(AgentEvent(EventType.TURN_START, {}))
@@ -55,10 +50,34 @@ def register_agent_tools(agent: "Agentao") -> None:
             # call_id is injected by build_compat_transport; fall back to name.
             _args = dict(args) if isinstance(args, dict) else {}
             call_id = _args.pop("__call_id__", None) or name
-            _subagent_call_ids[name] = call_id
             agent.transport.emit(AgentEvent(EventType.TOOL_START, {
                 "tool": name, "args": _args, "call_id": call_id,
             }))
+
+    # TOOL_OUTPUT / TOOL_COMPLETE receive the stable ``call_id`` (and, for
+    # completion, the real status / duration / error) forwarded by
+    # build_compat_transport, so a same-named parallel batch (e.g. four
+    # concurrent ``read_file``) stays correlatable with its matching
+    # TOOL_START *and* a failed or permission-denied sub-agent tool is
+    # reported as a failure rather than a hardcoded success. The tool-name
+    # fallback fires only when the id is genuinely absent (``None``) — an
+    # empty-string id is preserved so it is not silently collapsed.
+    def _agent_output_cb(name, chunk, call_id=None):
+        agent.transport.emit(AgentEvent(EventType.TOOL_OUTPUT, {
+            "tool": name, "chunk": chunk,
+            "call_id": call_id if call_id is not None else name,
+        }))
+
+    def _agent_tool_complete_cb(
+        name, call_id=None, status=None, duration_ms=None, error=None,
+    ):
+        agent.transport.emit(AgentEvent(EventType.TOOL_COMPLETE, {
+            "tool": name,
+            "call_id": call_id if call_id is not None else name,
+            "status": status if status is not None else "ok",
+            "duration_ms": duration_ms if duration_ms is not None else 0,
+            "error": error,
+        }))
 
     agent_tools = agent.agent_manager.create_agent_tools(
         all_tools=agent.tools.tools,
@@ -69,19 +88,8 @@ def register_agent_tools(agent: "Agentao") -> None:
         bg_store=agent.bg_store,
         confirmation_callback=lambda *a, **kw: agent.transport.confirm_tool(*a, **kw),
         step_callback=_agent_step_cb,
-        output_callback=lambda name, chunk: agent.transport.emit(
-            AgentEvent(EventType.TOOL_OUTPUT, {
-                "tool": name, "chunk": chunk,
-                "call_id": _subagent_call_ids.get(name, name),
-            })
-        ),
-        tool_complete_callback=lambda name: agent.transport.emit(
-            AgentEvent(EventType.TOOL_COMPLETE, {
-                "tool": name,
-                "call_id": _subagent_call_ids.pop(name, name),
-                "status": "ok", "duration_ms": 0, "error": None,
-            })
-        ),
+        output_callback=_agent_output_cb,
+        tool_complete_callback=_agent_tool_complete_cb,
         ask_user_callback=lambda *a, **kw: agent.transport.ask_user(*a, **kw),
         max_context_tokens=agent.context_manager.max_tokens,
         parent_messages_getter=lambda: agent.messages,

--- a/agentao/transport/sdk.py
+++ b/agentao/transport/sdk.py
@@ -136,6 +136,48 @@ class SdkTransport:
 _NULL = NullTransport()
 
 
+def _accepted_meta_keywords(
+    callback: Optional[Callable[..., Any]], candidates: tuple
+) -> tuple:
+    """Return the subset of ``candidates`` that ``callback`` accepts *by name*.
+
+    The legacy ``tool_complete_callback`` / ``output_callback`` signatures
+    were ``(name)`` and ``(name, chunk)`` — they had no channel for the
+    per-call id (or status / duration / error), so a bridge consuming them
+    had to reconstruct the id from the tool *name*, which collapses for a
+    parallel batch of same-named tool calls (e.g. four concurrent
+    ``read_file``). A callback opts into the richer metadata simply by naming
+    the parameter (``call_id``, ``status``, …); we forward only the keywords
+    it explicitly declares as ``POSITIONAL_OR_KEYWORD`` / ``KEYWORD_ONLY``,
+    so a genuinely legacy fixed-arity callback keeps its exact old behaviour
+    and never sees an unexpected keyword.
+
+    ``**kwargs`` is deliberately *not* treated as opt-in: the bridge passes
+    ``name`` / ``chunk`` positionally (the legacy contract), which a
+    ``**kwargs``-only callable cannot accept, so green-lighting it would only
+    raise a ``TypeError`` that ``SdkTransport.emit`` swallows — i.e. forward
+    nothing rather than silently drop the call.
+
+    Computed once per ``build_compat_transport`` (callbacks are stable for a
+    transport's lifetime), so per-event dispatch does no signature work.
+    """
+    if callback is None:
+        return ()
+    try:
+        params = inspect.signature(callback).parameters
+    except (TypeError, ValueError):
+        # Un-introspectable callable (some builtins / C funcs) — assume legacy.
+        return ()
+    keyword_ok = {
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    }
+    return tuple(
+        c for c in candidates
+        if c in params and params[c].kind in keyword_ok
+    )
+
+
 def build_compat_transport(
     confirmation_callback=None,
     step_callback=None,
@@ -151,6 +193,14 @@ def build_compat_transport(
     Called automatically by ``Agentao.__init__`` when old-style callbacks
     are passed without a ``transport`` argument.  All parameters are optional.
     """
+    # Decide once (not per-event) which metadata keywords each callback can
+    # receive, so a same-named parallel tool batch stays correlatable
+    # end-to-end (call_id) and a sub-agent tool failure is reported as a
+    # failure rather than collapsing onto the tool name / a hardcoded "ok".
+    _out_kw = _accepted_meta_keywords(output_callback, ("call_id",))
+    _tc_kw = _accepted_meta_keywords(
+        tool_complete_callback, ("call_id", "status", "duration_ms", "error"),
+    )
 
     def _on_event(event: AgentEvent) -> None:
         t = event.type
@@ -170,10 +220,16 @@ def build_compat_transport(
                 step_callback(d.get("tool"), _args)
         elif t == EventType.TOOL_OUTPUT:
             if output_callback:
-                output_callback(d.get("tool", ""), d.get("chunk", ""))
+                output_callback(
+                    d.get("tool", ""), d.get("chunk", ""),
+                    **{k: d.get(k) for k in _out_kw},
+                )
         elif t == EventType.TOOL_COMPLETE:
             if tool_complete_callback:
-                tool_complete_callback(d.get("tool", ""))
+                tool_complete_callback(
+                    d.get("tool", ""),
+                    **{k: d.get(k) for k in _tc_kw},
+                )
         elif t == EventType.THINKING:
             if thinking_callback:
                 thinking_callback(d.get("text", ""))

--- a/tests/test_subagent_tool_call_id.py
+++ b/tests/test_subagent_tool_call_id.py
@@ -1,0 +1,170 @@
+"""Regression: sub-agent TOOL_COMPLETE must carry the real ``call_id``
+(and the real status/error), not the tool name / a hardcoded success.
+
+Reported bug: a sub-agent running four concurrent ``read_file`` calls emitted
+``tool_call`` events with distinct ``toolCallId``s (``call_5d6…``) but every
+matching ``tool_complete`` carried ``toolCallId == "read_file"`` — the tool
+name, not the call id — so a single tool invocation could not be traced
+start→finish.
+
+Two compounding causes, both fixed:
+
+1. ``build_compat_transport`` dropped ``call_id`` (and status/error) on the
+   TOOL_COMPLETE / TOOL_OUTPUT translation, forcing the sub-agent bridge to
+   reconstruct the id from a tool-*name*-keyed dict and to hardcode
+   ``status="ok"``.
+2. That dict was written under the *prefixed* label on TOOL_START but read
+   under the *raw* name on TOOL_COMPLETE, so the lookup never hit (and even
+   when it did, same-named parallel calls collided onto one key).
+
+This test drives the real bridge wiring in ``register_agent_tools`` the way a
+sub-agent's events flow through ``build_compat_transport`` — including the real
+production prefixed step callback — and asserts each completion keeps its own
+id and faithful status.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict
+
+from agentao.agents.tools import AgentToolWrapper
+from agentao.tooling.agent_tools import register_agent_tools
+from agentao.transport import AgentEvent, EventType
+from agentao.transport.sdk import build_compat_transport
+
+from tests.support.host_events import CapturingTransport
+
+
+def _build_bridge_callbacks() -> Dict[str, Any]:
+    """Run ``register_agent_tools`` against a fake parent and capture the
+    sub-agent callbacks it wires (step / output / tool_complete)."""
+    captured: Dict[str, Any] = {}
+
+    def _create_agent_tools(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    parent_transport = CapturingTransport()
+    agent = SimpleNamespace(
+        agent_manager=SimpleNamespace(create_agent_tools=_create_agent_tools),
+        tools=SimpleNamespace(tools=[], register=lambda t: None),
+        bg_store=None,
+        transport=parent_transport,
+        context_manager=SimpleNamespace(max_tokens=100_000),
+        _llm_config={},
+        messages=[],
+        _current_token=None,
+        tool_runner=None,
+    )
+
+    register_agent_tools(agent)
+    captured["_parent_transport"] = parent_transport
+    return captured
+
+
+def _real_prefixed_step_cb(step_cb, agent_name: str, max_turns: int):
+    """The real production prefixed step callback (not a hand-copy), so a
+    drift in the label format / turn counting is exercised here too."""
+    wrapper = AgentToolWrapper(
+        definition={"name": agent_name, "description": "d"},
+        all_tools={},
+        llm_config_getter=lambda: {},
+        working_directory=Path("."),
+        step_callback=step_cb,
+    )
+    return wrapper._make_prefixed_step_callback(max_turns)
+
+
+def test_same_name_parallel_completions_keep_distinct_call_ids():
+    cap = _build_bridge_callbacks()
+    parent = cap["_parent_transport"]
+
+    # Wire the captured callbacks into the real legacy bridge, exactly as the
+    # sub-agent's Agentao.__init__ does — including the real prefixed step
+    # callback (TOOL_START labels get the prefix; tool_complete keeps the raw
+    # name, the exact asymmetry that broke name-keyed correlation).
+    sub_transport = build_compat_transport(
+        step_callback=_real_prefixed_step_cb(cap["step_callback"], "basic-info-reviewer", 100),
+        output_callback=cap["output_callback"],
+        tool_complete_callback=cap["tool_complete_callback"],
+    )
+
+    call_ids = ["call_5d6", "call_444", "call_008", "call_bd4"]
+
+    # Four concurrent same-name calls start (same turn → identical prefix).
+    sub_transport.emit(AgentEvent(EventType.TURN_START))
+    for cid in call_ids:
+        sub_transport.emit(AgentEvent(EventType.TOOL_START, {
+            "tool": "read_file", "args": {"file_path": f"/x/{cid}.md"}, "call_id": cid,
+        }))
+    # …then each completes.
+    for cid in call_ids:
+        sub_transport.emit(AgentEvent(EventType.TOOL_COMPLETE, {
+            "tool": "read_file", "call_id": cid, "status": "ok",
+            "duration_ms": 0, "error": None,
+        }))
+
+    starts = parent.by_type(EventType.TOOL_START)
+    completes = parent.by_type(EventType.TOOL_COMPLETE)
+
+    assert [e.data["call_id"] for e in starts] == call_ids
+    # The regression: completions must mirror the starts, not collapse to
+    # the tool name.
+    assert [e.data["call_id"] for e in completes] == call_ids
+    assert all(e.data["call_id"] != "read_file" for e in completes)
+    # And the prefixed display label rode along on the start events.
+    assert all("[basic-info-reviewer 1/100] read_file" == e.data["tool"] for e in starts)
+
+
+def test_completion_forwards_real_status_and_error():
+    # A failed sub-agent tool must surface as a failure, not a hardcoded "ok".
+    cap = _build_bridge_callbacks()
+    parent = cap["_parent_transport"]
+    sub_transport = build_compat_transport(
+        tool_complete_callback=cap["tool_complete_callback"],
+    )
+
+    sub_transport.emit(AgentEvent(EventType.TOOL_COMPLETE, {
+        "tool": "shell", "call_id": "call_err", "status": "error",
+        "duration_ms": 17, "error": "non-zero exit",
+    }))
+
+    (done,) = parent.by_type(EventType.TOOL_COMPLETE)
+    assert done.data["call_id"] == "call_err"
+    assert done.data["status"] == "error"
+    assert done.data["duration_ms"] == 17
+    assert done.data["error"] == "non-zero exit"
+
+
+def test_completion_without_call_id_falls_back_to_name():
+    # Floor case: a non-normalized emitter that omits call_id falls back to
+    # the tool name (preserving the old behaviour) and defaults status to ok.
+    cap = _build_bridge_callbacks()
+    parent = cap["_parent_transport"]
+    sub_transport = build_compat_transport(
+        tool_complete_callback=cap["tool_complete_callback"],
+    )
+
+    sub_transport.emit(AgentEvent(EventType.TOOL_COMPLETE, {"tool": "read_file"}))
+
+    (done,) = parent.by_type(EventType.TOOL_COMPLETE)
+    assert done.data["call_id"] == "read_file"
+    assert done.data["status"] == "ok"
+    assert done.data["error"] is None
+
+
+def test_tool_output_carries_call_id():
+    cap = _build_bridge_callbacks()
+    parent = cap["_parent_transport"]
+    sub_transport = build_compat_transport(
+        output_callback=cap["output_callback"],
+    )
+
+    sub_transport.emit(AgentEvent(EventType.TOOL_OUTPUT, {
+        "tool": "shell", "chunk": "hello\n", "call_id": "call_99",
+    }))
+
+    (out,) = parent.by_type(EventType.TOOL_OUTPUT)
+    assert out.data["call_id"] == "call_99"

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -108,6 +108,68 @@ class TestBuildCompatTransport:
         t.emit(AgentEvent(EventType.TOOL_COMPLETE, {"tool": "shell"}))
         assert calls == ["shell"]
 
+    def test_tool_complete_forwards_call_id_when_accepted(self):
+        # A callback declaring a ``call_id`` param receives the stable id so
+        # a same-named parallel batch stays correlatable with its TOOL_START.
+        calls = []
+
+        def cb(name, call_id=None):
+            calls.append((name, call_id))
+
+        t = build_compat_transport(tool_complete_callback=cb)
+        t.emit(AgentEvent(EventType.TOOL_COMPLETE, {"tool": "read_file", "call_id": "call_abc"}))
+        assert calls == [("read_file", "call_abc")]
+
+    def test_tool_complete_kwargs_only_callback_stays_legacy(self):
+        # A callback that declares only ``**kwargs`` does NOT opt into
+        # metadata forwarding: the bridge passes ``name`` positionally (the
+        # legacy contract), which **kwargs cannot absorb, so green-lighting it
+        # would only raise a swallowed TypeError. Opt-in is by naming the
+        # parameter, not by declaring **kwargs.
+        calls = []
+        t = build_compat_transport(
+            tool_complete_callback=lambda name, **kw: calls.append((name, kw))
+        )
+        t.emit(AgentEvent(EventType.TOOL_COMPLETE, {"tool": "read_file", "call_id": "call_xyz"}))
+        assert calls == [("read_file", {})]
+
+    def test_tool_complete_forwards_status_and_error_when_accepted(self):
+        # A failed sub-agent tool must reach a metadata-aware callback as a
+        # failure, not a hardcoded success.
+        calls = []
+
+        def cb(name, call_id=None, status=None, duration_ms=None, error=None):
+            calls.append((name, call_id, status, duration_ms, error))
+
+        t = build_compat_transport(tool_complete_callback=cb)
+        t.emit(AgentEvent(EventType.TOOL_COMPLETE, {
+            "tool": "shell", "call_id": "call_1", "status": "error",
+            "duration_ms": 42, "error": "boom",
+        }))
+        assert calls == [("shell", "call_1", "error", 42, "boom")]
+
+    def test_tool_output_forwards_call_id_when_accepted(self):
+        calls = []
+
+        def cb(name, chunk, call_id=None):
+            calls.append((name, chunk, call_id))
+
+        t = build_compat_transport(output_callback=cb)
+        t.emit(AgentEvent(EventType.TOOL_OUTPUT, {"tool": "shell", "chunk": "hi\n", "call_id": "call_1"}))
+        assert calls == [("shell", "hi\n", "call_1")]
+
+    def test_same_name_parallel_calls_stay_correlated(self):
+        # Regression: four concurrent ``read_file`` calls must each carry their
+        # own id on TOOL_COMPLETE rather than collapsing onto the tool name.
+        ids = ["call_a", "call_b", "call_c", "call_d"]
+        completed = []
+        t = build_compat_transport(
+            tool_complete_callback=lambda name, call_id=None: completed.append(call_id)
+        )
+        for cid in ids:
+            t.emit(AgentEvent(EventType.TOOL_COMPLETE, {"tool": "read_file", "call_id": cid}))
+        assert completed == ids
+
     def test_thinking_calls_thinking_callback(self):
         calls = []
         t = build_compat_transport(thinking_callback=lambda text: calls.append(text))


### PR DESCRIPTION
## Problem

Sub-agent (`[basic-info-reviewer 1/100]`) tool lifecycle events bridge to the parent through the legacy callback API. The `tool_call` (TOOL_START) SSE events carried distinct `toolCallId`s (`call_5d6…`, `call_444…`), but every matching `tool_complete` carried `toolCallId == "read_file"` — the tool **name**, not the call id — so a single tool invocation could not be traced start→finish, especially for a parallel batch of same-named `read_file` calls.

### Root cause (two compounding bugs)

1. **`call_id` channel dropped** — `build_compat_transport` translated `TOOL_COMPLETE`/`TOOL_OUTPUT` passing only the tool *name*, discarding the `call_id` (and `status`/`duration_ms`/`error`) the event actually carried. The bridge then had to reconstruct the id from a name-keyed dict.
2. **Name-keyed dict never matched** — `TOOL_START` is wrapped by `_make_prefixed_step_callback`, so it stored the key as the prefixed label `"[basic-info-reviewer 1/100] read_file"`, while `TOOL_COMPLETE` (unprefixed) looked it up by the raw `"read_file"` → never matched → always fell back to the raw name. Even matching keys collide for same-name same-turn parallel calls.

The real `call_id` was present at the sub-agent's `tool_executor._emit_complete` all along — only thrown away at the bridge.

## Fix

Forward the real metadata end-to-end instead of reconstructing it from the name:

- **`transport/sdk.py`** — `_accepted_meta_keywords(callback, candidates)` forwards only the keywords a callback **explicitly names** (`call_id`, `status`, `duration_ms`, `error`), computed **once per transport build**. Opt-in is by naming the param, never via `**kwargs` (the bridge passes `name`/`chunk` positionally, which a `**kwargs`-only callable can't accept). Legacy fixed-arity callbacks are byte-for-byte unchanged.
- **`tooling/agent_tools.py`** — drop the name-keyed dict; re-emit the **real** `status`/`duration_ms`/`error` (a failed or permission-denied sub-agent tool is no longer reported as a hardcoded success), and use `is not None` so an empty-string id isn't collapsed to the tool name.

## Review

Produced via `/code-review --fix` (xhigh, multi-agent). Notably this also fixes a higher-severity issue the reviewer surfaced beyond the original report: the completion callback previously hardcoded `status="ok"`, so **failed/denied sub-agent tools showed as successes** in ACP/CLI.

## Tests

- New end-to-end regression `tests/test_subagent_tool_call_id.py` (reuses shared `CapturingTransport`, drives the **real** prefixed step callback): same-name parallel correlation, status/error forwarding, floor (id-absent) case.
- `tests/test_transport.py` — coverage for the explicit-opt-in contract and status/error forwarding.
- Full default suite: **3193 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)