### PR TITLE
chore(release): prepare 0.4.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,78 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased]
+## [0.4.14] — 2026-07-02
 
-_Targeting 0.4.14. Add entries under the relevant heading as work lands._
+A **feature release** on top of 0.4.13. The headline is MCP transport work —
+Streamable HTTP support and finer per-call MCP timeouts — plus a `/thinking`
+command, a Jina `web_search` backend, and three provider/sub-agent robustness
+fixes.
+
+**Breaking (config behavior):** a bare `url` in `.agentao/mcp.json` now defaults
+to the **Streamable HTTP** transport instead of SSE. Legacy SSE endpoints must
+add `"type": "sse"`. That is the only break; everything else upgrades in place.
 
 ### Added
 
+- **MCP Streamable HTTP transport.** The MCP client now connects over Streamable
+  HTTP — the current MCP-spec transport that replaces the deprecated HTTP+SSE
+  transport — via the canonical `streamable_http_client`. Transport is selected
+  by an optional `type` field (`"stdio"` / `"http"` / `"sse"`, with
+  `"streamable-http"` / `"streamable_http"` aliases). An unknown `type`, or a
+  transport missing its required key, **fails closed** (`McpTransportConfigError`)
+  rather than silently connecting to the wrong protocol. The ACP handshake now
+  advertises `mcpCapabilities.http: true` and `session/new` accepts `http` MCP
+  entries. CLI: `/mcp add [--http|--sse] <name> <url>`. (#120)
+- **Split MCP timeouts.** `timeout` in `mcp.json` now accepts either an int
+  (legacy — the connect/startup budget) or `{ "startup": int, "request": int }`.
+  `request` bounds each tool call after init (previously unbounded); `startup`
+  bounds the whole connect **and** the `initialize()` / `list_tools()` handshake
+  for both transports. Backward compatible. (#119)
+- **MCP `structuredContent` fallback.** A tool that returns `content: []` plus
+  `structuredContent` no longer hands the model an empty string — the structured
+  payload is serialized to JSON when there are no content blocks (content blocks
+  still win when present). (#119)
+- **`/thinking [minimal|low|medium|high|off]`** sets the model's reasoning
+  effort (the `reasoning_effort` request field) on the live client's
+  `extra_body`; sub-agents launched afterward inherit it, and `off` restores the
+  provider default. The active level shows in the status bar. (#113)
+- **Jina `web_search` backend + auto fallback chain.** `web_search` adds a
+  `jina` backend (keyless; a `JINA_API_KEY` only lifts rate limits) and, in auto
+  mode, retreats on *error* through jina → bocha → duckduckgo. An explicit
+  `backend=` still pins exactly one backend with no fallback. Each fallback is
+  surfaced in the result and logged. (#114)
+- **`AGENTAO_WEB_FETCH_ALLOW_CIDRS`** — an opt-in `web_fetch` SSRF allowlist of
+  non-globally-routable CIDRs (the escape hatch for hosts behind a fake-IP proxy
+  such as Clash/V2Ray). Applied to the initial URL and every redirect hop,
+  scoped (allowlisting `198.18.0.0/15` does not also permit `169.254.169.254`),
+  and logged at startup. Default empty = fully strict. (#114)
+
 ### Changed
 
+- **BREAKING — MCP bare-`url` default flipped to Streamable HTTP.** A server
+  entry with a `url` and no `type` connected over SSE before 0.4.14; it now
+  connects over Streamable HTTP. Add `"type": "sse"` to keep a legacy SSE
+  endpoint. An inferred-HTTP handshake failure prints an actionable "try
+  `type: sse`" hint (suppressed for explicit `http`, for auth failures, and for
+  non-MCP endpoints). (#120)
+
 ### Fixed
+
+- **Sub-agent tool lifecycle events now carry the real `call_id`** (plus
+  status / duration / error) end-to-end, so a same-named parallel tool batch
+  (e.g. four concurrent `read_file`) can be traced start→finish, and a failed or
+  denied sub-agent tool is no longer reported as a hardcoded success. (#112)
+- **Streamed tool calls without an `index` field** (emitted by some
+  OpenAI-compatible / self-hosted providers) are keyed by synthetic
+  stream-stable ids instead of collapsing onto a single `None` key — fixing
+  garbled arguments across parallel calls and a finalization crash on streams
+  that mix indexed and index-less deltas. (#117)
+- **Empty / whitespace tool-call names no longer trigger a catalog-dump priming
+  loop.** Weak local models primed by tool-call syntax sitting in file or tool
+  content emitted blank-named calls that were answered with the full tool
+  catalog, inflating context on every retry; they now get a terse anti-priming
+  reply (no catalog) with a hard stop, while a genuine non-empty typo still gets
+  the catalog to self-correct. (#118)
 
 ---
 

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.14.dev0"
+__version__ = "0.4.14"
 
 
 def _ensure_utf8() -> None:

--- a/docs/releases/v0.4.14.md
+++ b/docs/releases/v0.4.14.md
@@ -1,0 +1,161 @@
+# Agentao 0.4.14
+
+A **feature release** on top of 0.4.13. The headline is MCP transport work —
+**Streamable HTTP** support and finer per-call MCP timeouts — plus a
+`/thinking` command, a Jina `web_search` backend, and three provider/sub-agent
+robustness fixes.
+
+It upgrades in place via `pip install -U agentao`, with **one** caveat: a bare
+`url` in `.agentao/mcp.json` now defaults to Streamable HTTP instead of SSE. If
+you connect to a legacy SSE MCP server, add `"type": "sse"` to its entry (see
+[Breaking change](#breaking-change) below).
+
+The headline:
+
+- **MCP Streamable HTTP transport.** Agentao's MCP client can now talk to
+  servers over Streamable HTTP — the current MCP-spec transport that replaces
+  the deprecated HTTP+SSE transport. Transport is selected explicitly by a
+  `type` field or inferred from the config, and a typo now fails closed instead
+  of silently connecting to the wrong protocol.
+- **Split MCP timeouts.** `timeout` gains a `{ startup, request }` form so a
+  hung tool call can be bounded per-call, not just at connect time.
+- **`/thinking`** sets the model's reasoning effort mid-session; sub-agents
+  inherit it.
+- **Jina web-search backend** with an on-error fallback chain, and an opt-in
+  `web_fetch` SSRF allowlist for hosts behind fake-IP proxies.
+
+## Why this release
+
+The MCP spec deprecated the HTTP+SSE transport in favor of Streamable HTTP;
+Agentao's client previously spoke only stdio and SSE, so an increasing number
+of remote MCP servers were simply unreachable. 0.4.14 adds Streamable HTTP as a
+first-class transport and makes it the **default** for a bare `url` — matching
+where the ecosystem is heading — while keeping SSE available behind an explicit
+`"type": "sse"`. The transport resolver is fail-closed by design: an unknown
+`type` or a URL entry missing its key raises rather than guessing, because
+guessing wrong means connecting to the wrong protocol.
+
+## MCP transports (stdio / Streamable HTTP / SSE)
+
+`.agentao/mcp.json` selects the transport with an optional `type`:
+
+```json
+{
+  "mcpServers": {
+    "local":  { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "."] },
+    "remote": { "url": "https://api.example.com/mcp" },
+    "legacy": { "url": "https://api.example.com/sse", "type": "sse" }
+  }
+}
+```
+
+- `type` is `"stdio"` / `"http"` / `"sse"` (aliases `"streamable-http"` and
+  `"streamable_http"` fold to `"http"`).
+- Omitted → inferred: `command` → stdio, a bare `url` → **Streamable HTTP**.
+- An unknown `type`, or a transport missing its required key, raises
+  `McpTransportConfigError` (fail-closed).
+
+The ACP handshake now advertises `mcpCapabilities.http: true`, and an ACP
+`session/new` may inject `http` MCP servers alongside `stdio` and `sse`.
+
+CLI: `/mcp add [--http|--sse] <name> <command|url>` — a flag-less URL stays
+inferred (Streamable HTTP), and a failed inferred-HTTP connect prints a hint to
+try `--sse` / `"type": "sse"`.
+
+## Finer MCP timeouts
+
+`timeout` now accepts either form:
+
+```json
+"slow-server": { "url": "https://.../mcp", "timeout": { "startup": 15, "request": 90 } }
+```
+
+- **int** (legacy) — the connect/startup budget; unchanged behavior.
+- **`{ startup, request }`** — `startup` bounds the connect **and** the
+  `initialize()` / `list_tools()` handshake (both transports); `request` bounds
+  each tool call after init (omit → unbounded, the MCP SDK default).
+
+Separately, a tool that returns `content: []` plus `structuredContent` now
+serializes that structured payload to JSON instead of handing the model an
+empty string.
+
+## `/thinking` — reasoning effort
+
+```
+/thinking            # show current level
+/thinking high       # set reasoning_effort=high
+/thinking off        # restore the provider default
+```
+
+Sets the `reasoning_effort` request field on the live client's `extra_body`
+passthrough. Sub-agents launched afterward inherit the level, and it shows in
+the status bar (`provider/model (high)`). Validation is permissive so
+provider-specific scales pass through.
+
+## Web tools
+
+- **`web_search` `jina` backend + auto fallback.** In auto mode (no
+  `backend=`), `web_search` retreats on *error* through jina → bocha →
+  duckduckgo. Jina works keyless; a `JINA_API_KEY` only lifts rate limits. An
+  explicit `backend=` pins exactly one backend with no fallback.
+- **`AGENTAO_WEB_FETCH_ALLOW_CIDRS`.** An opt-in SSRF allowlist of
+  non-globally-routable CIDRs for hosts behind a fake-IP proxy (Clash/V2Ray map
+  domains onto reserved ranges the guard otherwise blocks). Applied to the
+  initial URL and every redirect hop, scoped, and logged at startup. Default
+  empty = fully strict.
+
+## Fixes
+
+- **Sub-agent tool events carry the real `call_id`** (plus status / duration /
+  error), so same-named parallel tool batches trace start→finish and a
+  failed/denied sub-agent tool is no longer reported as a success. (#112)
+- **Streamed tool calls without an `index` field** (some OpenAI-compatible /
+  self-hosted providers) are keyed by synthetic stream-stable ids — fixing
+  garbled arguments across parallel calls and a crash on streams that mix
+  indexed and index-less deltas. (#117)
+- **Empty / whitespace tool-call names** no longer trigger a full-catalog
+  priming loop on weak local models; they get a terse anti-priming reply with a
+  hard stop, while a genuine non-empty typo still gets the catalog. (#118)
+
+## Breaking change
+
+**A bare `url` MCP server now defaults to Streamable HTTP, not SSE.**
+
+Before 0.4.14, `{ "url": "https://…" }` connected over SSE. It now connects over
+Streamable HTTP. If your server is a legacy SSE endpoint, add `"type": "sse"`:
+
+```json
+"legacy": { "url": "https://api.example.com/sse", "type": "sse" }
+```
+
+An inferred-HTTP handshake failure prints an actionable hint pointing you to the
+SSE type (suppressed for an explicit `http`, for auth failures, and for non-MCP
+endpoints). This is the only break in 0.4.14.
+
+## Tests & review
+
+Full suite green (3347 passed, 2 skipped) plus the mypy `--strict` typing gate
+and the replay + host + ACP schema-drift checks across Python 3.10 / 3.11 /
+3.12. The MCP transport change set passed a workflow-backed xhigh multi-agent
+review (7 fixes applied) and a Codex review pass (clean), and added
+`tests/test_mcp_streamable_http.py`.
+
+## Upgrade
+
+```bash
+pip install -U agentao          # library
+pip install -U 'agentao[cli]'   # interactive CLI
+pip install -U 'agentao[full]'  # all optional extras
+```
+
+The only migration from 0.4.13: add `"type": "sse"` to any `.agentao/mcp.json`
+entry that points at a legacy SSE MCP server. stdio servers and Streamable HTTP
+servers need no change.
+
+## Out of scope (deferred)
+
+- The 0.5.0 deprecation removals — `agentao.harness` (→ `agentao.host`), the 8
+  legacy `Agentao.__init__` callbacks, and the no-op `ToolRunner` compatibility
+  kwargs — all still warn / no-op and are removed in **0.5.0**, not before.
+- MCP resources/prompts surfaces (tools-only by design), and remaining ACP
+  conformance gaps.


### PR DESCRIPTION
Release-prep for **0.4.14** (steps 1–4: CHANGELOG, release note, version bump). No source logic changes — docs + version only. After this merges, run `gh release create v0.4.14` to publish to PyPI, then open the 0.4.15 dev cycle as a separate chore.

## Changes

- **Version:** `__version__` `0.4.14.dev0` → `0.4.14` (`agentao/__init__.py`; hatch reads it).
- **CHANGELOG.md:** promote `[Unreleased]` → `[0.4.14] — 2026-07-02` with Added / Changed (BREAKING) / Fixed entries for everything landed since v0.4.13 (#112–#120).
- **docs/releases/v0.4.14.md:** narrative release note.

## Release contents (since v0.4.13)

**Added:** MCP Streamable HTTP transport (#120) · split MCP timeouts + `structuredContent` fallback (#119) · `/thinking` (#113) · Jina `web_search` backend + `AGENTAO_WEB_FETCH_ALLOW_CIDRS` (#114)

**Changed (BREAKING):** a bare `url` in `.agentao/mcp.json` now defaults to Streamable HTTP instead of SSE — legacy SSE needs `"type": "sse"` (#120)

**Fixed:** sub-agent `call_id` correlation (#112) · streamed tool calls without `index` (#117) · empty-name phantom tool-call loop (#118)

## Note on versioning

0.4.14 carries **one config-behavior break** (the MCP bare-`url` default). Kept as a patch on the 0.4.x line rather than 0.5.0, since 0.5.0 is reserved for the scheduled deprecation *removals* (`agentao.harness` alias, the 8 legacy `__init__` callbacks, `ToolRunner` compat kwargs) — none of which are in this batch. The break is called out prominently in both the CHANGELOG and the release note.

## Not included (do after merge)

- `gh release create v0.4.14` (triggers PyPI via `publish.yml`).
- Open the 0.4.15 dev cycle (`0.4.15.dev0` + reopen `[Unreleased]`), mirroring #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)