### PR TITLE
docs(design): add subagent-discovery & vendor-sdk-convergence review records

### DIFF
--- a/docs/design/subagent-discovery-entrypoint-review.md
+++ b/docs/design/subagent-discovery-entrypoint-review.md
@@ -1,0 +1,395 @@
+# Sub-Agent Discovery — Entry-Point Asymmetry & the Skill-vs-Plugin Conflation
+
+**Status:** Review record. Drafted 2026-06-23 from a grep-verified read of the
+agent-definition, skill, and plugin discovery paths across all three runtime
+entry points (interactive CLI / `agentao run`, Python embedding via
+`build_from_environment`, ACP `session/new`). **This is a gap analysis +
+prioritized proposal, not an approved plan.** It exists to settle a specific
+question raised about sub-agent registration — and, in doing so, to correct the
+premise that question was built on.
+**Audience:** Agentao maintainers; anyone embedding agentao who expects skill- or
+plugin-bundled sub-agents to be visible.
+**Companion:** `subagent-discovery-entrypoint-review.zh.md`.
+**Related:**
+- `embedding-vs-acp.md` — why ACP and `agentao run` are *frontends* over the
+  embedded core, not the core contract. The "should plugin-loading live in the
+  core or the frontend?" question in §5 is a direct application of that boundary.
+- `host-tool-injection.md` — the host's explicit tool-injection contract
+  (`extra_tools` / `disable_tools` / `enabled_tools`). The opt-in plugin-load
+  proposal in §6 follows the same "host opts in explicitly, default is minimal"
+  posture.
+- `acp-server-conformance-review.md` — establishes ACP target-client = chat/
+  automation; relevant to whether ACP sessions *should* inherit global plugins.
+
+**Method:** read `AgentManager._load_definitions`, `SkillManager._load_skills`,
+the plugin discovery/resolution chain (`embedding/plugins/`), and the three
+construction paths; grep every call site of `_load_and_register_plugins`; grep
+for any code that bridges a skill root to `agents/`; `find` for plugin manifests
+under `skills/`. Code references anchored to `main`@`e477ad3` (2026-06-23).
+
+---
+
+## TL;DR
+
+The triggering report claimed: *"a skill's bundled sub-agents (e.g.
+`skills/skill-creator/agents/analyzer.md`) are discovered under the CLI but
+skipped by the embedding and ACP entry points."*
+
+**The headline premise is false.** Skill-bundled `agents/` subdirectories are
+bridged to **nothing** — not the CLI, not embedding, not ACP. `agents/`
+auto-discovery is a **plugin** feature; a bundled *skill* is not a *plugin* root,
+and the plugin discovery scan never looks inside `skills/`. So `skill-creator`'s
+three agent files are invisible to **every** entry point, including the
+interactive CLI. The report conflated *skill* with *plugin*.
+
+What **is** true, once the conflation is removed, is a smaller and different set
+of facts — two independent issues plus one absent feature:
+
+1. **Plugin loading is CLI-only** (real). `build_from_environment` and ACP
+   `session/new` load **zero** plugins — not just plugin-agents, but plugin
+   *skills, MCP servers, and hooks* too.
+2. **`AgentManager` has no global layer** (real, minor). It scans builtin +
+   project `.agentao/agents/` only; unlike `SkillManager`'s three layers, there
+   is no `~/.agentao/agents/`.
+3. **"A skill carries sub-agents" does not exist as wired** (absent feature, not
+   a bug). Nothing maps a skill's `agents/` into `AgentManager`.
+
+Whether (1) is a *bug* or an *intentional isolation boundary* is the maintainer's
+call — and there is a real trust argument that CLI-only is deliberate (§5). The
+recommendation (§6) is to fix (2) cheaply, treat (1) as a **default-off opt-in**
+to preserve host isolation, and treat (3) as a separate feature proposal if there
+is demand.
+
+> **Reverse-review correction (2026-06-23, adversarial re-check).** This doc was
+> re-verified against its own claims. The central thesis (§3 — a skill's
+> `agents/` is bridged to *nothing*, **including the CLI**) **survived and
+> strengthened**: `_plugin_inline_dirs` is populated *only* from the CLI
+> `--plugin-dir` flags (`cli/entrypoints.py:371-373`), never auto-seeded with
+> `skills/*`, so the CLI does not load skill directories as inline plugins.
+> Three *secondary* framings were over-stated and are corrected in place below:
+> 1. **Issue B is *not* boundary-free** (corrects §4.2 / §6-P1).
+>    `build_from_environment` already gates even *builtin* agents behind a
+>    default-**off** settings flag (`_builtin_agents_enabled`,
+>    `factory.py:48,238`; `enable_builtin_agents` defaults `False`,
+>    `agent.py:102`). Always-on scanning of user-global `~/.agentao/agents/`
+>    would contradict that conservative posture — yet `SkillManager`'s global
+>    layer *is* always-on. So B carries a real, if smaller, judgment call (*which
+>    precedent to follow*), not "no boundary question."
+> 2. **ACP already has a plugin-load escape hatch** (corrects §5 / §6-P2).
+>    `session/new` and `session/load` take an injected `agent_factory`
+>    (`acp/session_new.py:304`, `acp/session_load.py:122`). The asymmetry is only
+>    in the *default* factory; a host can already supply one that loads plugins.
+>    This weakens "ACP is a gap" and gives P2 a natural seam.
+> 3. **P2's settings-gated default-off pattern is not novel** (refines §6-P2). It
+>    is exactly how `enable_builtin_agents` already works in the same function —
+>    cite it as precedent, not invention. The non-trivial parts of the extraction
+>    are decoupling `_plugin_inline_dirs` into an `inline_dirs` parameter **and**
+>    binding `PluginManager` to the factory's frozen `cwd` (both detailed in
+>    §6-P2 step 1).
+
+---
+
+## 1. The triggering report (premise, verbatim)
+
+> *Skills carrying sub-agent definitions in their `agents/` subdir (e.g.
+> `skills/skill-creator/agents/analyzer.md`) are only discovered and registered
+> under the CLI entry point. The other two entry points — Python embedding
+> (`build_from_environment`) and ACP (`session/new`) — skip plugin/skill-agent
+> loading, making skill-defined sub-agents invisible to them.*
+
+The report then cited four mechanisms: `AgentManager` scanning only two dirs;
+`build_from_environment` calling no plugin loader; ACP delegating to it; and
+`_load_and_register_plugins` being CLI-only.
+
+The four *mechanisms* are mostly accurate (§2). The *premise they were marshalled
+to support* — "skill sub-agents are visible in the CLI" — is not (§3).
+
+## 2. What is verified true
+
+| Claim | Verdict | Evidence (`main`@`e477ad3`) |
+|---|---|---|
+| `_load_and_register_plugins` is CLI-only | ✅ true | Defined `cli/subcommands.py:283`; non-test call sites only `cli/app.py:112` and `cli/run.py:543`. |
+| `build_from_environment` loads no plugins | ✅ true | `grep "plugin" agentao/embedding/factory.py` → no match. Constructs `Agentao(**kwargs)` and returns. |
+| ACP `session/new` loads no plugins | ✅ true | `acp/session_new.py:158` — `default_agent_factory` returns `build_from_environment(working_directory=cwd, **overrides)` directly; no plugin step. |
+| `AgentManager._load_definitions` scans only two dirs | ✅ true | `agents/manager.py:31-37` — builtin `definitions/` (gated on `include_builtin_agents`) + project `.agentao/agents/`. No global layer. |
+| `SkillManager` scans three layers | ✅ true | `skills/manager.py` — global `~/.agentao/skills` (`:14`), project `.agentao/skills` (`:99`/`104`), repo `skills/` (`:100`/`105`), plus bundled `_BUNDLED_SKILLS_DIR` (`:17`). |
+
+So the report's *directory-comparison* table (AgentManager 2 layers vs
+SkillManager 3) is correct, and the *plugin-load-is-CLI-only* observation is
+correct.
+
+## 3. The false premise: a skill's `agents/` is bridged to nothing
+
+The report's example — `skills/skill-creator/agents/analyzer.md` — drives the
+whole framing. It does not survive a grep.
+
+**(a) `agents/` discovery belongs to the *plugin* subsystem, not skills.**
+The only code that joins a root to `agents/` is the plugin agent resolver:
+
+```
+embedding/plugins/resolvers/agents.py:41   default_dir = plugin.root_path / "agents"
+embedding/plugins/resolvers/agents.py:85   def _scan_agents_dir(plugin_name, agents_dir): ...
+```
+
+`SkillManager` has **no** `agents/` handling at all — grep of
+`agentao/skills/manager.py` for `agents` returns only the *skill* directory
+constants, never an `agents/` subscan.
+
+**(b) Plugin discovery never looks inside `skills/`.**
+`PluginManager.discover_candidates` (`embedding/plugins/manager.py:91-110`) scans
+exactly three sources:
+
+```
+:96   global   ~/.agentao/plugins
+:100  project  <cwd>/.agentao/plugins
+:104  inline   self._inline_dirs   (populated only by the CLI — entrypoints.py:373)
+```
+
+The repo's `skills/` tree is not among them.
+
+**(c) `skill-creator` is a bundled *skill*, not a *plugin*.**
+`find skills/skill-creator` shows `SKILL.md` + `agents/{analyzer,comparator,
+grader}.md` and **no plugin manifest** (`agentao-plugin.json` does not exist
+anywhere in the tree). It reaches the runtime via `SkillManager`'s bundled-skill
+seeding (`skills/manager.py:17`, `:60`), which copies it to `~/.agentao/skills/`
+— a *skills* directory, never a *plugins* directory.
+
+**Conclusion.** For `skills/skill-creator/agents/analyzer.md` to be registered,
+`skill-creator` would have to be loaded as a **plugin** (a plugin root whose
+`agents/` is auto-scanned). It is not, and nothing in any entry point makes it
+one. The agent files are therefore invisible to **all three** entry points,
+**including the CLI** — exactly the opposite of "visible in the CLI, missing
+elsewhere."
+
+> This is the failure mode `CLAUDE.md` warns about under *"Don't intuition-audit
+> architecture."* The `agents/` directory name is shared vocabulary between the
+> skill and plugin subsystems, and the report assumed a bridge that the code does
+> not contain.
+
+## 4. The two real, independent issues (and one absent feature)
+
+Dropping the conflation, three separable things remain:
+
+### 4.1 Issue A — plugin loading is CLI-only (real)
+
+`_load_and_register_plugins` (`cli/subcommands.py:283-372`) is not just an
+agent loader. In one pass it registers the **entire plugin surface** onto the
+agent:
+
+- plugin **skills** → `agent.skill_manager.register_plugin_skills` (`:301`)
+- plugin **agents** → `agent.agent_manager.register_plugin_agents` (`:321`),
+  then `agent._register_agent_tools()` (`:337`)
+- plugin **MCP servers** → merged + MCP manager re-init (`:347-359`)
+- plugin **hooks** → `agent._plugin_hook_rules` / `tool_runner` (`:361-372`)
+
+Because this lives in `cli/` and is called only from `cli/app.py` and
+`cli/run.py`, an embedded host (and every ACP/IDE session, which routes through
+`build_from_environment`) gets **none** of it. The asymmetry is real, and it is
+*broader* than the report framed it — it is the whole plugin subsystem, not
+sub-agents specifically.
+
+### 4.2 Issue B — `AgentManager` lacks a global layer (real, minor)
+
+`AgentManager._load_definitions` scans builtin + project `.agentao/agents/`
+only (`agents/manager.py:31-37`). `SkillManager` scans a global
+`~/.agentao/skills/` layer; the agent manager has no `~/.agentao/agents/`
+equivalent. A user who drops a personal agent definition in their home config
+dir — mirroring how user-global skills work — gets nothing. This is independent
+of the plugin question and is the cheapest thing here to *implement* (one
+`_scan_directory(user_root() / "agents")` call, ordered for the
+right precedence).
+
+> **It is cheap to implement but it is *not* boundary-free** (reverse-review
+> correction). The codebase is already inconsistent about auto-loading
+> ambient agent state: `SkillManager`'s global layer is always-on, but
+> `build_from_environment` keeps even *builtin* agents **off by default** behind
+> a settings flag (`_builtin_agents_enabled`, `factory.py:48,238`;
+> `enable_builtin_agents=False`, `agent.py:102`). So "should user-global agent
+> definitions be auto-registered everywhere?" is a genuine judgment call —
+> *follow the always-on skills precedent, or the default-off builtin-agents
+> precedent?* An agent definition is lower-risk than a plugin (it carries only a
+> system prompt + tool allowlist, runs only when the LLM invokes it — closer to a
+> passive skill than to a side-effecting MCP server/hook), which argues for the
+> skills precedent; but it is not the no-decision change the first draft implied.
+
+### 4.3 Absent feature — "a skill carries sub-agents"
+
+The capability the report *assumed* exists — a skill bundling sub-agents in its
+own `agents/` subdir and having them registered when the skill is active — is
+**not implemented**. Building it is a *new feature* (a skill→AgentManager
+bridge), not a bug fix, and it raises its own design questions (do a skill's
+sub-agents register on skill *activation* or on *discovery*? are they namespaced
+by skill? do they deactivate with the skill?). It should be evaluated on demand,
+not folded into an "entry-point parity" fix.
+
+> **A sharper finding** (reverse-review note, corrects the first-draft "inert
+> payload" claim): the reporter's example refutes the *mechanism* twice over.
+> `skill-creator`'s `agents/{analyzer,comparator,grader}.md` are **not agent
+> definitions** — they carry no YAML frontmatter (`name:`/`description:`), just a
+> prose H1, so `parse_frontmatter` would yield an empty name even if scanned. And
+> the skill does **not want them registered**: its SKILL.md uses them as
+> *reference docs it reads at runtime* ("spawn a grader subagent that **reads
+> `agents/grader.md`**", "**Read `agents/comparator.md`**", "the agents/ directory
+> contains instructions … **Read them when you need to spawn** the relevant
+> subagent" — `SKILL.md:225,327,455`), then spawns a *generic* subagent with that
+> content as instructions. So the files are neither inert nor registrable — they
+> already work, as instruction payload, exactly as the upstream skill format
+> intends. That makes C a **demand-gated hypothetical**: the one in-tree artifact
+> that *looks* like it needs a skill→agent registration bridge does not. See
+> §6-P3 for when that would change.
+
+> **Upstream packaging corroborates this** (cross-checked against Claude Code's
+> own plugin install, 2026-06-23). Claude Code distributes skill-creator as a
+> *plugin* (`~/.claude/plugins/installed_plugins.json` →
+> `skill-creator@claude-plugins-official`, with a `.claude-plugin/plugin.json`
+> manifest) — yet its `agents/{analyzer,comparator,grader}` are **still not
+> registered as sub-agents** there either. Two reasons, both structural: the
+> plugin manifest declares no `agents` field, and the files sit at
+> `skills/skill-creator/agents/` *inside the skill*, not at the plugin's agent
+> root `<plugin>/agents/` that plugin agent-discovery scans (the same
+> `plugin.root_path / "agents"` rule agentao uses, §3). Confirmed empirically:
+> those names are absent from the session's available agent types. So the
+> upstream **deliberately** packages them as skill assets, not plugin-agents —
+> and in *both* Claude Code (where skill-creator is a plugin) and agentao (where
+> it is a bundled skill), they are skill-internal reference docs, never
+> registered sub-agents. The reporter's premise — "a skill's bundled agents get
+> registered" — fails even by the precedent it most likely came from.
+
+## 5. Is Issue A a bug, or an intentional isolation boundary?
+
+This is the load-bearing judgment, and it is the maintainer's call — not
+self-evidently a defect.
+
+**The argument that CLI-only is deliberate.** Plugins are sourced primarily from
+the user's **global** `~/.agentao/plugins`. Having `build_from_environment`
+auto-load them would mean **every embedded host, and every ACP/IDE session,
+silently inherits the end user's global agents, MCP servers, and hooks.** For an
+*embedded harness* that is a trust/isolation footgun: a host application that
+embeds `Agentao(...)` to do one bounded job generally does **not** want its agent
+surface, tool set, and outbound MCP connections silently expanded by whatever the
+machine's user happens to have installed globally. Hooks especially — a global
+plugin hook firing inside an embedded host's tool pipeline is an injection
+surface the host never opted into. The CLI is the one context where "load the
+user's plugins" is unambiguously the user's intent, because the user *is* the
+operator. So routing plugin loading through the CLI layer, and leaving the core
+construction path plugin-free, is a defensible **default-deny** posture
+consistent with how agentao treats other ambient inputs.
+
+**The argument that it is a gap.** The asymmetry is **undocumented**. An embedder
+reasonably expects the three entry points to be at parity, and there is no
+*first-class* host-API surface today to say "yes, load my plugins." The real
+smell is not the default — it is the *absence of a documented opt-in*, which
+leaves the behavior looking accidental rather than chosen.
+
+**A seam already exists, which tilts this toward "intentional, just
+undocumented."** ACP `session/new` and `session/load` already accept an injected
+`agent_factory` (`acp/session_new.py:304`, `acp/session_load.py:122`), and an
+embedded host constructs `Agentao` itself — so *both* non-CLI paths can already
+load plugins by supplying a factory / post-construction step that calls the
+loader. The capability is reachable today; what is missing is a blessed, named,
+documented switch rather than an ad-hoc workaround. That a deliberate injection
+point exists at exactly the construction seam is itself weak evidence the
+plugin-free default is a choice, not an oversight.
+
+Per the project's standing rule (*pain judgment is the user's call*), this doc
+does not declare Issue A a "real pain." It presents the trade-off and recommends
+a posture that satisfies both readings.
+
+## 6. Proposals (prioritized — maintainer's call)
+
+**P1 — close Issue B (cheap to implement; one small boundary call to settle
+first).**
+Add the global layer to `AgentManager._load_definitions`:
+`_scan_directory(user_root() / "agents")` — note `user_root()` is **already**
+`~/.agentao`, so the path is `~/.agentao/agents`, **not** `user_root()/".agentao"
+/"agents"` (that would scan `~/.agentao/.agentao/agents`). Place it to give the
+right precedence vs project defs (mirror `SkillManager`'s global<project
+ordering, and decide whether project overrides global as skills do), and **add a
+covering test** for the override order. Self-contained; ship independently.
+**Before merging, settle the one judgment call** (per the
+reverse-review correction in §4.2): does user-global agent auto-loading follow
+the *always-on* skills precedent or the *default-off, settings-gated*
+builtin-agents precedent? Recommendation: follow skills (always-on) — an agent
+*definition* is passive (system prompt + tool allowlist, runs only on LLM
+invocation), unlike a plugin's side-effecting MCP/hooks — but make that an
+explicit decision in the PR, not an implicit one.
+
+**P2 — make plugin loading reachable from the core, default-off (resolves Issue
+A without breaking isolation).**
+1. Extract a **narrow helper** from `cli/subcommands.py` into `embedding/` —
+   e.g. `load_plugins_for_agent(agent, *, cwd, inline_dirs=None)` — wrapping the
+   current `_load_and_register_plugins` body. The move is mostly mechanical (the
+   body already imports almost exclusively from `embedding/plugins/*`), but it
+   needs **two** explicit parameterizations, not one:
+   - **`inline_dirs`** — today it reads the CLI global `_plugin_inline_dirs`
+     (`cli/subcommands.py:291`); pass it in (default `None`, since inline dirs
+     come only from the CLI `--plugin-dir` flags).
+   - **`cwd`** — `PluginManager` defaults its project-scan root to `Path.cwd()`
+     (`PluginManager.__init__` → `self._cwd = _find_project_root(cwd or
+     Path.cwd())`, `embedding/plugins/manager.py:79`). The CLI gets away with the
+     default because cwd == working dir there, but a host calling
+     `build_from_environment(working_directory=wd)` deliberately **freezes** the
+     runtime to `wd`. The helper must therefore pass `cwd=agent.working_directory`
+     into `PluginManager(cwd=..., inline_dirs=...)`; otherwise project plugins are
+     scanned at the process cwd, breaking the frozen-cwd contract the factory
+     exists to uphold.
+
+   (`logger` is a plain module logger and moves cleanly — not a real coupling.)
+2. CLI keeps calling the helper by default (unchanged behavior). Have
+   `build_from_environment` accept an explicit `load_plugins: bool = False` (or
+   honor a `.agentao/settings.json` flag), default **off**; when set, call
+   `load_plugins_for_agent(agent, cwd=wd, ...)` after construction. **This
+   default-off-settings-gated pattern already exists in the same function**:
+   `enable_builtin_agents` is resolved exactly this way
+   (`_builtin_agents_enabled(settings)` → default-`False` override,
+   `factory.py:48,238`). Follow that precedent so the switch is idiomatic, not a
+   new mechanism.
+3. ACP `session/new` / `session/load` inherit the switch for free via
+   `default_agent_factory` (the injected `agent_factory` seam already noted in
+   §5); expose it through whatever ACP/host config surface is appropriate (gated
+   by the chat/automation target decision in `acp-server-conformance-review.md`).
+4. Document the switch and the default-off rationale in `host-api.md` /
+   `host-tool-injection.md`, so the posture reads as *chosen*, not *accidental*.
+
+This keeps the safe default (no silent global-plugin inheritance) while giving
+embedders and ACP hosts an explicit, documented way to opt in — the same shape as
+the existing host tool-injection contract.
+
+**P3 — "skill carries sub-agents" (build only on a concrete demand signal).**
+Treat §4.3 as a separate feature spec; do not bundle it into P2. **When to build
+it — three triggers, none of which fire today:**
+1. **A skill genuinely needs registration.** A skill ships `agents/*.md` *in
+   agent-definition format* (YAML `name:`/`description:` frontmatter) and its
+   author expects them to surface as invokable sub-agent tools while the skill is
+   active — and reports they don't. The one in-tree example, `skill-creator`,
+   explicitly does **not** meet this: its `agents/` are read-at-runtime
+   instruction docs, not definitions (§4.3). So in-tree demand is **zero** right
+   now.
+2. **Skills become a distribution unit** (published/shared, à la plugins). Until
+   then, anyone wanting *distributable* bundled agents already has a path — ship
+   a **plugin**, whose `agents/` is auto-scanned (§3). P3's niche only opens if
+   skill-as-distribution diverges from plugin-as-distribution.
+3. **A host/user asks for it directly.** Per the demand-gated rule (gap ≠ need),
+   the request is the signal — not the mere existence of unbridged `agents/`
+   dirs.
+
+**Decide the design on paper now; build later.** Settle §4.3's three questions
+(activation-vs-discovery timing, skill-namespacing, lifecycle coupling) before
+any code, so the feature is ready the moment a trigger fires. The natural shape
+is a `SkillManager`→`AgentManager` bridge firing on skill *activation* (so
+sub-agents share the skill's lifecycle) — **not** teaching `PluginManager` to
+scan `skills/`, which would merge two distinct trust/lifecycle models (§7).
+
+## 7. Non-goals / what NOT to do
+
+- **Do not** make `build_from_environment` auto-load global plugins by default to
+  "fix parity." That silently expands every embedded host's agent/MCP/hook
+  surface from the machine's global config — the isolation footgun in §5.
+- **Do not** teach `PluginManager` to scan `skills/` as a plugin source. Skills
+  and plugins are distinct subsystems with distinct trust and lifecycle models;
+  merging them to make one example work is the wrong layer.
+- **Do not** describe P1 (Issue B) and P2 (Issue A) as one change. They are
+  independent; P1 carries only a *small* default-loading decision of its own
+  (§4.2 — which precedent the global agent layer follows) and should not be
+  bound to, or held hostage by, the broader plugin-isolation decision that
+  governs P2.

--- a/docs/design/subagent-discovery-entrypoint-review.zh.md
+++ b/docs/design/subagent-discovery-entrypoint-review.zh.md
@@ -1,0 +1,317 @@
+# 子 Agent 发现 —— 入口不对称 与 Skill/Plugin 混淆
+
+**状态：** 评审记录。2026-06-23 起草，基于对 agent 定义、skill、plugin 三套发现路径
+在三个运行入口（交互式 CLI / `agentao run`、Python 嵌入 `build_from_environment`、
+ACP `session/new`）上的 grep 验证式通读。**这是缺口分析 + 优先级建议，不是已批准的
+方案。** 它用来回答一个关于子 agent 注册的具体疑问 —— 并在回答过程中，纠正那个疑问
+所依据的前提。
+**读者：** Agentao 维护者；任何期望 skill 或 plugin 携带的子 agent 可见的嵌入方。
+**配套：** `subagent-discovery-entrypoint-review.md`（英文）。
+**相关：**
+- `embedding-vs-acp.md` —— 为什么 ACP 与 `agentao run` 是嵌入核心之上的*前端*，而非
+  核心契约本身。§5 里"plugin 加载该放核心还是前端？"正是这条边界的直接应用。
+- `host-tool-injection.md` —— 宿主显式工具注入契约
+  （`extra_tools` / `disable_tools` / `enabled_tools`）。§6 的 opt-in plugin 加载
+  建议沿用同一姿态："宿主显式 opt-in，默认最小"。
+- `acp-server-conformance-review.md` —— 确立 ACP 目标客户端 = chat/automation；与
+  "ACP 会话*该不该*继承全局 plugin" 直接相关。
+
+**方法：** 通读 `AgentManager._load_definitions`、`SkillManager._load_skills`、
+plugin 发现/解析链（`embedding/plugins/`）及三条构造路径；grep
+`_load_and_register_plugins` 的所有调用点；grep 任何把 skill 根目录桥接到 `agents/`
+的代码；`find` `skills/` 下的 plugin manifest。代码引用锚定 `main`@`e477ad3`
+（2026-06-23）。
+
+---
+
+## TL;DR
+
+触发本评审的报告称：*"skill 携带的子 agent（如
+`skills/skill-creator/agents/analyzer.md`）只在 CLI 下被发现注册，嵌入与 ACP 入口
+跳过了它们。"*
+
+**这个标题前提是错的。** skill 携带的 `agents/` 子目录被桥接到了**任何地方都没有**——
+CLI 没有、嵌入没有、ACP 也没有。`agents/` 自动发现是 **plugin** 的特性；一个 bundled
+*skill* 不是 *plugin* 根目录，而 plugin 发现扫描从不进入 `skills/`。所以
+`skill-creator` 的三个 agent 文件对**每一个**入口都不可见，**包括交互式 CLI**。报告
+把 *skill* 和 *plugin* 混为一谈了。
+
+去掉混淆后**属实**的，是一组更小、也不同的事实 —— 两个独立问题 + 一个尚不存在的特性：
+
+1. **plugin 加载是 CLI 专属**（真实）。`build_from_environment` 和 ACP `session/new`
+   加载的 plugin 数量为 **零** —— 不只是 plugin-agent，连 plugin 的 *skill、MCP
+   server、hook* 一并不加载。
+2. **`AgentManager` 没有全局层**（真实，但小）。它只扫 builtin + 项目
+   `.agentao/agents/`；不像 `SkillManager` 有三层，它没有 `~/.agentao/agents/`。
+3. **"skill 携带子 agent" 这个特性尚未接线**（缺失特性，不是 bug）。没有任何代码把
+   skill 的 `agents/` 映射进 `AgentManager`。
+
+(1) 究竟是 *bug* 还是 *有意的隔离边界*，是维护者的判断 —— 而且有一条真实的信任论据
+支持 "CLI-only 是刻意的"（§5）。建议（§6）是：低成本修掉 (2)；把 (1) 当作
+**默认关闭的 opt-in** 以保住宿主隔离；若有需求，把 (3) 当独立特性提案另议。
+
+> **反向复核纠正（2026-06-23，对抗性再核）。** 本文已对照自身声明重新验证。中心论点
+> （§3 —— skill 的 `agents/` 被桥接到*任何地方都没有*，**包括 CLI**）**活下来且更
+> 硬**：`_plugin_inline_dirs` *只*由 CLI `--plugin-dir` 旗标填充
+> （`cli/entrypoints.py:371-373`），从不自动注入 `skills/*`，所以 CLI 不会把 skill
+> 目录当 inline plugin 加载。三处*次级* framing 被夸大，已就地纠正：
+> 1. **问题 B *并非*无边界**（纠正 §4.2 / §6-P1）。`build_from_environment` 已经把
+>    连*builtin* agent 都门控在一个默认**关**的 settings 开关后
+>    （`_builtin_agents_enabled`，`factory.py:48,238`；`enable_builtin_agents` 默认
+>    `False`，`agent.py:102`）。常开扫描用户全局 `~/.agentao/agents/` 会与这个保守
+>    姿态冲突 —— 然而 `SkillManager` 的全局层*却是*常开。所以 B 带着一个真实（虽更小）
+>    的判断 ——*跟哪个先例*—— 而非"无边界争议"。
+> 2. **ACP 已有 plugin 加载逃生口**（纠正 §5 / §6-P2）。`session/new` 和
+>    `session/load` 都接受注入的 `agent_factory`（`acp/session_new.py:304`、
+>    `acp/session_load.py:122`）。不对称只在*默认* factory 上；宿主已能自带一个加载
+>    plugin 的 factory。这削弱了"ACP 是 gap"，也给 P2 一个天然接缝。
+> 3. **P2 的 settings 门控默认关模式并不新**（细化 §6-P2）。它正是同一函数里
+>    `enable_builtin_agents` 的既有做法 —— 当作先例引用，不是发明。抽取里不平凡的部分
+>    有**两处**：把 `_plugin_inline_dirs` 解耦为 `inline_dirs` 参数，**以及**把
+>    `PluginManager` 绑定到 factory 冻结的 `cwd`（两者详见 §6-P2 第 1 步）。
+
+---
+
+## 1. 触发报告（前提，原文）
+
+> *skill 在其 `agents/` 子目录携带的子 agent 定义（如
+> `skills/skill-creator/agents/analyzer.md`），只有在 CLI 入口下才被发现和注册。
+> 另两个入口 —— Python 嵌入（`build_from_environment`）和 ACP（`session/new`）——
+> 完全跳过了 plugin/skill-agent 加载，导致 skill 内定义的子 agent 对它们不可见。*
+
+报告随后列了四条机制：`AgentManager` 只扫两个目录；`build_from_environment` 不调用
+plugin 加载；ACP 委托给它；`_load_and_register_plugins` 仅 CLI 触发。
+
+这四条*机制*大体准确（§2）。但它们被用来支撑的那个*前提* ——
+"skill 子 agent 在 CLI 下可见" —— 不成立（§3）。
+
+## 2. 经验证属实的部分
+
+| 声明 | 结论 | 证据（`main`@`e477ad3`） |
+|---|---|---|
+| `_load_and_register_plugins` 仅 CLI | ✅ 真 | 定义于 `cli/subcommands.py:283`；非测试调用点只有 `cli/app.py:112` 与 `cli/run.py:543`。 |
+| `build_from_environment` 不加载 plugin | ✅ 真 | `grep "plugin" agentao/embedding/factory.py` → 无匹配。构造 `Agentao(**kwargs)` 后直接返回。 |
+| ACP `session/new` 不加载 plugin | ✅ 真 | `acp/session_new.py:158` —— `default_agent_factory` 直接返回 `build_from_environment(working_directory=cwd, **overrides)`，无 plugin 步骤。 |
+| `AgentManager._load_definitions` 只扫两个目录 | ✅ 真 | `agents/manager.py:31-37` —— builtin `definitions/`（受 `include_builtin_agents` 控制）+ 项目 `.agentao/agents/`。无全局层。 |
+| `SkillManager` 扫三层 | ✅ 真 | `skills/manager.py` —— 全局 `~/.agentao/skills`（`:14`）、项目 `.agentao/skills`（`:99`/`104`）、仓库 `skills/`（`:100`/`105`），外加 bundled `_BUNDLED_SKILLS_DIR`（`:17`）。 |
+
+所以报告的*目录对比*表（AgentManager 2 层 vs SkillManager 3 层）正确，
+*plugin 加载仅 CLI* 的观察也正确。
+
+## 3. 错误前提：skill 的 `agents/` 没有被桥接到任何地方
+
+报告的例子 —— `skills/skill-creator/agents/analyzer.md` —— 撑起了整个叙事。它过不了
+grep。
+
+**(a) `agents/` 发现属于 *plugin* 子系统，不属于 skill。**
+唯一把某个根目录拼上 `agents/` 的代码，是 plugin 的 agent 解析器：
+
+```
+embedding/plugins/resolvers/agents.py:41   default_dir = plugin.root_path / "agents"
+embedding/plugins/resolvers/agents.py:85   def _scan_agents_dir(plugin_name, agents_dir): ...
+```
+
+`SkillManager` **完全没有** `agents/` 处理 —— 对 `agentao/skills/manager.py` grep
+`agents` 只命中 *skill* 目录常量，从无 `agents/` 子扫描。
+
+**(b) plugin 发现从不进入 `skills/`。**
+`PluginManager.discover_candidates`（`embedding/plugins/manager.py:91-110`）只扫
+三处来源：
+
+```
+:96   全局   ~/.agentao/plugins
+:100  项目   <cwd>/.agentao/plugins
+:104  inline self._inline_dirs   （仅由 CLI 填充 —— entrypoints.py:373）
+```
+
+仓库的 `skills/` 树不在其列。
+
+**(c) `skill-creator` 是 bundled *skill*，不是 *plugin*。**
+`find skills/skill-creator` 显示 `SKILL.md` + `agents/{analyzer,comparator,
+grader}.md`，且**没有任何 plugin manifest**（整棵树都不存在 `agentao-plugin.json`）。
+它经由 `SkillManager` 的 bundled-skill 落盘（`skills/manager.py:17`、`:60`）到达
+运行时，被复制进 `~/.agentao/skills/` —— 一个 *skills* 目录，绝非 *plugins* 目录。
+
+**结论。** 要让 `skills/skill-creator/agents/analyzer.md` 被注册，`skill-creator`
+必须作为 **plugin** 被加载（一个其 `agents/` 会被自动扫描的 plugin 根）。它不是，而且
+没有任何入口把它变成 plugin。因此这些 agent 文件对**三个入口全部**不可见，**包括
+CLI** —— 与"CLI 可见、别处缺失"恰好相反。
+
+> 这正是 `CLAUDE.md` 在 *"别凭直觉审计架构"* 下警告的失效模式。`agents/` 这个目录名
+> 是 skill 与 plugin 两个子系统共享的词汇，报告假设了一座代码里并不存在的桥。
+
+## 4. 两个真实且独立的问题（外加一个缺失特性）
+
+去掉混淆，剩下三件可分开处理的事：
+
+### 4.1 问题 A —— plugin 加载仅 CLI（真实）
+
+`_load_and_register_plugins`（`cli/subcommands.py:283-372`）不只是 agent 加载器。
+它一趟把**整个 plugin 面**注册到 agent 上：
+
+- plugin **skill** → `agent.skill_manager.register_plugin_skills`（`:301`）
+- plugin **agent** → `agent.agent_manager.register_plugin_agents`（`:321`），
+  随后 `agent._register_agent_tools()`（`:337`）
+- plugin **MCP server** → 合并 + MCP manager 重建（`:347-359`）
+- plugin **hook** → `agent._plugin_hook_rules` / `tool_runner`（`:361-372`）
+
+因为它住在 `cli/` 且只被 `cli/app.py`、`cli/run.py` 调用，嵌入宿主（以及每个走
+`build_from_environment` 的 ACP/IDE 会话）一样都拿不到。不对称是真实的，而且*比报告
+所述更宽* —— 缺的是整个 plugin 子系统，不单是子 agent。
+
+### 4.2 问题 B —— `AgentManager` 缺全局层（真实，但小）
+
+`AgentManager._load_definitions` 只扫 builtin + 项目 `.agentao/agents/`
+（`agents/manager.py:31-37`）。`SkillManager` 有全局 `~/.agentao/skills/` 层；
+agent manager 没有对应的 `~/.agentao/agents/`。用户在 home 配置目录放一个个人 agent
+定义 —— 类比用户全局 skill 的用法 —— 什么都不会发生。这与 plugin 问题无关，也是这里
+最便宜*实现*的（一句 `_scan_directory(user_root() / "agents")`，按正确
+优先级排序）。
+
+> **实现便宜，但*并非*无边界**（反向复核纠正）。代码库对"自动加载环境态 agent"本身
+> 就已不一致：`SkillManager` 全局层常开，而 `build_from_environment` 把连*builtin*
+> agent 都默认**关**、门控在 settings 开关后（`_builtin_agents_enabled`，
+> `factory.py:48,238`；`enable_builtin_agents=False`，`agent.py:102`）。所以
+> "用户全局 agent 定义该不该到处自动注册？"是个真实判断 ——*跟常开的 skill 先例，还是
+> 跟默认关的 builtin-agent 先例？* 一个 agent 定义比 plugin 风险低（只带 system
+> prompt + 工具白名单，仅在 LLM 调用时运行 —— 更接近被动 skill，而非有副作用的 MCP
+> server/hook），这倾向 skill 先例；但它不是初稿暗示的那种"无需决策"的改动。
+
+### 4.3 缺失特性 —— "skill 携带子 agent"
+
+报告*假设*存在的能力 —— skill 在自己的 `agents/` 子目录里捆绑子 agent、并在 skill
+激活时被注册 —— **尚未实现**。把它做出来是*新特性*（一座 skill→AgentManager 的桥），
+不是 bug 修复，且它自带设计问题（skill 的子 agent 在 skill *激活*时注册还是*发现*时
+注册？是否按 skill 命名空间隔离？随 skill 停用而停用吗？）。应按需求评估，不要塞进
+"入口对等"修复里。
+
+> **一个更锐利的发现**（反向复核注，纠正初稿"惰性载荷"的说法）：报告者的例子从两个
+> 层面推翻了那个*机制*。`skill-creator` 的 `agents/{analyzer,comparator,grader}.md`
+> **不是 agent 定义** —— 它们没有 YAML frontmatter（`name:`/`description:`），只有一个
+> prose H1，即便被扫描，`parse_frontmatter` 得到的 name 也是空的。而且这个 skill **并不
+> 想让它们被注册**：其 SKILL.md 把它们当作*运行时读取的参考文档*用（"spawn a grader
+> subagent that **reads `agents/grader.md`**"、"**Read `agents/comparator.md`**"、
+> "the agents/ directory contains instructions … **Read them when you need to
+> spawn** the relevant subagent" —— `SKILL.md:225,327,455`），然后用这些内容作为指令
+> 去 spawn 一个*通用* subagent。所以这些文件既非惰性、也不可注册 —— 它们已经在工作，
+> 作为指令载荷，恰如上游 skill 格式的本意。这让 C 成为一个**需求门控的假设**：唯一一个
+> *看起来*需要 skill→agent 注册桥的在树产物，其实并不需要。何时会改变见 §6-P3。
+
+> **上游打包方式佐证了这一点**（对照 Claude Code 自己的 plugin 安装核实，2026-06-23）。
+> Claude Code 把 skill-creator 作为 *plugin* 分发
+> （`~/.claude/plugins/installed_plugins.json` → `skill-creator@claude-plugins-official`，
+> 带 `.claude-plugin/plugin.json` manifest）—— 可它的
+> `agents/{analyzer,comparator,grader}` 在那边**同样不被注册为子 agent**。两个原因，都是
+> 结构性的：plugin manifest 没声明 `agents` 字段；而这些文件位于
+> `skills/skill-creator/agents/`——*在 skill 内部*，不在 plugin 的 agent 根
+> `<plugin>/agents/`（plugin agent 发现扫描的正是后者，与 agentao 同一条
+> `plugin.root_path / "agents"` 规则，§3）。实证确认：这些名字不在本会话的可用 agent
+> 类型里。所以上游是**刻意**把它们打包成 skill 资产、而非 plugin-agent —— 在 Claude
+> Code（skill-creator 是 plugin）和 agentao（它是 bundled skill）*两边*，它们都是 skill
+> 内部、运行时读取的参考文档，从不是注册子 agent。报告者的前提——"skill 捆绑的 agent 会
+> 被注册"——连它最可能的来源（Claude Code）都不成立。
+
+## 5. 问题 A 是 bug，还是有意的隔离边界？
+
+这是承重判断，且是维护者的决定 —— 并非不言自明的缺陷。
+
+**支持 "CLI-only 是刻意的" 的论据。** plugin 主要来源是用户的**全局**
+`~/.agentao/plugins`。让 `build_from_environment` 自动加载它们，意味着**每一个嵌入
+宿主、每一个 ACP/IDE 会话，都会静默继承终端用户全局的 agent、MCP server 和 hook。**
+对一个*嵌入式 harness* 而言这是信任/隔离上的脚枪：一个嵌入 `Agentao(...)` 去做一件
+有界工作的宿主应用，通常*不希望*自己的 agent 面、工具集、外联 MCP 连接，被这台机器的
+用户碰巧全局装了什么而悄悄扩张。尤其是 hook —— 一个全局 plugin hook 在嵌入宿主的工具
+管线里触发，是宿主从未 opt-in 的注入面。CLI 是唯一一个"加载用户的 plugin"毫无歧义
+即用户意图的场景，因为用户*就是*操作者。所以把 plugin 加载走 CLI 层、让核心构造路径
+保持无 plugin，是一种站得住脚的 **默认拒绝** 姿态，与 agentao 对待其他环境输入的方式
+一致。
+
+**支持 "这是缺口" 的论据。** 这种不对称**没有文档**。嵌入方合理地期望三个入口对等，
+而今天没有任何*一等的* host-API 表面能说"是的，加载我的 plugin"。真正的 smell 不是
+这个默认 —— 而是 *缺少有文档的 opt-in*，让该行为看起来像意外而非选择。
+
+**一个接缝已经存在，这把天平推向"刻意，只是没写文档"。** ACP `session/new` 与
+`session/load` 已接受注入的 `agent_factory`（`acp/session_new.py:304`、
+`acp/session_load.py:122`），而嵌入宿主自己构造 `Agentao` —— 所以*两条*非 CLI 路径
+今天就能通过提供一个调用加载器的 factory / 构造后步骤来加载 plugin。能力当下可达；缺的
+是一个受祝福、有名字、有文档的开关，而非临时变通。在构造接缝处恰好存在一个刻意的注入
+点，本身就是"无 plugin 默认是选择而非疏漏"的弱证据。
+
+按项目既定规矩（*"痛"的判断是用户的事*），本文不替你把问题 A 定为"真实痛点"。它摆出
+取舍，并推荐一个同时满足两种解读的姿态。
+
+## 6. 建议（按优先级 —— 维护者定夺）
+
+**P1 —— 修问题 B（实现便宜；但要先定一个小的边界判断）。**
+给 `AgentManager._load_definitions` 加全局层：
+`_scan_directory(user_root() / "agents")` —— 注意 `user_root()` **本身就是**
+`~/.agentao`，所以路径是 `~/.agentao/agents`，**不是** `user_root()/".agentao"
+/"agents"`（那会扫到 `~/.agentao/.agentao/agents`）。放在能给出正确优先级的位置
+（对照 `SkillManager` 的 全局<项目 顺序，并决定是否像 skill 那样项目覆盖全局），并
+**加一个覆盖测试**验证覆盖顺序。自包含；可独立发版。**合并前先定那个判断**（见 §4.2
+的反向复核纠正）：用户全局 agent
+自动加载该跟*常开*的 skill 先例，还是*默认关、settings 门控*的 builtin-agent 先例？
+建议：跟 skill（常开）—— 一个 agent *定义*是被动的（system prompt + 工具白名单，仅在
+LLM 调用时运行），不像 plugin 那样带有副作用的 MCP/hook —— 但要在 PR 里把它写成显式
+决策，而非隐式。
+
+**P2 —— 让 plugin 加载在核心可达，默认关闭（在不破坏隔离的前提下解决问题 A）。**
+1. 从 `cli/subcommands.py` 抽一个**窄 helper** 到 `embedding/` —— 例如
+   `load_plugins_for_agent(agent, *, cwd, inline_dirs=None)`，包住现在
+   `_load_and_register_plugins` 的函数体。搬家大体机械（函数体几乎只 import
+   `embedding/plugins/*`），但需要**两处**显式参数化，不是一处：
+   - **`inline_dirs`** —— 现在读 CLI 全局 `_plugin_inline_dirs`
+     （`cli/subcommands.py:291`）；传进去（默认 `None`，因为 inline 目录只来自 CLI
+     `--plugin-dir` 旗标）。
+   - **`cwd`** —— `PluginManager` 的项目扫描根默认取 `Path.cwd()`
+     （`PluginManager.__init__` → `self._cwd = _find_project_root(cwd or
+     Path.cwd())`，`embedding/plugins/manager.py:79`）。CLI 能蒙混过关是因为那里
+     cwd == 工作目录，但宿主调 `build_from_environment(working_directory=wd)` 是
+     刻意把运行时**冻结**到 `wd`。所以 helper 必须把 `cwd=agent.working_directory`
+     传进 `PluginManager(cwd=..., inline_dirs=...)`；否则 project plugin 会按进程
+     cwd 扫描，破坏 factory 存在的意义 —— 冻结工作目录契约。
+
+   （`logger` 只是普通模块 logger，干净迁移 —— 不算真耦合。）
+2. CLI 默认继续调用该 helper（行为不变）。让 `build_from_environment` 接受显式
+   `load_plugins: bool = False`（或读取 `.agentao/settings.json` 的 flag），默认
+   **关**；置位时在构造后调用 `load_plugins_for_agent(agent, cwd=wd, ...)`。
+   **这个默认关 + settings 门控模式在同一函数里已经存在**：`enable_builtin_agents`
+   正是这样解析的（`_builtin_agents_enabled(settings)` → 默认 `False` 的 override，
+   `factory.py:48,238`）。沿用这个先例，让开关地道、不是新机制。
+3. ACP `session/new` / `session/load` 通过 `default_agent_factory` 免费继承该开关
+   （即 §5 提到的注入 `agent_factory` 接缝）；用合适的 ACP/host 配置面暴露它（受
+   `acp-server-conformance-review.md` 里 chat/automation 目标决策的约束）。
+4. 在 `host-api.md` / `host-tool-injection.md` 记录该开关及默认关闭的理由，让这个姿态
+   读起来是*选择*，而非*意外*。
+
+这样既保住安全默认（不静默继承全局 plugin），又给嵌入方和 ACP 宿主一条显式、有文档的
+opt-in 路径 —— 与现有宿主工具注入契约同形。
+
+**P3 —— "skill 携带子 agent"（仅在出现明确需求信号时才做）。**
+把 §4.3 当作独立特性规格；不要并入 P2。**何时做 —— 三个触发条件，今天一个都没触发：**
+1. **某个 skill 真的需要注册。** 一个 skill 以*agent 定义格式*（YAML
+   `name:`/`description:` frontmatter）携带 `agents/*.md`，且作者期望它们在 skill
+   激活时作为可调用的子 agent 工具出现 —— 却发现没有。唯一的在树例子 `skill-creator`
+   明确**不满足**：它的 `agents/` 是运行时读取的指令文档，不是定义（§4.3）。所以当下
+   在树需求为**零**。
+2. **skill 成为分发单元**（像 plugin 那样发布/共享）。在那之前，任何想要*可分发*的
+   捆绑 agent 的人都已有路径 —— 发一个 **plugin**，其 `agents/` 会被自动扫描（§3）。
+   只有当 skill-作为-分发 与 plugin-作为-分发 分道扬镳时，P3 的生态位才打开。
+3. **宿主/用户直接提出需求。** 按需求门控规则（gap ≠ need），那个请求才是信号 ——
+   而非仅仅"存在未桥接的 `agents/` 目录"这一事实。
+
+**现在在纸面上定设计，以后再写代码。** 在动任何代码前先敲定 §4.3 的三个问题
+（激活-vs-发现 时机、skill 命名空间、生命周期耦合），让特性在触发条件一出现就能落地。
+自然的形态是一座在 skill *激活*时触发的 `SkillManager`→`AgentManager` 桥（让子 agent
+与 skill 共享生命周期）—— **而非**教 `PluginManager` 去扫 `skills/`，那会合并两套不同的
+信任/生命周期模型（§7）。
+
+## 7. 非目标 / 不要做什么
+
+- **不要**为"修对等"而让 `build_from_environment` 默认自动加载全局 plugin。那会从机器
+  全局配置静默扩张每一个嵌入宿主的 agent/MCP/hook 面 —— 即 §5 的隔离脚枪。
+- **不要**教 `PluginManager` 把 `skills/` 当 plugin 来源扫描。skill 与 plugin 是两个
+  独立子系统，信任与生命周期模型各异；为让一个例子跑通而合并它们，是错的层。
+- **不要**把 P1（问题 B）和 P2（问题 A）描述成一次改动。它们独立；P1 只自带一个*小的*
+  默认加载决策（§4.2 —— 全局 agent 层跟哪个先例），不应被、也不应受制于管 P2 的更大的
+  plugin 隔离决策绑架。

--- a/docs/design/vendor-sdk-convergence-review.md
+++ b/docs/design/vendor-sdk-convergence-review.md
@@ -1,0 +1,248 @@
+# Vendor-SDK Convergence — Path A Re-examination Trigger Review
+
+**Status:** Strategic review record. Drafted 2026-06-18 after a June-2026 competitive
+landscape sweep (CLI agents, embeddable agent-loop SDKs, general agent frameworks).
+**This is a *trigger determination*, not a strategy reversal.** It records that
+`path-a-roadmap.md` §16.4's "external shift" condition has plausibly fired, lays out the
+evidence, and proposes — *for the maintainer's judgment* — what changes and what does
+not. It does **not** unilaterally retire or rewrite Path A; §1–§8 of the roadmap remain
+locked until a maintainer decision says otherwise.
+**Audience:** Agentao maintainers and strategic reviewers.
+**Companion:** `vendor-sdk-convergence-review.zh.md`.
+**Related:**
+- `path-a-roadmap.md` — the locked embed-first strategy this review tests against (esp. §2.1 success metrics, §2.3 non-goals, §7.1 Mode 2, §16.4 retirement triggers).
+- `embedded-host-contract.md` — the host-contract design this review affirms is *not* the problem.
+- `pi-mono-borrow-review.md` / `codex-reverse-review.md` — the reverse-review discipline this record follows (evidence before recommendation; gap ≠ need).
+
+**Method:** competitive sweep → identify the single market shift that postdates the
+roadmap lock → re-score Agentao's moat axis-by-axis → keep/cut/gate the implied
+directions → determine whether §16.4 fires. Code references anchored to `main`@`bcdb8e4`
+(2026-06-18); positioning claims about external SDKs are dated and will drift — re-verify
+before acting on any one of them.
+
+---
+
+## TL;DR
+
+The Path A roadmap was **locked 2026-04-30**. Since then, the two largest model vendors
+shipped embeddable, governed, sandboxed agent loops driven from the host's own
+Python/TypeScript process — **the literal Path A value proposition**:
+
+- **Claude Agent SDK** — "the exact agent loop that powers Claude Code … driven from
+  your own Python or TypeScript program," four-layer permission pipeline + optional
+  sandbox.
+- **OpenAI Agents SDK** — sandbox execution + model-native harness (isolated workspace,
+  file-level permissions, snapshot/rehydrate). Non-OpenAI models are reachable via
+  Any-LLM / LiteLLM adapters that the docs label **best-effort / beta**, with known gaps
+  in tool calling, structured output, and usage reporting — i.e. broad adapter coverage,
+  *not* Agentao-style first-class provider-neutrality.
+
+**Finding:** "embeddable governed agent loop for Python" is no longer a differentiator —
+it is now table stakes offered by Anthropic and OpenAI with far greater distribution and
+native model integration. This is exactly the condition `path-a-roadmap.md` §16.4 names
+as a retirement/re-examination trigger. **The embed contract is not the problem (P0
+proved it clean); the *answer to "why embed Agentao instead of the vendor SDK"* is the
+problem.**
+
+**Disposition (proposed, maintainer to ratify):**
+- **§16.4 trigger: FIRED (re-examination, not retirement).** The embed-first thesis is
+  narrowed, not invalidated — a defensible moat survives (§3). Convene the surviving-moat
+  decision rather than opening a Path B/C document.
+- **Do now (messaging, ~zero code):** re-headline the differentiation from "embeddable"
+  (now commodity) to "provider-neutral + local/private-first + governed & auditable" (§4 D1).
+- **Do now (distribution):** fix the discoverability/name-collision drag (§4 D2, §5).
+- **Reframe (channel):** treat the existing ~21.5%-of-codebase ACP investment as a
+  distribution channel riding **early-but-real** ecosystem signals, not just a feature (§4 D3).
+- **Re-prioritize but still demand-gate:** roadmap P1.1 (`on_usage_event`) and P1.2
+  (OTel) gain salience because the vendor SDKs *already ship* usage/cost tracking and
+  OpenTelemetry — so these are **table-stakes parity items Agentao currently lacks**, not
+  vendor weak spots. Raise priority *only when a lighthouse asks* (§4 D4).
+- **Cut / hold (unchanged from §2.3):** CLI/TUI polish, hosted SaaS, strong cross-platform
+  sandbox, speculative P1 without a named adopter.
+
+---
+
+## 1. Why this record exists
+
+`path-a-roadmap.md` §16.4 commits to three retirement/re-examination triggers, the third
+being: *"an external shift invalidates the embed-first thesis (e.g., a Python-native agent
+runtime ships with stdlib-level distribution)."* The roadmap also commits (§16.2) to
+re-reading §1–§8 at each checkpoint and asking *"is the success picture still the right
+success picture? External shifts … may have changed what 'embedded' means."*
+
+The June-2026 sweep surfaced one shift large enough to test that trigger. This record
+isolates it, scores its impact, and proposes a disposition — under the same evidence-first
+discipline as the borrow reviews (`pi-mono-borrow-review.md`: *"the first-pass list was
+biased toward 'architecturally interesting' rather than 'actually missing'"*). The
+symmetric risk here is over-reacting to a competitor's launch; §3 and §4 are written to
+guard against that.
+
+## 2. The competitive landscape (June 2026)
+
+Agentao sits at the cross-section of four categories, contested individually on each axis:
+
+| Category | 2026 leaders | Agentao position |
+|---|---|---|
+| **A. CLI coding-agent products** | opencode (~150k★, ~6.5M MAU), Claude Code, Codex CLI, Gemini CLI, Aider, Goose (now under Linux Foundation), Crush, Continue `cn` | Capable CLI, but **Path A §2.3 already concedes this** ("opencode already wins TUI"). Not the battlefield. |
+| **B. Embeddable agent-loop SDKs** — *Path A's real arena* | **Claude Agent SDK**, **OpenAI Agents SDK**, Vercel AI SDK ("program agent harnesses"), Pi | **Newly crowded by first-party vendor SDKs.** This is the §3 shift. |
+| **C. General agent frameworks** | pydantic-ai (typed contracts), smolagents (code-first), Agno (~39k★), Strands, LangGraph, Instructor | *Build-your-own-agent toolkits.* Agentao differs: **batteries-included** (tools + skills + permissions + memory + replay already wired), not an orchestration kit. Genuine, stable distinction. |
+| **D. Coding-agent platforms** | OpenHands, SWE-agent | Hosted products/research. Out of Path A scope. |
+
+The takeaway is not "Agentao is behind in four races." It is that Agentao's identity is a
+*combination* (a governed, provider-neutral, batteries-included coding runtime that is also
+a clean embeddable library), and the combination remains unique even though **each
+individual axis is contested** — most newly so in category B.
+
+## 3. The shift: first-party SDKs occupy Path A's pitch
+
+Both facts below postdate the 2026-04-30 roadmap lock:
+
+- **Claude Agent SDK** lets a host "take the exact agent loop that powers Claude Code —
+  the same tool execution, context management, permission system, and subagent machinery —
+  and drive it from your own Python or TypeScript program," with a four-layer permission
+  pipeline (deny → mode → allow → `canUseTool`) and an optional isolated sandbox.
+- **OpenAI Agents SDK** added sandbox execution and a model-native harness: an isolated
+  Unix-like workspace with filesystem + shell, file-level permissions, and durable
+  snapshot/rehydrate state. It reaches non-OpenAI models through Any-LLM / LiteLLM
+  adapters that the official docs flag as **best-effort / beta**, with capability gaps
+  (tool calling, structured output, usage reporting) versus the native OpenAI path.
+
+Map that against Agentao's README first line — *"local-first, private-first, embeddable
+agent harness for Python hosts"* — and the **"embeddable / permissioned / subagents /
+sandbox" portion is now matched by both vendors**, who bring distribution and native model
+integration Agentao cannot. The clean embed contract that P0 delivered is necessary but no
+longer sufficient differentiation. The strategic question shifts from *"is the embed
+contract clean?"* (yes) to *"why would a host embed Agentao instead of the vendor's own
+SDK?"*
+
+## 4. Moat re-score, axis by axis
+
+### Still defensible — structurally hard for a vendor SDK to match
+
+1. **Provider-neutral *and vendor-data-path-free* by construction.** OpenAI-compatible
+   *any* provider + runtime `/provider` switching (`agentao/runtime/`, `LLM_PROVIDER`).
+   Note the distinction precisely: the vendor SDKs now ship *broad third-party provider
+   adapters* (Claude Agent SDK can target other models; OpenAI's SDK reaches 100+ via
+   Any-LLM/LiteLLM, best-effort/beta) — so "you can point it at another model" is **no
+   longer exclusive to Agentao**. What stays exclusive is the *posture*: agentao is not a
+   vendor's loop wearing an adapter, carries no vendor harness culture, and routes through
+   no vendor data path. The moat is **no-vendor-loop / no-vendor-telemetry**, not merely
+   "multi-model."
+2. **Local-first / private-first / no managed infra / no global state.** Capability
+   injection, no host-logger pollution, multi-`Agentao()` isolation
+   (`tests/test_multi_agentao_isolation.py`, `tests/test_no_host_logger_pollution.py`).
+   Hosts that *cannot* route code through a vendor loop are the wedge.
+3. **Local, in-process audit contract.** Permission modes + replay JSONL audit sink
+   (v1.2, `agentao/host/replay_projection.py`) + `events()` host stream. **Do not
+   overclaim here:** both vendor SDKs ship first-class governance/observability — Claude
+   Agent SDK lists hooks, permissions, sessions, cost/usage tracking, OpenTelemetry, and
+   checkpointing; OpenAI's SDK has tracing, usage, and sandbox permissions/results/resume
+   state. Agentao's narrower, defensible edge is that its audit trail is a **local JSONL
+   replay artifact under a no-vendor-loop posture** — the record lives in the host's files,
+   not a vendor's tracing backend — which is the relevant property for hosts that cannot
+   emit telemetry to a vendor. It is a *locality/ownership* edge, not a "vendors lack
+   audit" edge.
+4. **ACP-server interop — riding early-but-real ecosystem signals.** The ~21.5% of the
+   codebase in `acp/` + `acp_client/` (11,659 / 54,205 LOC, verified 2026-06-18) aligns
+   with an emerging standard. **Verifiable today:** ACP was created by Zed and Zed ships an
+   ACP client; Google's Gemini CLI has a documented Zed/ACP integration. **Claimed but not
+   yet primary-sourced in this record (treat as early signals, verify before weighting):**
+   JetBrains full-IDE support, GitHub Copilot CLI ACP support, and the "25+ agents" count —
+   these came from secondary roundups, not vendor docs. Net: ACP is a *plausible, growing*
+   channel for "the provider-neutral, governed agent you bring to an ACP editor," not yet a
+   *confirmed* tailwind. D3's weight should track how many of the unverified claims hold up.
+5. **Chinese ecosystem.** jieba 中文 memory segmentation, bilingual docs, `agentao.cn`.
+   Structurally underserved by the US vendor SDKs; aligned with the roadmap's §14
+   lighthouse-outreach plan (Chinese-community FastAPI / pytest / Jupyter candidates).
+
+### Contested / eroding
+
+- **"Embeddable" alone** — now table stakes (§3).
+- **CLI UX** — conceded to opencode (§2.3, no change).
+- **Sandbox sophistication** — OpenAI/Claude now ship container snapshotting; Agentao's
+  macOS `sandbox-exec` is narrower. **No action implied** — §2.3 already declares strong
+  cross-platform sandbox a non-goal; the vendor move *confirms* that call rather than
+  reversing it.
+
+## 5. A measurable distribution drag
+
+**Method snapshot (for reproducibility):** query `"agentao" python agent framework github`
+run 2026-06-18 via the assistant's `WebSearch` tool (US locale, logged-out, top-10
+results); the top organic hit was an unrelated `github.com/taoagents/agentao` ("ridges-old"
+repo) and **`jin-bo/agentao` did not appear in the top results.** Search ranking drifts by
+locale, login state, and date — re-run incognito/logged-out and record the engine + date
+before citing this as current. As of this snapshot: given §2.1's success metric is *"being
+depended on / found,"* this name-collision + discoverability gap is a direct, measurable
+drag on the dependents target — and it corroborates §7.1 Mode 2 (*"the problem is
+distribution, not technology"*) independent of the §3 shift. Unlike the moat questions,
+this one is unambiguous and cheap to act on.
+
+## 6. Implied directions — keep / cut / gate
+
+Framed as options for maintainer judgment (gap ≠ need; pain judgment is the maintainer's;
+demand-gating holds). Ordered by leverage.
+
+| ID | Direction | Disposition | Rationale |
+|---|---|---|---|
+| **D1** | Re-headline differentiation: lead with "provider-neutral + local/private-first + **governed & auditable**", demote "embeddable" | **Do now** (messaging, ~zero code) | Directly answers the new "why not the vendor SDK?" question; the current README leads with the now-commodity word. |
+| **D2** | Fix discoverability: repo topics, PyPI keywords, a "vs Claude/OpenAI Agent SDK" comparison page; lean into the Chinese-ecosystem wedge | **Do now** (distribution) | §5 is unambiguous; §14 already names distribution as the dominant non-engineering risk. |
+| **D3** | Position ACP-server as a *channel*, not just a feature ("the governed, provider-neutral agent you plug into an ACP editor") | **Reframe (weight gated on §4.4 verification)** | Turns a large existing code investment into distribution; rides early-but-real ACP signals. Weight should scale with how many §4.4 unverified-adoption claims (JetBrains / Copilot CLI / "25+ agents") survive primary-source checking. Harness-appropriate (interop, like `acp_client`). |
+| **D4** | Roadmap P1.1 `on_usage_event` + P1.2 OTel | **Re-prioritize, still gate** | These are **table-stakes parity items** — both vendor SDKs already ship usage/cost tracking + OpenTelemetry, so this is Agentao closing a gap, not exploiting a vendor weak spot. Salience ↑, but **start only when a lighthouse asks** — §4 discipline unchanged. |
+| **D5** | Interop bridge: drive a Claude/OpenAI Agent SDK agent *from* Agentao, or expose Agentao *under* their tool interface | **Hold (demand-gated)** | Passes the harness-vs-product test (interop, like `acp_client`), but speculative without a named host. Record as a candidate, not a commitment. |
+| — | CLI/TUI polish · hosted SaaS · strong cross-platform sandbox · speculative P1 | **Cut / hold (unchanged)** | Consistent with §2.3 and prior boundary-rejections; the §3 shift reinforces these calls rather than reopening them. |
+
+## 7. §16.4 trigger determination
+
+**Determination (proposed): the §16.4 third trigger has FIRED — as a re-examination, not
+a retirement.**
+
+- It is **not** the failure-path §7.2 guardrail (that is three flat months of PyPI
+  dependents; this record makes no claim about the metric trend — the M+3 checkpoint on
+  2026-07-31 still owns that).
+- It is **not** the success-path successor (that is the 2027-04-30 strategic review).
+- It is the **external-shift** clause: the embed-first *thesis* is narrowed because
+  "embeddable" became commodity, but a defensible moat survives (§4), so the correct output
+  is a *re-headline + distribution* response under Path A, not a Path B/C pivot.
+
+Per §16.3, a checkpoint's output is "what the snapshots say / what we are changing / what
+the roadmap should say differently." This record is not a calendar checkpoint. To respect
+the §16.4 lock cleanly, the proposed roadmap edits are **split by which sections they
+touch**:
+
+- **Edit that needs no unlock (a living section):** append a **note to §16.4** recording
+  that the external-shift trigger fired on 2026-06-18, with this document as the linked
+  record. §16 is checkpoint/metric framing, not locked strategy — this is the only edit
+  this record will make if asked.
+- **Edit that *would require* an explicit unlock (a locked section):** adding a line to
+  **§2.1** noting that "embeddable" is necessary-not-sufficient as of 2026-Q2. §2.1 is
+  inside the locked §1–§8, so this record **does not** propose making that edit silently —
+  it flags it as a *candidate* that only a maintainer ratification-to-unlock should apply.
+  Until then, §1–§8 stay locked verbatim.
+
+This avoids the contradiction of "don't touch §1–§8" while editing §2.1: the default action
+is the §16.4 note alone; the §2.1 line is held behind an explicit unlock.
+
+## 8. What would change this determination
+
+Listed so the record can be falsified rather than defended:
+
+- **If** a lighthouse adopter reports they chose Agentao *specifically* for vendor-neutrality
+  or audit → the moat (§4) is confirmed stronger than scored; D1/D2 are validated, escalate
+  distribution.
+- **If** the next two monthly snapshots show PyPI dependents moving on the back of the
+  Chinese-ecosystem wedge → D2 is the dominant lever; deprioritize everything else.
+- **If** a vendor SDK ships first-class provider-neutrality *and* a local-only, no-telemetry
+  mode *and* a first-class audit contract → moat axes 1–3 erode simultaneously; that is the
+  signal to open the Path B/C document §16.4 reserves for true invalidation.
+- **If** the §4.4 unverified ACP-adoption claims (JetBrains full IDE / GitHub Copilot CLI /
+  "25+ agents") fail primary-source checking, or ACP adoption stalls or fragments →
+  downgrade D3 and revisit the ~21.5% allocation at the next heavy checkpoint
+  (M+6, 2026-10-31).
+
+---
+
+*This record follows the reverse-review discipline of `pi-mono-borrow-review.md` and
+`codex-reverse-review.md`: evidence before recommendation, gap ≠ need, and an explicit
+falsification clause so the determination can be checked against reality rather than
+re-argued. It records a trigger and proposes a response; the decision to ratify is the
+maintainer's.*

--- a/docs/design/vendor-sdk-convergence-review.zh.md
+++ b/docs/design/vendor-sdk-convergence-review.zh.md
@@ -1,0 +1,193 @@
+# 厂商 SDK 趋同 —— Path A 再审视触发评审
+
+**状态：** 战略评审记录。起草于 2026-06-18，基于一次 2026 年 6 月的竞品格局扫描（CLI
+agent、可嵌入 agent-loop SDK、通用 agent 框架）。**这是一次"触发判定"，不是战略反转。**
+本记录确认 `path-a-roadmap.md` §16.4 的"外部变化"条件很可能已经满足，列出证据，并
+*供维护者判断*——提出什么该变、什么不该变。它**不**单方面退役或重写 Path A；在维护者
+做出决定之前，路线图 §1–§8 保持锁定。
+**读者：** Agentao 维护者与战略评审者。
+**对照件：** `vendor-sdk-convergence-review.md`。
+**相关：**
+- `path-a-roadmap.md` —— 本评审据以检验的、已锁定的 embed-first 战略（尤其 §2.1 成功指标、§2.3 非目标、§7.1 模式二、§16.4 退役触发条件）。
+- `embedded-host-contract.md` —— 本评审确认*并非问题所在*的宿主契约设计。
+- `pi-mono-borrow-review.md` / `codex-reverse-review.md` —— 本记录遵循的反向评审纪律（先证据后建议；gap ≠ need）。
+
+**方法：** 竞品扫描 → 找出唯一一个晚于路线图锁定的市场变化 → 逐轴重估 Agentao 护城河
+→ 对衍生方向做 keep/cut/gate → 判定 §16.4 是否触发。代码引用锚定于 `main`@`bcdb8e4`
+（2026-06-18）；关于外部 SDK 的定位陈述带有日期、会漂移——在据其行动前请重新核实。
+
+---
+
+## TL;DR
+
+Path A 路线图**锁定于 2026-04-30**。此后，两大模型厂商各自交付了可嵌入、受治理、带沙箱、
+从宿主自身 Python/TypeScript 进程驱动的 agent loop——**正是 Path A 的字面卖点**：
+
+- **Claude Agent SDK** —— "驱动 Claude Code 的同一个 agent loop……从你自己的 Python/
+  TypeScript 程序里驱动"，四层权限管线 + 可选沙箱。
+- **OpenAI Agents SDK** —— 沙箱执行 + model-native harness（隔离工作区、文件级权限、
+  快照/恢复）。非 OpenAI 模型经 Any-LLM / LiteLLM adapter 接入，官方文档标注为
+  **best-effort / beta**，在工具调用、结构化输出、usage 上报上存在能力差异——即覆盖面广的
+  adapter，*而非* Agentao 式的一等 provider 中立。
+
+**结论：** "可嵌入的受治理 Python agent loop"已不再是差异化——它已成为 Anthropic 与
+OpenAI 凭借更大分发与原生模型集成提供的"标配"。这恰是 `path-a-roadmap.md` §16.4 命名
+的再审视/退役触发条件。**嵌入契约不是问题（P0 已证明它干净）；问题是"宿主为何要嵌入
+Agentao 而非厂商自家 SDK"这个问题的答案。**
+
+**处置（提议，待维护者批准）：**
+- **§16.4 触发：已触发（再审视，非退役）。** embed-first 论点被收窄、而非失效——仍有可守
+  护城河（§3）。应召集"幸存护城河"决策，而非直接开 Path B/C 文档。
+- **立即做（文案，近零代码）：** 把差异化标题从"可嵌入"（已商品化）改为"provider 中立 +
+  本地/隐私优先 + 可治理可审计"（§4 D1）。
+- **立即做（分发）：** 修复可发现性/重名拖累（§4 D2、§5）。
+- **重构定位（渠道）：** 把已占代码库 ~21.5% 的 ACP 投入当作乘着**早期但真实**生态信号的
+  *分发渠道*，而非仅是功能（§4 D3）。
+- **重排优先级但仍门控：** 路线图 P1.1（`on_usage_event`）与 P1.2（OTel）重要性上升，原因是
+  厂商 SDK *已经*出货 usage/cost 追踪与 OpenTelemetry——所以这是**Agentao 当前缺失的标配补齐项**，
+  而非厂商的薄弱点。仅在有灯塔提出时才提优先级（§4 D4）。
+- **砍/搁置（与 §2.3 一致）：** CLI/TUI 打磨、托管 SaaS、强跨平台沙箱、无具名采用者的投机性 P1。
+
+---
+
+## 1. 本记录为何存在
+
+`path-a-roadmap.md` §16.4 承诺了三条退役/再审视触发条件，第三条是：*"外部变化使
+embed-first 论点失效（例如某个 Python 原生 agent 运行时以标准库级别的分发出货）。"* 路线图
+同时承诺（§16.2）在每个检查点重读 §1–§8 并自问*"成功图景是否仍是对的成功图景？外部变化……
+可能已改变'嵌入'的含义。"*
+
+2026 年 6 月的扫描浮现出一个足够大、足以检验该触发条件的变化。本记录将其隔离、评估其影响、
+提出处置——遵循与借鉴评审相同的"先证据"纪律（`pi-mono-borrow-review.md`：*"第一轮清单偏向
+'架构上有趣'而非'确实缺失'"*）。此处对称的风险是对竞品发布反应过度；§3 与 §4 的写法即为防此。
+
+## 2. 竞品格局（2026 年 6 月）
+
+Agentao 处在四个品类的交叉点，每条轴上都被单独挑战：
+
+| 品类 | 2026 领头羊 | Agentao 位置 |
+|---|---|---|
+| **A. CLI 编码 agent 产品** | opencode（~150k★、~650 万月活）、Claude Code、Codex CLI、Gemini CLI、Aider、Goose（已入 Linux 基金会）、Crush、Continue `cn` | CLI 能打，但 **Path A §2.3 已让出此战场**（"opencode 已赢 TUI"）。 |
+| **B. 可嵌入 agent-loop SDK** —— *Path A 的真正战场* | **Claude Agent SDK**、**OpenAI Agents SDK**、Vercel AI SDK、Pi | **被一方厂商 SDK 新挤入。** 即 §3 的变化。 |
+| **C. 通用 agent 框架** | pydantic-ai（类型契约）、smolagents（代码优先）、Agno（~39k★）、Strands、LangGraph、Instructor | *自己搭 agent 的工具箱。* Agentao 不同：**开箱即用**（工具+技能+权限+记忆+replay 已接好），非编排套件。真实且稳定的区分。 |
+| **D. 编码 agent 平台** | OpenHands、SWE-agent | 托管产品/研究，不在 Path A 范围。 |
+
+要点不是"Agentao 在四场赛跑里落后"，而是 Agentao 的身份是一个*组合*（受治理、provider
+中立、开箱即用的编码运行时，同时又是干净的可嵌入库），这一组合仍然独特——尽管**每条单轴都
+被挑战**，B 类最为新近。
+
+## 3. 变化：一方厂商 SDK 占据了 Path A 的卖点
+
+以下两个事实均晚于 2026-04-30 路线图锁定：
+
+- **Claude Agent SDK** 让宿主"取用驱动 Claude Code 的同一个 agent loop——同样的工具执行、
+  上下文管理、权限系统、子代理机制——从你自己的 Python/TypeScript 程序里驱动"，带四层权限
+  管线（deny → mode → allow → `canUseTool`）和可选隔离沙箱。
+- **OpenAI Agents SDK** 新增沙箱执行与 model-native harness：带文件系统 + shell 的隔离类
+  Unix 工作区、文件级权限、可持久的快照/恢复状态。它经 Any-LLM / LiteLLM adapter 接入非
+  OpenAI 模型，官方文档将其标注为 **best-effort / beta**，相对原生 OpenAI 路径在工具调用、
+  结构化输出、usage 上报上存在能力差异。
+
+对照 Agentao README 首句——*"本地优先、隐私优先、可嵌入 Python 宿主的 agent harness"*——
+其中**"可嵌入/带权限/子代理/沙箱"部分现已被两家厂商对齐**，而它们带来 Agentao 无法企及的
+分发与原生模型集成。P0 交付的干净嵌入契约是必要的，但已不再是充分的差异化。战略问题从
+*"嵌入契约干不干净？"*（干净）转为*"宿主为何要嵌入 Agentao 而非厂商自家 SDK？"*
+
+## 4. 逐轴重估护城河
+
+### 仍可守 —— 厂商 SDK 结构上难以匹配
+
+1. **天生 provider 中立*且无厂商数据链路*。** OpenAI 兼容的*任意* provider + 运行时
+   `/provider` 切换（`agentao/runtime/`、`LLM_PROVIDER`）。需精确区分：厂商 SDK 现已出货
+   *广覆盖的第三方 provider adapter*（Claude SDK 可指向其他模型；OpenAI 的 SDK 经
+   Any-LLM/LiteLLM 覆盖 100+，best-effort/beta）——所以"能指向另一个模型"**已不再为 Agentao
+   独占**。仍独占的是*姿态*：agentao 不是套了 adapter 的厂商 loop、不带厂商 harness 文化、
+   不经任何厂商数据链路。护城河是 **no-vendor-loop / no-vendor-telemetry**，而非仅仅"多模型"。
+2. **本地优先/隐私优先/无托管基建/无全局状态。** 能力注入、不污染宿主 logger、多实例隔离
+   （`tests/test_multi_agentao_isolation.py`、`tests/test_no_host_logger_pollution.py`）。
+   *无法*把代码经厂商 loop 路由的宿主，就是楔子。
+3. **本地、进程内的审计契约。** 权限模式 + replay JSONL 审计 sink（v1.2，
+   `agentao/host/replay_projection.py`）+ `events()` 宿主事件流。**此处不可夸大：**两家厂商
+   SDK 均出货一等的治理/可观测——Claude Agent SDK 列出 hooks、permissions、sessions、cost/usage
+   追踪、OpenTelemetry、checkpointing；OpenAI 的 SDK 有 tracing、usage、沙箱 permissions/results/
+   resume state。Agentao 更窄、可守的优势是其审计轨迹是**在 no-vendor-loop 姿态下的本地 JSONL
+   replay 产物**——记录落在宿主自己的文件里，而非厂商的 tracing 后端——这对无法向厂商发送遥测的
+   宿主才是相关属性。这是*本地性/所有权*优势，不是"厂商没有审计"优势。
+4. **ACP-server 互操作 —— 乘着早期但真实的生态信号。** 代码库中 `acp/` + `acp_client/` 的
+   ~21.5%（11,659 / 54,205 LOC，2026-06-18 核实）与一个新兴标准对齐。**今日可核验：**ACP 由
+   Zed 创建、Zed 出货 ACP 客户端；Google Gemini CLI 有文档化的 Zed/ACP 集成。**已声称但本记录
+   尚无一手来源（按早期信号处理，权衡前先核实）：**JetBrains 全 IDE 支持、GitHub Copilot CLI 的
+   ACP 支持、以及"25+ agent"这一计数——这些来自二手汇总，而非厂商文档。净结论：ACP 是"可插进
+   ACP 编辑器的、provider 中立的受治理 agent"的一个*可信、增长中的*渠道，但还**不是已确认**的
+   顺风。D3 的权重应随上述未核实声称的成立比例而定。
+5. **中文生态。** jieba 中文记忆分词、双语文档、`agentao.cn`。被美国厂商 SDK 结构性服务不足；
+   契合路线图 §14 灯塔外联计划（中文社区 FastAPI / pytest / Jupyter 候选）。
+
+### 被挑战/被侵蚀
+
+- **单凭"可嵌入"** —— 已成标配（§3）。
+- **CLI 体验** —— 已让给 opencode（§2.3，无变化）。
+- **沙箱成熟度** —— OpenAI/Claude 已上容器快照；Agentao 的 macOS `sandbox-exec` 更窄。
+  **不衍生任何动作**——§2.3 已把强跨平台沙箱列为非目标；厂商此举*印证*而非推翻该判断。
+
+## 5. 一个可量化的分发拖累
+
+**方法快照（供复验）：** 查询 `"agentao" python agent framework github`，于 2026-06-18 经
+助手的 `WebSearch` 工具运行（US locale、登出态、前 10 条结果）；首个自然结果是无关的
+`github.com/taoagents/agentao`（"ridges-old" 仓库），且**`jin-bo/agentao` 未出现在前列。**
+搜索排名随地区、登录状态、时间漂移——引用为现状前请以无痕/登出态重跑并记录引擎 + 日期。截至
+本快照：鉴于 §2.1 的成功指标是*"被依赖/被找到"*，这种重名 + 可发现性缺口是对 dependents 目标
+的直接、可量化拖累——并独立于 §3 的变化印证了 §7.1 模式二（*"问题在分发，不在技术"*）。与
+护城河问题不同，这一条无歧义且行动成本低。
+
+## 6. 衍生方向 —— keep / cut / gate
+
+作为供维护者判断的选项（gap ≠ need；痛点由维护者判定；按需门控仍成立）。按杠杆排序。
+
+| ID | 方向 | 处置 | 理由 |
+|---|---|---|---|
+| **D1** | 重写差异化标题：以"provider 中立 + 本地/隐私优先 + **可治理可审计**"打头，"可嵌入"降级 | **立即做**（文案，近零代码） | 直接回答新的"为何不用厂商 SDK"；现 README 以已商品化的词打头。 |
+| **D2** | 修复可发现性：仓库 topics、PyPI 关键词、一页"vs Claude/OpenAI Agent SDK"对比；主攻中文生态楔子 | **立即做**（分发） | §5 无歧义；§14 已把分发列为最主要的非工程风险。 |
+| **D3** | 把 ACP-server 当*渠道*而非仅功能（"插进 ACP 编辑器的、受治理、provider 中立的 agent"） | **重构定位（权重门控于 §4.4 核实）** | 把已有大块代码投入变成分发；乘早期但真实的 ACP 信号。权重应随 §4.4 未核实采用声称（JetBrains / Copilot CLI / "25+ agent"）经一手来源核实的成立比例而定。属 harness 范畴（互操作，类比 `acp_client`）。 |
+| **D4** | 路线图 P1.1 `on_usage_event` + P1.2 OTel | **重排优先级，仍门控** | 这是**标配补齐项**——两家厂商 SDK 已出货 usage/cost 追踪 + OpenTelemetry，故是 Agentao 补缺口，而非利用厂商弱点。重要性↑，但**仅在灯塔提出时才启动**——§4 纪律不变。 |
+| **D5** | 互操作桥：从 Agentao *驱动* Claude/OpenAI Agent SDK 的 agent，或把 Agentao *暴露*在其工具接口下 | **搁置（按需门控）** | 通过 harness-vs-product 检验（互操作，类比 `acp_client`），但无具名宿主前属投机。记为候选，非承诺。 |
+| — | CLI/TUI 打磨 · 托管 SaaS · 强跨平台沙箱 · 投机性 P1 | **砍/搁置（不变）** | 与 §2.3 及既往边界否决一致；§3 的变化强化而非重开这些判断。 |
+
+## 7. §16.4 触发判定
+
+**判定（提议）：§16.4 第三条触发条件已触发——作为再审视，而非退役。**
+
+- 它**不是**失败路径的 §7.2 守门线（那是 PyPI dependents 连续三月平淡；本记录不对指标趋势
+  下任何结论——2026-07-31 的 M+3 检查点仍管这件事）。
+- 它**不是**成功路径的后继文档（那是 2027-04-30 的战略评审）。
+- 它是**外部变化**条款：embed-first *论点*因"可嵌入"商品化而收窄，但仍有可守护城河（§4），
+  故正确产出是 Path A 内的*重写标题 + 分发*回应，而非 Path B/C 转向。
+
+按 §16.3，检查点产出为"快照说了什么 / 我们改什么 / 路线图该怎么改写"。本记录不是日历检查点。
+为干净地尊重 §16.4 锁定，提议的路线图改动**按所触及的章节拆分**：
+
+- **无需解锁的改动（活章节）：** 在 **§16.4 追加一条记录**，写明外部变化触发条件于 2026-06-18
+  触发、以本文档为关联记录。§16 属检查点/指标表述，非锁定战略——若被要求，这是本记录唯一会做的改动。
+- ***需要*显式解锁的改动（锁定章节）：** 在 **§2.1** 加一行，说明截至 2026-Q2"可嵌入"已是必要
+  非充分。§2.1 处于锁定的 §1–§8 之内，故本记录**不**提议悄悄做此改动——而是把它标为*候选*，仅当
+  维护者批准并解锁时才应用。在此之前，§1–§8 逐字保持锁定。
+
+这避免了"勿动 §1–§8"却又改 §2.1 的矛盾：默认动作只是 §16.4 那条记录；§2.1 那行被显式解锁挡在后面。
+
+## 8. 什么会改变这一判定
+
+列出以便本记录可被证伪、而非被辩护：
+
+- **若**某灯塔采用者反馈他们*正是因为*厂商中立或审计而选 Agentao → 护城河（§4）被证明强于评分；
+  D1/D2 获验证，加码分发。
+- **若**接下来两次月度快照显示 PyPI dependents 因中文生态楔子而上升 → D2 是主导杠杆，其余降级。
+- **若**某厂商 SDK 出货一等的 provider 中立 *且* 纯本地无遥测模式 *且* 一等审计契约 → 护城河
+  轴 1–3 同时被侵蚀；那才是开 §16.4 为真正失效保留的 Path B/C 文档的信号。
+- **若** §4.4 未核实的 ACP 采用声称（JetBrains 全 IDE / GitHub Copilot CLI / "25+ agent"）一手
+  核实不成立，或 ACP 采用停滞/碎片化 → 降级 D3，并在下个重型检查点（M+6，2026-10-31）重审 ~21.5% 的分配。
+
+---
+
+*本记录遵循 `pi-mono-borrow-review.md` 与 `codex-reverse-review.md` 的反向评审纪律：先证据后
+建议、gap ≠ need，并附明确的证伪条款，使判定能对照现实核验、而非被反复辩论。它记录一个触发、
+提出一个回应；是否批准，由维护者决定。*


### PR DESCRIPTION
## Summary

Commits two design **review records** that were drafted in earlier sessions and left untracked in the working tree:

- **`subagent-discovery-entrypoint-review.{md,zh.md}`** (2026-06-23) — entry-point asymmetry and the skill-vs-plugin conflation in sub-agent discovery (grep-verified read of the agent/skill/plugin discovery paths).
- **`vendor-sdk-convergence-review.{md,zh.md}`** (2026-06-18) — Path A re-examination trigger after the June-2026 vendor-SDK competitive scan.

Review records only; **no code change**. EN + ZH pairs, per the `docs/design/` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)