### PR TITLE
fix(tests): defuse retriever fixture time bomb — dynamic fresh timestamp

### DIFF
--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 import uuid
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -30,6 +31,12 @@ def _make_retriever(tmp_path: Path):
     return MemoryRetriever(mgr), mgr
 
 
+# Fixtures must stay inside score()'s 90-day stale window forever, so the
+# default timestamp is computed relative to now — a hardcoded date walked
+# past the window once and the -2.0 stale penalty flipped scores negative.
+_FRESH_ISO = (datetime.now() - timedelta(days=1)).isoformat(timespec="seconds")
+
+
 def _make_record(
     scope="project",
     title="test entry",
@@ -37,7 +44,7 @@ def _make_record(
     tags=None,
     keywords=None,
     source="explicit",
-    created_at="2026-04-08T10:00:00",
+    created_at=_FRESH_ISO,
     updated_at=None,
 ) -> MemoryRecord:
     eid = uuid.uuid4().hex[:8]
@@ -172,13 +179,14 @@ def test_score_stale_penalty(tmp_path):
     )
     fresh_record = _make_record(
         title="old entry", tags=[], keywords=[],
-        updated_at="2026-04-08T00:00:00",
+        updated_at=_FRESH_ISO,
     )
     query_tokens = {"old"}
     s_stale, reasons_stale, _ = ret.score(stale_record, query_tokens, set())
-    s_fresh, _, _ = ret.score(fresh_record, query_tokens, set())
+    s_fresh, reasons_fresh, _ = ret.score(fresh_record, query_tokens, set())
     assert s_stale < s_fresh
     assert "stale_penalty" in reasons_stale
+    assert "stale_penalty" not in reasons_fresh
 
 
 def test_score_filepath_match(tmp_path):


### PR DESCRIPTION
## Summary

Main's CI went red on 2026-07-08 without any code change: `tests/test_retriever.py` hardcodes `created_at="2026-04-08T10:00:00"` in `_make_record`, and that date just crossed `score()`'s 90-day stale window (`memory/retriever.py:412`). The −2.0 stale penalty now flips otherwise-positive scores negative:

- `test_score_exact_tag_match_boosts_score`: `1.5 + ~0.25 − 2.0 ≈ −0.25`
- `test_score_content_match`: `1.0 + ~0.25 − 2.0 ≈ −0.75`

(First observed on PR #123, a docs-only change — the failures reproduce identically on origin/main.)

## Fix

- Default fixture timestamp is now computed relative to `now` (yesterday), with a comment explaining why it must never be hardcoded.
- `test_score_stale_penalty`'s "fresh" record pointed at the same hardcoded date — it was silently stale too, weakening the contrast the test exists to check. Repointed at the dynamic timestamp and strengthened the test: the fresh record must NOT carry `stale_penalty`.

## Testing

- `tests/test_retriever.py`: 50 passed
- Full suite: **3347 passed**, 2 skipped, 9 deselected

## Watch item (not in this PR)

Other memory tests also hardcode 2026 dates (`test_memory_renderer.py`, `test_memory_store.py`, `test_memory_session.py`, `test_memory_store_swap.py`). Those don't score through the recency/stale path today, so they don't fail — but they're the same pattern if scoring assertions are ever added there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)