### PR TITLE
chore: open 0.4.15 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+_Targeting 0.4.15. Add entries under the relevant heading as work lands._
+
+### Added
+
+### Changed
+
+### Fixed
+
+---
+
 ## [0.4.14] — 2026-07-02
 
 A **feature release** on top of 0.4.13. The headline is MCP transport work —

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.14"
+__version__ = "0.4.15.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Post-release housekeeping after v0.4.14 shipped to PyPI. Mirrors #111.

- bump `__version__` `0.4.14` → `0.4.15.dev0` (PEP 440 canonical `.dev0`)
- CHANGELOG: reopen `[Unreleased]` targeting 0.4.15

No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)