### PR TITLE
fix(llm): handle streamed tool calls without an index field

### DIFF
--- a/agentao/llm/_stream_response.py
+++ b/agentao/llm/_stream_response.py
@@ -34,6 +34,18 @@ class _StreamAccumulator:
         self.content_parts: List[str] = []
         self.reasoning_parts: List[str] = []
         self.tool_calls_data: Dict[int, Dict[str, str]] = {}
+        # Streaming tool-call keying state. The OpenAI streaming spec tags
+        # every tool_call delta with an ``index`` so fragments reassemble
+        # across chunks; some OpenAI-compatible providers (local / self-hosted
+        # inference servers, gateways) omit it. We assign each call a synthetic,
+        # monotonically-increasing key — never the provider's raw index nor a
+        # chunk-local position — so indexed and indexless calls can coexist
+        # without colliding and ``sorted()`` at build time preserves arrival
+        # order. ``tool_calls_data`` persists across chunks, so a per-chunk
+        # ``enumerate`` position cannot identify a call. See goose #10023.
+        self._tc_key_by_index: Dict[int, int] = {}
+        self._tc_last_key: Optional[int] = None
+        self._tc_next_key: int = 0
         self.finish_reason: str = "stop"
         self.response_model: str = model
         self.usage_data: Any = None
@@ -43,6 +55,34 @@ class _StreamAccumulator:
         # iterations without exposing anything to the host, so they must NOT
         # block the pre-output retry path.
         self.progress_made: bool = False
+
+    def tool_call_key(self, tc_delta: Any) -> int:
+        """Stream-stable accumulation key for one streaming tool_call delta.
+
+        Honours the provider's ``index`` when present: continuation deltas of
+        the same call carry the same index and merge onto one key. When index
+        is absent, a delta that carries an ``id`` starts a new call (fresh
+        key); an arguments-only delta continues the call most recently opened.
+        Keys are synthetic and assigned in arrival order, so indexed and
+        indexless calls never share a key and ``sorted()`` preserves call
+        order. ``index`` is read via ``getattr`` because a provider that truly
+        omits the field may yield a delta without the attribute at all.
+        """
+        index = getattr(tc_delta, "index", None)
+        if index is not None:
+            key = self._tc_key_by_index.get(index)
+            if key is None:
+                key = self._tc_next_key
+                self._tc_next_key += 1
+                self._tc_key_by_index[index] = key
+            self._tc_last_key = key
+            return key
+        # Indexless: an id announces a new call; an arguments-only continuation
+        # appends to the call we last opened (or starts one if none is open).
+        if getattr(tc_delta, "id", None) or self._tc_last_key is None:
+            self._tc_last_key = self._tc_next_key
+            self._tc_next_key += 1
+        return self._tc_last_key
 
     def build(self) -> "_StreamResponse":
         """Materialise the accumulated deltas into a duck-type response."""

--- a/agentao/llm/client.py
+++ b/agentao/llm/client.py
@@ -709,10 +709,13 @@ class LLMClient(_LoggingMixin):
             if delta and getattr(delta, "reasoning_content", None):
                 acc.reasoning_parts.append(delta.reasoning_content)
 
-            # Accumulate tool call deltas
+            # Accumulate tool call deltas. ``acc.tool_call_key`` resolves the
+            # stream-stable key for this delta, tolerating providers that omit
+            # the OpenAI ``index`` field (see _StreamAccumulator.tool_call_key
+            # and goose #10023).
             if delta and delta.tool_calls:
                 for tc_delta in delta.tool_calls:
-                    idx = tc_delta.index
+                    idx = acc.tool_call_key(tc_delta)
                     if idx not in acc.tool_calls_data:
                         acc.tool_calls_data[idx] = {"id": "", "name": "", "arguments": ""}
                     if tc_delta.id:

--- a/tests/test_chat_stream_reasoning.py
+++ b/tests/test_chat_stream_reasoning.py
@@ -11,11 +11,11 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
-def _chunk(content=None, reasoning=None, finish=None):
+def _chunk(content=None, reasoning=None, finish=None, tool_calls=None):
     """Build a single SSE chunk with the fields chat_stream actually reads."""
     delta = SimpleNamespace(
         content=content,
-        tool_calls=None,
+        tool_calls=tool_calls,
         reasoning_content=reasoning,
     )
     choice = SimpleNamespace(delta=delta, finish_reason=finish)
@@ -23,6 +23,19 @@ def _chunk(content=None, reasoning=None, finish=None):
         choices=[choice],
         usage=None,
         model="test-thinking-model",
+    )
+
+
+def _tc_delta(*, index=None, id=None, name=None, arguments=None):
+    """One streaming tool_call delta, shaped as the OpenAI SDK yields it.
+
+    The first delta of a call carries ``id``/``name``; continuation deltas
+    carry only ``arguments``. ``index`` is None for providers that omit it.
+    """
+    return SimpleNamespace(
+        index=index,
+        id=id,
+        function=SimpleNamespace(name=name, arguments=arguments),
     )
 
 
@@ -102,43 +115,13 @@ def test_chat_stream_reasoning_with_tool_calls():
     """reasoning_content must coexist with tool_calls in the same response."""
     client = _make_client()
 
-    tc_delta_open = SimpleNamespace(
-        index=0,
-        id="call_1",
-        function=SimpleNamespace(name="get_weather", arguments=""),
-    )
-    tc_delta_args = SimpleNamespace(
-        index=0,
-        id=None,
-        function=SimpleNamespace(name=None, arguments='{"city":"SF"}'),
-    )
+    tc_delta_open = _tc_delta(index=0, id="call_1", name="get_weather", arguments="")
+    tc_delta_args = _tc_delta(index=0, arguments='{"city":"SF"}')
 
     chunks = [
         _chunk(reasoning="I should check the weather."),
-        SimpleNamespace(
-            choices=[SimpleNamespace(
-                delta=SimpleNamespace(
-                    content=None,
-                    tool_calls=[tc_delta_open],
-                    reasoning_content=None,
-                ),
-                finish_reason=None,
-            )],
-            usage=None,
-            model="test-thinking-model",
-        ),
-        SimpleNamespace(
-            choices=[SimpleNamespace(
-                delta=SimpleNamespace(
-                    content=None,
-                    tool_calls=[tc_delta_args],
-                    reasoning_content=None,
-                ),
-                finish_reason="tool_calls",
-            )],
-            usage=None,
-            model="test-thinking-model",
-        ),
+        _chunk(tool_calls=[tc_delta_open]),
+        _chunk(tool_calls=[tc_delta_args], finish="tool_calls"),
         _usage_only_chunk(),
     ]
     client.client.chat.completions.create = MagicMock(return_value=iter(chunks))
@@ -157,6 +140,103 @@ def test_chat_stream_reasoning_with_tool_calls():
     assert msg.tool_calls[0].function.arguments == '{"city":"SF"}'
 
 
+def _run_tool_stream(client, chunks, tools=None):
+    """Drive chat_stream over ``chunks`` and return the rebuilt message."""
+    client.client.chat.completions.create = MagicMock(
+        return_value=iter([*chunks, _usage_only_chunk()])
+    )
+    response = client.chat_stream(
+        messages=[{"role": "user", "content": "go"}],
+        tools=tools or [{"type": "function", "function": {"name": "noop"}}],
+        max_tokens=64,
+    )
+    return response.choices[0].message
+
+
+def test_chat_stream_single_tool_call_without_index():
+    """A whole tool call delivered in one indexless delta (the goose #10023
+    shape: local/self-hosted servers and gateways that omit ``index``) must be
+    rebuilt intact."""
+    msg = _run_tool_stream(_make_client(), [
+        _chunk(tool_calls=[_tc_delta(
+            id="functions.get_weather:0",
+            name="get_weather",
+            arguments='{"city":"Paris"}',
+        )], finish="tool_calls"),
+    ])
+
+    assert msg.tool_calls is not None
+    assert len(msg.tool_calls) == 1
+    assert msg.tool_calls[0].function.name == "get_weather"
+    assert msg.tool_calls[0].function.arguments == '{"city":"Paris"}'
+
+
+def test_chat_stream_parallel_tool_calls_one_chunk_without_index():
+    """Two distinct indexless calls in one chunk must stay separate. Distinct
+    names make the assertion discriminating: a collision concatenates them into
+    "get_weatherget_time" instead of yielding two calls."""
+    msg = _run_tool_stream(_make_client(), [
+        _chunk(tool_calls=[
+            _tc_delta(id="c0", name="get_weather", arguments='{"city":"Paris"}'),
+            _tc_delta(id="c1", name="get_time", arguments='{"tz":"JST"}'),
+        ], finish="tool_calls"),
+    ])
+
+    assert [tc.function.name for tc in msg.tool_calls] == ["get_weather", "get_time"]
+    assert [tc.function.arguments for tc in msg.tool_calls] == [
+        '{"city":"Paris"}', '{"tz":"JST"}',
+    ]
+
+
+def test_chat_stream_parallel_tool_calls_across_chunks_without_index():
+    """Indexless parallel calls arriving one-per-chunk must stay distinct.
+    A chunk-local position would reset to 0 each chunk and collapse both onto
+    one key; the id-keyed accumulator gives each its own. Guards goose #10023's
+    cross-chunk case."""
+    msg = _run_tool_stream(_make_client(), [
+        _chunk(tool_calls=[_tc_delta(id="c0", name="get_weather", arguments='{"city":"Paris"}')]),
+        _chunk(tool_calls=[_tc_delta(id="c1", name="get_time", arguments='{"tz":"JST"}')],
+               finish="tool_calls"),
+    ])
+
+    assert [tc.function.name for tc in msg.tool_calls] == ["get_weather", "get_time"]
+    assert [tc.function.arguments for tc in msg.tool_calls] == [
+        '{"city":"Paris"}', '{"tz":"JST"}',
+    ]
+
+
+def test_chat_stream_fragmented_arguments_without_index():
+    """An indexless call whose arguments are fragmented across chunks (first
+    delta carries id+name, continuations carry arguments only) must reassemble
+    onto the same call, not spawn phantom entries."""
+    msg = _run_tool_stream(_make_client(), [
+        _chunk(tool_calls=[_tc_delta(id="c0", name="get_weather", arguments='{"city":')]),
+        _chunk(tool_calls=[_tc_delta(arguments='"Paris"')]),
+        _chunk(tool_calls=[_tc_delta(arguments='}')], finish="tool_calls"),
+    ])
+
+    assert len(msg.tool_calls) == 1
+    assert msg.tool_calls[0].function.name == "get_weather"
+    assert msg.tool_calls[0].function.arguments == '{"city":"Paris"}'
+
+
+def test_chat_stream_mixed_indexed_and_indexless_tool_calls():
+    """A stream mixing an indexed call with an indexless one across chunks must
+    keep them distinct. The pre-fix code crashed here (``sorted({0, None})``
+    TypeError); a chunk-local position would silently collide the indexless
+    call onto key 0. The synthetic-key accumulator keeps both."""
+    msg = _run_tool_stream(_make_client(), [
+        _chunk(tool_calls=[_tc_delta(index=0, id="a", name="get_weather", arguments='{"city":"Paris"}')]),
+        _chunk(tool_calls=[_tc_delta(id="b", name="get_time", arguments='{"tz":"JST"}')],
+               finish="tool_calls"),
+    ])
+
+    assert [tc.function.name for tc in msg.tool_calls] == ["get_weather", "get_time"]
+    assert [tc.function.arguments for tc in msg.tool_calls] == [
+        '{"city":"Paris"}', '{"tz":"JST"}',
+    ]
+
+
 if __name__ == "__main__":
     test_chat_stream_accumulates_reasoning_content()
     print("✓ accumulates reasoning_content")
@@ -164,3 +244,13 @@ if __name__ == "__main__":
     print("✓ reasoning is None when absent")
     test_chat_stream_reasoning_with_tool_calls()
     print("✓ reasoning coexists with tool_calls")
+    test_chat_stream_single_tool_call_without_index()
+    print("✓ single tool call without index")
+    test_chat_stream_parallel_tool_calls_one_chunk_without_index()
+    print("✓ parallel indexless calls in one chunk stay distinct")
+    test_chat_stream_parallel_tool_calls_across_chunks_without_index()
+    print("✓ parallel indexless calls across chunks stay distinct")
+    test_chat_stream_fragmented_arguments_without_index()
+    print("✓ fragmented indexless arguments reassemble")
+    test_chat_stream_mixed_indexed_and_indexless_tool_calls()
+    print("✓ mixed indexed/indexless calls stay distinct")


### PR DESCRIPTION
## Problem

Some OpenAI-compatible providers (local/self-hosted inference servers, gateways) omit the `index` field on streaming `tool_call` deltas that the OpenAI streaming spec otherwise requires. The streaming accumulator keyed `tool_calls_data` directly on `tc_delta.index`, so an absent index put everything on a `None` key:

- a **single** indexless call survived by luck (`sorted([None])` is fine);
- **parallel** indexless calls concatenated their names/arguments into garbage (`get_weatherget_time`, `{"city":"Paris"}{"tz":"JST"}`), losing all but one;
- a stream **mixing** indexed and indexless deltas crashed at finalization — `sorted({0, None})` raises `TypeError`.

This surfaced from a review of goose #10023, which fixes the same class of bug.

## Fix

Move keying into `_StreamAccumulator.tool_call_key`, which assigns **synthetic, stream-stable** keys:

- honor the provider's `index` when present (continuation deltas of one call merge onto a single key);
- when absent, treat an `id`-bearing delta as a **new call** (fresh key) and an arguments-only delta as a **continuation** of the call last opened;
- read `index` via `getattr` for providers that omit the attribute entirely.

`tool_calls_data` persists across the whole stream, so a chunk-local `enumerate` position — goose's approach, valid there because goose rebuilds the dict **per chunk** — cannot identify a call across chunks. The synthetic key can.

## Tests

Added discriminating cases for single, parallel-one-chunk (distinct names), parallel-**cross-chunk**, fragmented-continuation, and **mixed** indexed/indexless streams. Verified each fails against both baselines:

- **pre-fix** (`None` key): 3 fail, mixed case raises the `TypeError`;
- **half-fix** (chunk-local position): 3 fail with visible `{..}{..}` concatenation;
- **this fix**: 8/8 pass.

Full suite: 3250 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)