### PR TITLE
feat(runtime): classify incomplete turns and surface TurnOutcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,63 @@ _Targeting 0.4.15. Add entries under the relevant heading as work lands._
 
 ### Added
 
+- **`TURN_END.incomplete_reason`** — a single closed vocabulary classifying
+  *why* a turn's `final_text` is not a complete, model-authored answer, in
+  three families: the turn ended normally but the model produced no answer
+  (`no_output`, `reasoning_only`); the harness halted a turn that was not
+  converging (`length_truncated` — now covering a final answer cut off
+  mid-sentence, not only truncated tool calls; `doom_loop`); or the LLM call
+  itself failed (`llm_error`). `None` on a healthy turn, and suppressed when the
+  turn was cancelled or already errored — those carry their own status. Every
+  turn-ending path commits exactly one value, so there is no unclassified
+  ending. The replay adapter mirrors it onto the `TURN_COMPLETED` record.
+  Additive, so no `schema_version` bump (same precedent as `tool_count`).
+  `max_iterations` is a sixth way a turn ends without a complete answer but is a
+  deliberately separate axis — a sticky transport flag with its own exit code 4
+  and `on_max_iterations` interaction, not a value here.
+
+- **`error.reason` on the `agentao run` envelope** — the machine-readable
+  discriminator behind `error.type`, carrying the `incomplete_reason` value
+  verbatim so a caller can branch on `no_output` vs `reasoning_only` without
+  parsing `message`.
+
+- **`agent.last_turn` → `TurnOutcome`** — a structured read-after companion to
+  `chat()` / `arun()`'s string return. `chat()` still returns the turn's text
+  as a `str`; `agent.last_turn` (a frozen `TurnOutcome` with `text`, `status`,
+  `incomplete_reason`, `tool_count`, `error`, and an `is_answer` convenience)
+  is how a host tells a real answer from a placeholder / harness notice without
+  subscribing to the internal `Transport`. `TurnOutcome` is importable from the
+  top-level package (`from agentao import TurnOutcome`) without pulling the LLM
+  stack. Mirrors the `TURN_END` payload field-for-field — both are fed from a
+  single gated value in `runtime/turn.py`, so they never disagree.
+
 ### Changed
 
 ### Fixed
+
+- **A turn cancelled mid-stream now reports `status: "cancelled"`.** When a
+  cancellation token fired while the LLM was streaming, the model could return a
+  normally-built empty message without raising, so the turn reached its ordinary
+  ending site and emitted `TURN_END` with `status: "ok"` though it was
+  interrupted. `runtime/turn.py` now reflects the cancellation in `status`, so
+  the wire event and `agent.last_turn` both report it honestly (and a
+  placeholder-vs-answer check does not read a cancelled turn as an answer).
+
+- **`agentao run` no longer exits `0` on a turn that produced no answer.**
+  A turn ending with an empty assistant message exited `0` and served the
+  `[No response]` / `[No text response]` placeholder as if it were the model's
+  answer; a turn the harness aborted after repeated length truncation or a
+  doom loop did the same with its canned abort string; a final answer cut off
+  mid-sentence at the token limit, and a turn whose LLM call failed outright
+  (returning the `[LLM API error: …]` notice), likewise exited `0`. Automation
+  reading `final_text` could not distinguish any of these from a real answer.
+  All now exit `1` with a precise `error.type` — `empty_response` when the
+  model said nothing, `length_truncated` / `doom_loop` when the harness halted
+  a non-converging turn, `runtime_error` (with `error.reason: "llm_error"` and
+  the provider's actual message) when the LLM call failed. Note that such a
+  turn may have run tools first: `tool_calls` reports how many, and their side
+  effects have already landed, so a non-zero exit does **not** imply an
+  untouched workspace.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,14 +107,25 @@ State is on `AgentaoCLI` (`agentao/cli/app.py`) and projected into prompts.
 
 ### System prompt composition
 
-Built fresh on every `chat()` — `agent.py::_build_system_prompt()` delegates to `agentao/prompts/` (`SystemPromptBuilder`):
+Built fresh on every `chat()` — `agent.py::_build_system_prompt()` delegates to `agentao/prompts/` (`SystemPromptBuilder`). Sections are ordered to keep the **stable prefix byte-identical across turns** so provider prompt-caching can reuse it; everything that changes within a session sits below that line. `builder.py::_build_sections()` is the authoritative order:
+
+*Stable prefix (cached across turns):*
 
 1. `AGENTAO.md` (if present in cwd) — project-specific instructions
-2. Agent instructions — base Agentao capabilities
-3. Current date/time — `YYYY-MM-DD HH:MM:SS (Day)`
-4. Memory blocks — `<memory-stable>` + `<memory-context>` (top-k recall scored against current user message)
-5. Available skills — names + descriptions
-6. Active skills context — full SKILL.md + on-demand `references/*.md`
+2. Agent instructions — identity, reliability, task classification, execution protocol, completion standard, untrusted input, operational guidelines
+3. Reasoning requirement — only when a thinking handler is attached
+4. Available agents — suppressed in plan mode (delegation contradicts research-only intent)
+5. `<memory-stable>` — stable persistent memories; last item of the prefix
+
+*Volatile suffix (changes within a session):*
+
+6. Available skills — names + descriptions
+7. Active skills context — full SKILL.md + on-demand `references/*.md`
+8. Todos
+9. `<memory-context>` — top-k recall scored against the current user message, excluding anything already in `<memory-stable>`
+10. Plan prompt — plan mode only
+
+**The date/time is *not* in the system prompt.** It is injected per-turn as a `<system-reminder>` prepended to the *user message* (`runtime/chat_loop/_runner.py::run`, `Current Date/Time: YYYY-MM-DD HH:MM:SS (Day)`) — keeping it out of the cached prefix is the whole point. `tests/test_date_in_prompt.py` asserts both halves.
 
 ### Conversation flow
 

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -58,11 +58,12 @@ _ensure_utf8()
 # and independently testable, while keeping `from agentao import Agentao` and
 # `agentao.Agentao(...)` working unchanged.
 
-__all__ = ["Agentao", "SkillManager"]
+__all__ = ["Agentao", "SkillManager", "TurnOutcome"]
 
 if TYPE_CHECKING:
     # Type checkers and IDEs see explicit imports; the runtime path uses __getattr__.
     from .agent import Agentao
+    from .runtime.outcome import TurnOutcome
     from .skills import SkillManager
 
 
@@ -73,6 +74,11 @@ def __getattr__(name: str):
     if name == "SkillManager":
         from .skills import SkillManager
         return SkillManager
+    if name == "TurnOutcome":
+        # Lightweight dataclass — importable without the LLM stack, so a host
+        # can type-annotate ``agent.last_turn`` cheaply.
+        from .runtime.outcome import TurnOutcome
+        return TurnOutcome
     raise AttributeError(f"module 'agentao' has no attribute {name!r}")
 
 

--- a/agentao/agent.py
+++ b/agentao/agent.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from .mcp import McpClientManager  # type-only; MCP SDK is heavy
     from .memory import MemoryManager  # noqa: F401
     from .replay import ReplayConfig, ReplayManager  # type-only — replay no longer in core surface
+    from .runtime.outcome import TurnOutcome  # noqa: F401
     from .tools.base import RegistrableTool  # noqa: F401
 
 
@@ -489,6 +490,11 @@ class Agentao:
 
         # Per-turn cancellation token (set at the start of each chat() call)
         self._current_token: Optional[CancellationToken] = None
+
+        # Structured outcome of the most recent turn (see the ``last_turn``
+        # property). Populated in ``runtime/turn.py``'s finally; None until the
+        # first turn completes.
+        self._last_turn_outcome: Optional["TurnOutcome"] = None
 
         # Conversation history
         self.messages: List[Dict[str, Any]] = []
@@ -1013,6 +1019,21 @@ class Agentao:
 
     def reload_replay_config(self) -> "ReplayConfig":
         return self._ensure_replay_manager().reload_config()
+
+    @property
+    def last_turn(self) -> "Optional[TurnOutcome]":
+        """Structured outcome of the most recent ``chat()`` / ``arun()`` turn.
+
+        ``None`` before the first turn completes. Those methods return the
+        turn's text as a ``str``; this is the companion that says whether that
+        text is a real answer. Read ``agent.last_turn.is_answer`` (or branch on
+        ``agent.last_turn.incomplete_reason``) before treating the reply as the
+        model's — the harness substitutes a placeholder / canned notice for an
+        answerless, halted, or failed turn, and the bare string cannot be told
+        apart from a real one. Mirrors the ``TURN_END`` transport payload, so a
+        host gets the same facts without subscribing to the internal channel.
+        """
+        return self._last_turn_outcome
 
     def _register_agent_tools(self):
         # Implementation lives in ``agentao.tooling.agent_tools`` — see

--- a/agentao/cli/run.py
+++ b/agentao/cli/run.py
@@ -44,6 +44,39 @@ EXIT_INTERRUPTED = 130
 
 DEFAULT_MAX_ITERATIONS = 100
 
+# Maps a TURN_END ``incomplete_reason`` to the error envelope it produces:
+# ``{reason: (error type, message stem)}``. All exit 1 — the run has no answer
+# to hand back either way — and the ``type`` separates the sub-families a
+# pipeline may want to treat differently: "the model said nothing"
+# (``empty_response``), "the harness halted a non-converging turn"
+# (``length_truncated`` / ``doom_loop`` — worth retrying with a smaller task),
+# and "the LLM call itself failed" (``runtime_error``). Exit 4 is deliberately
+# not reused for these: its documented meaning is the iteration cap, which is a
+# separate axis (``transport.max_iterations_hit``, checked first below). Keys
+# are the runtime's ``INCOMPLETE_*`` constants (agentao/runtime/chat_loop/
+# _runner.py) — the wire vocabulary, kept as literals here so the CLI does not
+# import runtime internals at module scope; a parity test binds the two sets.
+_INCOMPLETE_OUTCOMES: Dict[str, Tuple[str, str]] = {
+    "no_output": ("empty_response", "the model returned an empty response"),
+    "reasoning_only": (
+        "empty_response", "the model returned reasoning but no text answer",
+    ),
+    "length_truncated": (
+        "length_truncated",
+        "output was cut off at the token limit before the turn could finish",
+    ),
+    "doom_loop": (
+        "doom_loop",
+        "the model repeated the same tool call until the doom-loop detector "
+        "halted the turn",
+    ),
+    "llm_error": (
+        "runtime_error",
+        "the LLM API call failed (provider error / rate limit / auth) after "
+        "retries",
+    ),
+}
+
 PERMISSION_MODE_CHOICES = ("read-only", "workspace-write", "full-access", "plan")
 
 
@@ -604,9 +637,10 @@ def _run_pipeline(
 
     tool_calls_count = 0
     captured_turn_id: Optional[str] = None
+    incomplete_reason: Optional[str] = None
 
     def _on_tool_event(event: Any) -> None:
-        nonlocal tool_calls_count, captured_turn_id
+        nonlocal tool_calls_count, captured_turn_id, incomplete_reason
         ev_type = getattr(event, "type", None)
         # ``run_turn`` clears ``agent._current_turn_id`` in its finally
         # block, so by the time we serialize RunResult the field is
@@ -614,6 +648,14 @@ def _run_pipeline(
         # can correlate the run with replay / host events.
         if ev_type == EventType.TURN_BEGIN and captured_turn_id is None:
             captured_turn_id = getattr(agent, "_current_turn_id", None)
+            return
+        # The runtime reports a turn that produced no complete answer; the
+        # classifier below turns that into a non-zero exit so a pipeline
+        # can't read "the model said nothing" as success.
+        if ev_type == EventType.TURN_END:
+            incomplete_reason = (getattr(event, "data", None) or {}).get(
+                "incomplete_reason"
+            )
             return
         # ToolExecutor fires TOOL_START *before* the deny check, so
         # counting that event would over-report denied / user-cancelled
@@ -654,6 +696,8 @@ def _run_pipeline(
         token=token,
         runtime_error=runtime_error,
         max_iterations=max_iterations,
+        incomplete_reason=incomplete_reason,
+        final_text=final_text,
     )
 
     delta_prompt = max(0, agent.llm.total_prompt_tokens - pre_prompt)
@@ -696,8 +740,20 @@ def _classify_outcome(
     token,
     runtime_error: Optional[BaseException],
     max_iterations: int,
+    incomplete_reason: Optional[str] = None,
+    final_text: str = "",
 ) -> Tuple[Optional[RunErrorEnvelope], int, str]:
-    """Map post-chat state to ``(error_envelope, exit_code, status)``."""
+    """Map post-chat state to ``(error_envelope, exit_code, status)``.
+
+    ``incomplete_reason`` is the TURN_END classification of a turn that ended
+    without a complete model answer (see :data:`_INCOMPLETE_OUTCOMES`, else
+    ``None``). It is checked last, so every outcome that *explains* the
+    missing answer — rejection, max-iterations, cancellation, a raised
+    error — keeps its own more specific code. ``final_text`` is the turn's
+    return value, used to surface the provider's actual message on the
+    ``llm_error`` path (where it holds the ``[LLM API error: …]`` notice).
+    """
+
     if transport.rejection is not None:
         return (
             RunErrorEnvelope(**transport.rejection),
@@ -730,6 +786,36 @@ def _classify_outcome(
     if runtime_error is not None:
         return (
             RunErrorEnvelope(type="runtime_error", message=str(runtime_error)),
+            EXIT_RUNTIME_ERROR,
+            "error",
+        )
+    if incomplete_reason is not None:
+        # The turn completed, but there is no complete model answer to return.
+        # Exiting 0 here would hand a pipeline the bare "[No response]"
+        # placeholder — or the harness's own abort text — as if the model had
+        # said it. Any tool calls the turn made still ran (see ``tool_calls``
+        # on the same envelope), so the wording never claims nothing happened.
+        envelope_type, detail = _INCOMPLETE_OUTCOMES.get(
+            incomplete_reason,
+            ("empty_response", "the model produced no answer"),
+        )
+        # On the ``llm_error`` path the turn's return value is the harness's
+        # ``[LLM API error: …]`` notice — the provider's actual failure. Surface
+        # it so the envelope is as informative as a raised ``runtime_error``,
+        # rather than dropping it behind the generic stem when ``final_text`` is
+        # nulled for a non-"ok" status.
+        if incomplete_reason == "llm_error" and final_text.strip():
+            message = f"{detail}: {final_text.strip()}"
+        else:
+            message = f"{detail}; the run produced no answer."
+        return (
+            RunErrorEnvelope(
+                type=envelope_type,
+                # Machine-readable discriminator: a consumer branching on the
+                # variant must not have to parse ``message``.
+                reason=incomplete_reason,
+                message=message,
+            ),
             EXIT_RUNTIME_ERROR,
             "error",
         )

--- a/agentao/cli/run_models.py
+++ b/agentao/cli/run_models.py
@@ -244,11 +244,20 @@ class RunErrorEnvelope(BaseModel):
         "runtime_error",
         "invalid_spec",
         "interrupted",
+        "empty_response",
+        "length_truncated",
+        "doom_loop",
     ]
     message: str
     tool_name: Optional[str] = None
     tool_call_id: Optional[str] = None
     matched_rule: Optional[Dict[str, Any]] = None
+    # Machine-readable sub-classification. For a turn that produced no
+    # complete answer this carries the runtime's ``incomplete_reason``
+    # verbatim ("no_output", "reasoning_only", "length_truncated",
+    # "doom_loop"), so a consumer can branch on one field without
+    # substring-matching ``message`` or widening its ``type`` match.
+    reason: Optional[str] = None
     # ``ask_user`` raises ``interaction_required`` and the transport
     # records the prompt text the agent wanted to ask. The envelope
     # carries that text through so automation can decide what to do.

--- a/agentao/replay/adapter.py
+++ b/agentao/replay/adapter.py
@@ -73,6 +73,7 @@ class ReplayAdapter:
         status: str = "ok",
         error: Optional[str] = None,
         tool_count: Optional[int] = None,
+        incomplete_reason: Optional[str] = None,
     ) -> None:
         turn_id = self._turn_id
         if turn_id is None:
@@ -84,6 +85,13 @@ class ReplayAdapter:
         }
         if tool_count is not None:
             payload["tool_count"] = tool_count
+        if incomplete_reason is not None:
+            # ``status`` stays "ok" for a turn that merely lacks an answer —
+            # the runtime completed it normally. Without this the replay would
+            # show a placeholder (or a halted turn's canned text) on an "ok"
+            # turn and give a triager no way to see why the run reported a
+            # failure.
+            payload["incomplete_reason"] = incomplete_reason
         self._recorder.record(
             EventKind.TURN_COMPLETED,
             turn_id=turn_id,
@@ -213,6 +221,22 @@ class ReplayAdapter:
             return handler(count, messages)
         return {"action": "stop"}
 
+    def subscribe(self, listener):
+        """Delegate side-channel subscription to the wrapped transport.
+
+        Splicing this adapter in front of ``agent.transport`` (when replay is
+        on) must not strip the inner transport's subscriber channel — otherwise
+        a host that observes turn outcomes via ``agent.transport.subscribe``
+        (the documented path for TURN_END / ``incomplete_reason``) silently
+        registers nothing the moment replay is enabled. Forward to the inner
+        ``subscribe`` when it exists; return a no-op unsubscribe otherwise, per
+        the optional-method contract in ``transport/base.py``.
+        """
+        inner_subscribe = getattr(self._inner, "subscribe", None)
+        if callable(inner_subscribe):
+            return inner_subscribe(listener)
+        return lambda: None
+
     # -- translation --------------------------------------------------------
 
     def _mirror(self, event: AgentEvent) -> None:
@@ -234,11 +258,15 @@ class ReplayAdapter:
         if kind == EventType.TURN_END:
             try:
                 tc = data.get("tool_count")
+                incomplete = data.get("incomplete_reason")
                 self.end_turn(
                     str(data.get("final_text", "") or ""),
                     status=str(data.get("status", "ok") or "ok"),
                     error=data.get("error"),
                     tool_count=tc if isinstance(tc, int) else None,
+                    incomplete_reason=(
+                        incomplete if isinstance(incomplete, str) else None
+                    ),
                 )
             except Exception:
                 pass

--- a/agentao/runtime/chat_loop/__init__.py
+++ b/agentao/runtime/chat_loop/__init__.py
@@ -23,7 +23,28 @@ underscored to match. Each mix-in reads ``self._agent`` (and, for
 
 from __future__ import annotations
 
-from ._runner import ChatLoopRunner
+from ._runner import (
+    EMPTY_REASONING_ONLY_PLACEHOLDER,
+    EMPTY_RESPONSE_PLACEHOLDER,
+    INCOMPLETE_ANSWER_REASONS,
+    INCOMPLETE_DOOM_LOOP,
+    INCOMPLETE_LENGTH_TRUNCATED,
+    INCOMPLETE_LLM_ERROR,
+    INCOMPLETE_NO_OUTPUT,
+    INCOMPLETE_REASONING_ONLY,
+    ChatLoopRunner,
+)
 from ._serialize import _serialize_tool_call
 
-__all__ = ["ChatLoopRunner", "_serialize_tool_call"]
+__all__ = [
+    "EMPTY_REASONING_ONLY_PLACEHOLDER",
+    "EMPTY_RESPONSE_PLACEHOLDER",
+    "INCOMPLETE_ANSWER_REASONS",
+    "INCOMPLETE_DOOM_LOOP",
+    "INCOMPLETE_LENGTH_TRUNCATED",
+    "INCOMPLETE_LLM_ERROR",
+    "INCOMPLETE_NO_OUTPUT",
+    "INCOMPLETE_REASONING_ONLY",
+    "ChatLoopRunner",
+    "_serialize_tool_call",
+]

--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -58,6 +58,66 @@ def _is_length_truncation(finish_reason) -> bool:
     )
 
 
+# Substituted for an empty final assistant message (see
+# ``_handle_final_response``) so history stays valid for strict API proxies.
+EMPTY_REASONING_ONLY_PLACEHOLDER = "[No text response]"
+EMPTY_RESPONSE_PLACEHOLDER = "[No response]"
+
+# ``incomplete_reason`` is the single closed vocabulary for one question — why
+# this turn's ``final_text`` is not a complete, model-authored answer. Every
+# turn-ending path in ``run()`` commits exactly one of these (or ``None`` for a
+# real answer); there is no unclassified ending. Three sub-families:
+#
+#   the turn ended normally and the model simply produced no answer
+#       NO_OUTPUT       — nothing at all
+#       REASONING_ONLY  — reasoning, but no answer text
+#   the harness halted a turn that was not converging, so whatever text came
+#   back (a canned string, or the model's own partial text) is incomplete
+#       LENGTH_TRUNCATED — output cut off at the token limit (a tool call whose
+#                          arguments were truncated, or a final answer cut off
+#                          mid-sentence)
+#       DOOM_LOOP        — the same call repeated until the detector fired
+#   the LLM call itself failed and never yielded a turn
+#       LLM_ERROR       — the provider call raised (5xx / rate limit / auth)
+#                          after retries; the harness returned its own
+#                          ``[LLM API error: …]`` notice, not a model answer
+#
+# ``max_iterations`` is a *sixth* way a turn ends without a complete answer, but
+# it is a deliberately separate axis — not a value here. It rides a sticky
+# transport flag (``NonInteractiveTransport.max_iterations_hit``), reached
+# through the ``transport.on_max_iterations`` interaction callback, and carries
+# its own exit code (4). The flag is set when the cap is *hit* (even if a host
+# hook then continues past it), whereas this field is set only when a turn
+# *ends*; collapsing the two would lose that distinction. The host reconciles
+# them in ``cli/run.py::_classify_outcome`` (the flag is checked first).
+#
+# These are the wire values hosts branch on, so they are part of the event
+# contract — see developer-guide part-4/2-agent-events.md.
+INCOMPLETE_NO_OUTPUT = "no_output"
+INCOMPLETE_REASONING_ONLY = "reasoning_only"
+INCOMPLETE_LENGTH_TRUNCATED = "length_truncated"
+INCOMPLETE_DOOM_LOOP = "doom_loop"
+INCOMPLETE_LLM_ERROR = "llm_error"
+
+# The complete closed set — the ``incomplete_reason`` wire vocabulary. The CLI
+# maps each of these to an error envelope; a parity test binds the two so the
+# two lists cannot drift.
+INCOMPLETE_ANSWER_REASONS = frozenset({
+    INCOMPLETE_NO_OUTPUT,
+    INCOMPLETE_REASONING_ONLY,
+    INCOMPLETE_LENGTH_TRUNCATED,
+    INCOMPLETE_DOOM_LOOP,
+    INCOMPLETE_LLM_ERROR,
+})
+
+# The "harness halted a non-converging turn" family. Hook text or a re-entry
+# cap does not make such a turn converge, so its classification must survive
+# the ``_resolve_stop_hook`` paths that clear the answerless family. (LLM_ERROR
+# is not here: it never reaches ``_resolve_stop_hook`` — see the error-return
+# path in ``run()``.)
+_HALTED_REASONS = frozenset({INCOMPLETE_LENGTH_TRUNCATED, INCOMPLETE_DOOM_LOOP})
+
+
 # Model-facing tool-result stamped on every tool call in an assistant message
 # that was truncated at the output-token limit. Such a message was cut off, so
 # the streamed tool-call arguments may be truncated — the JSON can even balance
@@ -130,8 +190,9 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             self.active_skills = active_skills
             self.memory_version = memory_version
 
-    # Per-site differences in Stop-hook handling. The three sites
-    # (max-iterations / doom-loop / final-response) share one code path
+    # Per-site differences in Stop-hook handling. The four sites
+    # (max-iterations / doom-loop / length-truncation / final-response)
+    # share one code path
     # (``_resolve_stop_hook``); only the log text, the ``force_continue``
     # telemetry label, and whether ``additional_contexts`` ride on the
     # answer differ.
@@ -314,6 +375,13 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                 image_fallback_index=image_fallback_index if iteration == 1 else None,
             )
             if llm_outcome.error_return is not None:
+                # The LLM call failed and was swallowed into a ``[LLM API
+                # error: …]`` notice (see ``_call_llm_with_overflow_recovery``).
+                # This return bypasses ``_resolve_stop_hook``, so classify the
+                # turn here — otherwise the harness's own error notice ships as
+                # a successful model answer at exit 0. Same commit discipline as
+                # every other ending site: no turn leaves ``run()`` unclassified.
+                agent._turn_incomplete_reason = INCOMPLETE_LLM_ERROR
                 return llm_outcome.error_return
             response = llm_outcome.response
             messages_with_system = llm_outcome.messages_with_system
@@ -369,6 +437,7 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                     assistant_message=assistant_message,
                     iteration=iteration,
                     system_prompt=system_prompt,
+                    finish_reason=finish_reason,
                 )
                 if step.action == "continue":  # Stop-hook re-entry
                     messages_with_system = step.messages_with_system
@@ -604,11 +673,15 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                 agent.llm.logger.warning(
                     "Sanitised lone surrogates in length-truncation abort message"
                 )
+            # The harness gave up on a turn the model could not get through, so
+            # ``assistant_content`` is either our canned string or whatever
+            # partial text preceded the truncated calls — incomplete either way.
             return self._resolve_stop_hook(
                 turn_end_reason="length_truncation",
                 assistant_content=assistant_content,
                 final_msg=final_msg,
                 system_prompt=system_prompt,
+                incomplete_reason=INCOMPLETE_LENGTH_TRUNCATED,
             )
 
         return ChatLoopRunner._Step(
@@ -682,6 +755,7 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                 assistant_content=assistant_content_doom,
                 final_msg=final_msg_doom,
                 system_prompt=system_prompt,
+                incomplete_reason=INCOMPLETE_DOOM_LOOP,
             )
         if token.is_cancelled:
             raise AgentCancelledError(token.reason)
@@ -718,12 +792,15 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
         assistant_message,
         iteration: int,
         system_prompt: str,
+        finish_reason: Optional[str] = None,
     ) -> "ChatLoopRunner._Step":
         """Finalize a turn that ended without tool calls."""
         agent = self._agent
         agent.llm.logger.info(f"Reached final response in iteration {iteration}")
         reasoning_content = getattr(assistant_message, "reasoning_content", None)
         assistant_content = assistant_message.content or ""
+        truncated = _is_length_truncation(finish_reason)
+        incomplete_reason: Optional[str] = None
         if not assistant_content.strip():
             # Some models (byte-level reasoning backends — Kimi, GLM,
             # Qwen-via-Ollama) end a turn with empty/whitespace content and
@@ -731,14 +808,39 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             # message that strict API proxies reject on the next turn.
             # Substitute a neutral marker.
             assistant_content = (
-                "[No text response]"
+                EMPTY_REASONING_ONLY_PLACEHOLDER
                 if reasoning_content
-                else "[No response]"
+                else EMPTY_RESPONSE_PLACEHOLDER
+            )
+            # The placeholder keeps history valid but is not an answer. Record
+            # which kind so hosts can tell "model emitted nothing" from "model
+            # reasoned but never answered"; ``_resolve_stop_hook`` commits it
+            # once the Stop hook has had its say. Truncation wins over both:
+            # when the empty content is the model hitting the output-token limit
+            # mid-reasoning (``finish_reason=length``), the actionable fact is
+            # "ran out of tokens" (retry smaller), not "chose not to answer".
+            incomplete_reason = (
+                INCOMPLETE_LENGTH_TRUNCATED
+                if truncated
+                else INCOMPLETE_REASONING_ONLY if reasoning_content
+                else INCOMPLETE_NO_OUTPUT
             )
             agent.llm.logger.warning(
                 "Empty final assistant content in iteration %d; "
                 "substituted placeholder to keep history valid",
                 iteration,
+            )
+        elif truncated:
+            # Non-empty answer, but the model was cut off at the output-token
+            # limit mid-sentence — a partial answer, not a complete one. Keep
+            # the partial text in history, but flag the turn incomplete so
+            # ``agentao run`` does not serve a half-sentence as a finished
+            # answer at exit 0.
+            incomplete_reason = INCOMPLETE_LENGTH_TRUNCATED
+            agent.llm.logger.warning(
+                "Final assistant content truncated at the output-token limit "
+                "in iteration %d (finish_reason=%s)",
+                iteration, finish_reason,
             )
         final_msg: Dict[str, Any] = {"role": "assistant", "content": assistant_content}
         _attach_reasoning(final_msg, reasoning_content)
@@ -752,6 +854,7 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             assistant_content=assistant_content,
             final_msg=final_msg,
             system_prompt=system_prompt,
+            incomplete_reason=incomplete_reason,
         )
 
     def _resolve_stop_hook(
@@ -761,14 +864,31 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
         assistant_content: str,
         final_msg: Dict[str, Any],
         system_prompt: str,
+        incomplete_reason: Optional[str] = None,
     ) -> "ChatLoopRunner._Step":
         """Dispatch the Stop hook and translate its verdict into a step.
 
-        Shared by all three turn-ending sites (max-iterations, doom-loop,
-        final-response); per-site differences live in ``_STOP_SITES``.
+        Shared by all four turn-ending sites (max-iterations, doom-loop,
+        length-truncation, final-response); per-site differences live in
+        ``_STOP_SITES``.
         ``final_msg`` is appended to history here (after a possible
         ``blocking_error`` / ``additional_contexts`` rewrite) so the
         original answer never leaks into history on a block.
+
+        ``incomplete_reason`` is the caller's classification of *why* the turn
+        has no complete model-authored answer. Three of the four sites pass a
+        value — ``final_response`` (``no_output`` / ``reasoning_only`` /
+        ``length_truncated``), ``length_truncation``, and ``doom_loop``; only
+        ``max_iterations`` omits it, keeping its own exit-4 channel. It is
+        recorded on the agent at each return point rather than at substitution
+        time, because only here is the turn's outcome final: the Stop hook may
+        replace the answer (block), hand the turn back to the loop
+        (force-continue), the re-entry cap may fire, or the hook may merely
+        decorate the answer (additional_contexts). A hook supplying text cures
+        the *answerless* family (``no_output`` / ``reasoning_only``) — the
+        caller now receives that text — but does not cure a *halted* turn
+        (``length_truncated`` / ``doom_loop``): hook text does not make a
+        non-converging turn converge, so ``_HALTED_REASONS`` survives the block.
         """
         agent = self._agent
         site = self._STOP_SITES[turn_end_reason]
@@ -781,6 +901,15 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             blocked = f"[Blocked by Stop hook] {stop_result.blocking_error}"
             final_msg["content"] = blocked
             agent.messages.append(final_msg)
+            # The hook supplied the text the caller receives, so an *answerless*
+            # turn (no_output / reasoning_only) is no longer answerless. A
+            # *halted* turn (length_truncated / doom_loop) is not cured by hook
+            # text — it still never converged — so its classification survives,
+            # keeping ``agentao run`` at exit 1 instead of serving the hook's
+            # diagnostic string as a successful answer.
+            agent._turn_incomplete_reason = (
+                incomplete_reason if incomplete_reason in _HALTED_REASONS else None
+            )
             self._emit_stop_hook_fired(
                 outcome="block",
                 turn_end_reason=turn_end_reason,
@@ -794,6 +923,12 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             if self._stop_reentries >= self._stop_reentry_cap:
                 agent.llm.logger.warning(site["reentry_cap_log"], self._stop_reentry_cap)
                 agent.messages.append(final_msg)
+                # Capped: the caller receives ``assistant_content`` unchanged
+                # (no hook text substituted), so the turn is exactly as
+                # incomplete as when it entered — an answerless or halted turn
+                # stays classified. Without this, a capped length_truncation /
+                # doom_loop turn would emit ``None`` and exit 0.
+                agent._turn_incomplete_reason = incomplete_reason
                 self._emit_stop_hook_fired(
                     outcome="reentry_capped",
                     turn_end_reason=turn_end_reason,
@@ -819,6 +954,11 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             messages_with_system = [
                 {"role": "system", "content": system_prompt}
             ] + agent.messages
+            # The turn is not ending — the loop gets another iteration, which
+            # will re-classify when it reaches its own ending site. Clearing
+            # here keeps an earlier empty iteration from sticking to a turn
+            # that goes on to answer (or to end for some other reason).
+            agent._turn_incomplete_reason = None
             self._emit_stop_hook_fired(
                 outcome=site["force_continue_outcome"],
                 turn_end_reason=turn_end_reason,
@@ -847,6 +987,10 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             final_msg["content"] = f"{assistant_content}\n{extra}"
             assistant_content = final_msg["content"]
         agent.messages.append(final_msg)
+        # ``additional_contexts`` decorates the answer, it does not supply one:
+        # an empty turn wrapped in a ``<stop-hook>`` block is still a turn the
+        # model never answered, so the classification survives the rewrite.
+        agent._turn_incomplete_reason = incomplete_reason
         self._emit_stop_hook_fired(
             outcome="allow",
             turn_end_reason=turn_end_reason,

--- a/agentao/runtime/outcome.py
+++ b/agentao/runtime/outcome.py
@@ -1,0 +1,54 @@
+"""``TurnOutcome`` — the structured result of a single turn.
+
+``Agentao.chat()`` / ``arun()`` return the turn's text as a ``str`` (a stable,
+backward-compatible contract). That string alone cannot tell a real answer from
+the ``[No response]`` placeholder, a harness abort notice, or an ``[LLM API
+error: …]`` string. ``TurnOutcome`` is the companion a host reads afterwards via
+``agent.last_turn`` to get the missing fact.
+
+It is a plain frozen dataclass, importable without pulling the LLM stack, and
+mirrors the ``TURN_END`` transport payload field-for-field — so a host that
+cannot (or does not want to) subscribe to the internal ``Transport`` still has
+the same facts through a simple synchronous read.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class TurnOutcome:
+    """What the most recent turn produced, beyond its text.
+
+    Fields (mirroring ``TURN_END``):
+        text              — the turn's final text (same value ``chat()`` returned)
+        status            — ``"ok"`` | ``"error"`` | ``"cancelled"``
+        incomplete_reason — why the turn has no complete model answer, or
+                            ``None`` for a real answer. A single closed
+                            vocabulary: ``no_output`` / ``reasoning_only`` /
+                            ``length_truncated`` / ``doom_loop`` / ``llm_error``.
+        tool_count        — tool calls the model made across the turn
+        error             — error detail when ``status != "ok"``, else ``None``
+    """
+
+    text: str
+    status: str
+    incomplete_reason: Optional[str]
+    tool_count: int
+    error: Optional[str] = None
+
+    @property
+    def is_answer(self) -> bool:
+        """True only for a complete, model-authored answer.
+
+        The single check a host needs before treating ``text`` as the model's
+        reply: the turn ended ``"ok"`` and nothing classified it as incomplete.
+        A cancelled or errored turn, or one the harness could not get an answer
+        out of, is ``False``.
+        """
+        return self.status == "ok" and self.incomplete_reason is None
+
+
+__all__ = ["TurnOutcome"]

--- a/agentao/runtime/turn.py
+++ b/agentao/runtime/turn.py
@@ -23,6 +23,7 @@ from ..cancellation import AgentCancelledError, CancellationToken
 from ..replay.observability import latest_session_summary_id
 from ..transport import AgentEvent, EventType
 from .identity import new_turn_id
+from .outcome import TurnOutcome
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from ..agent import Agentao
@@ -79,6 +80,14 @@ def run_turn(
     # total so host telemetry can size a turn without replaying every
     # TOOL_START. Reset per turn (and read defensively in the finally).
     agent._turn_tool_count = 0
+    # Turn-level "this turn has no complete model answer" classification
+    # (None / "no_output" / "reasoning_only" / "length_truncated" /
+    # "doom_loop"), typed Optional[str]. The chat loop sets it at whichever
+    # site ends the turn; reset per turn (and read defensively in the finally).
+    # No PEP 526 annotation here: this is a non-self attribute, which mypy
+    # rejects outright, and under ``from __future__ import annotations`` the
+    # annotation is inert anyway — it matches the un-annotated sibling above.
+    agent._turn_incomplete_reason = None
     # Snapshot the latest session-summary id so the inner loop can
     # fire SESSION_SUMMARY_WRITTEN each time compress_messages writes
     # a new one. Held on the instance so compression paths inside the
@@ -125,12 +134,44 @@ def run_turn(
         error_detail = str(e)
         raise
     finally:
+        tool_count = getattr(agent, "_turn_tool_count", 0)
+        # A token cancelled mid-stream can let the turn return normally — the
+        # LLM yields a normally-built empty message without raising
+        # (llm/client.py::_consume_stream breaks out of the chunk loop), so the
+        # turn reaches the ordinary ending site with status "ok" though it was
+        # interrupted. Reflect the cancellation in ``status`` so both the wire
+        # event and ``agent.last_turn`` report it honestly (and a
+        # placeholder-vs-answer check does not read a cancelled turn as an
+        # answer).
+        if status == "ok" and token.is_cancelled:
+            status = "cancelled"
+            if error_detail is None:
+                error_detail = token.reason or "cancelled"
+        # ``incomplete_reason`` is None unless the turn ended without a complete
+        # model answer — the model produced none, the harness halted a
+        # non-converging turn, or the LLM call failed. A cancelled or errored
+        # turn is not "answerless"; it carries its own status. This single gated
+        # value feeds both the wire event and the read-after, so they never
+        # disagree.
+        incomplete_reason = (
+            getattr(agent, "_turn_incomplete_reason", None)
+            if status == "ok"
+            else None
+        )
+        agent._last_turn_outcome = TurnOutcome(
+            text=final_text,
+            status=status,
+            incomplete_reason=incomplete_reason,
+            tool_count=tool_count,
+            error=error_detail,
+        )
         try:
             agent.transport.emit(AgentEvent(EventType.TURN_END, {
                 "final_text": final_text,
                 "status": status,
                 "error": error_detail,
-                "tool_count": getattr(agent, "_turn_tool_count", 0),
+                "tool_count": tool_count,
+                "incomplete_reason": incomplete_reason,
             }))
         except Exception:
             pass

--- a/agentao/transport/events.py
+++ b/agentao/transport/events.py
@@ -56,10 +56,21 @@ class AgentEvent:
 
     ``schema_version`` is the runtime-payload version contract for the
     wire form (independent of ACP's protocol version); bump it when a
-    payload field's shape or semantics change.
+    payload field's shape or semantics change. Adding a new key is not
+    such a change: consumers ignore keys they do not know, so additive
+    fields ship without a bump (``tool_count`` and ``incomplete_reason``
+    both joined TURN_END this way). Because the version is a single value
+    across every event type, bumping it for one payload would strand a
+    consumer pinned to the old version on *that* event rather than let it
+    skip one unread field.
 
     Common data payloads:
         TURN_START    {}
+        TURN_BEGIN    {"user_message": "..."}
+        TURN_END      {"final_text": "...", "status": "ok"|"error"|"cancelled",
+                       "error": None, "tool_count": 3,
+                       "incomplete_reason": None|"no_output"|"reasoning_only"
+                       |"length_truncated"|"doom_loop"}
         TOOL_START    {"tool": "run_shell_command", "args": {...}, "call_id": "uuid"}
         TOOL_OUTPUT   {"tool": "run_shell_command", "chunk": "hello\\n", "call_id": "uuid"}
         TOOL_COMPLETE {"tool": "run_shell_command", "call_id": "uuid",

--- a/developer-guide/en/cli/12-non-interactive.md
+++ b/developer-guide/en/cli/12-non-interactive.md
@@ -159,14 +159,28 @@ For the full design rationale — including v1 scope, deferred typing (`number` 
 }
 ```
 
-On failure, `final_text` is `null` and `error` carries `{ type, message, tool_name?, tool_call_id?, question?, matched_rule? }`. Error `type` is one of `permission_required`, `permission_denied`, `interaction_required`, `max_iterations`, `runtime_error`, `invalid_spec`, `interrupted`. Consumers should treat the envelope as forward-compatible (extra fields ignored).
+On failure, `final_text` is `null` and `error` carries `{ type, message, reason?, tool_name?, tool_call_id?, question?, matched_rule? }`. Error `type` is one of `permission_required`, `permission_denied`, `interaction_required`, `max_iterations`, `runtime_error`, `invalid_spec`, `interrupted`, `empty_response`, `length_truncated`, `doom_loop`. Consumers should treat the envelope as forward-compatible (extra fields ignored).
+
+Three types mean the turn completed with no answer to hand back, and `reason` carries the runtime's exact classification for all of them — branch on `reason`, not on `message`:
+
+| `type` | `reason` | Meaning |
+|---|---|---|
+| `empty_response` | `no_output` | The model emitted nothing. |
+| `empty_response` | `reasoning_only` | The model emitted reasoning but no answer text. |
+| `length_truncated` | `length_truncated` | Output cut off at the token limit — a tool call whose arguments were truncated (the harness then halts the turn), or a final answer cut off mid-sentence. |
+| `doom_loop` | `doom_loop` | The model repeated the same call until the detector halted the turn. |
+| `runtime_error` | `llm_error` | The LLM API call failed (provider 5xx / rate limit / auth) after retries; the message carries the provider's actual error. |
+
+The split is deliberate: `empty_response` means the model said nothing, `length_truncated` / `doom_loop` mean the harness halted a non-converging turn (often worth retrying with a smaller task, which "the model said nothing" usually is not), and `llm_error` means the provider call failed. All exit `1`, and the set is closed — every turn that ends without a complete answer classifies, so a pipeline never reads one as success at exit `0`.
+
+Note that a turn can end this way *after* running tools: the model may do the work and then fail to summarize it. `tool_calls` on the same envelope reports how many ran, and their side effects have already landed — an `empty_response` failure does **not** mean the workspace is untouched.
 
 ### Exit codes (unified across `agentao run` and `agentao -p`)
 
 | Code  | Meaning |
 |-------|---------|
 | `0`   | Completed normally |
-| `1`   | Runtime error |
+| `1`   | Runtime error, or a turn that produced no answer (`runtime_error`, `empty_response`, `length_truncated`, `doom_loop`) |
 | `2`   | Invalid usage / spec validation failed / unknown spec field |
 | `3`   | Permission or interaction required (no interactive approval available) |
 | `4`   | Max tool iterations reached; answer may be incomplete |

--- a/developer-guide/en/part-4/2-agent-events.md
+++ b/developer-guide/en/part-4/2-agent-events.md
@@ -52,7 +52,7 @@ TURN_BEGIN -> (user message arrives — turn begins; carries the user text)
 TURN_END   -> (turn ends; carries final assistant text + status/error)
 ```
 
-`TURN_BEGIN` / `TURN_END` fire **once per user-driven turn**; `TURN_START` fires **once per LLM iteration** inside that turn. Replay recorders subscribe to the outer pair via `Transport.subscribe()` (see [4.1](./1-transport-protocol)) instead of being reached through agent state.
+`TURN_BEGIN` / `TURN_END` fire **once per user-driven turn**; `TURN_START` fires **once per LLM iteration** inside that turn. The replay recorder is wired by splicing a `ReplayAdapter` over `agent.transport` that translates the outer pair into recorder turn writes (`ReplayAdapter._mirror`) — not through a subscription. `Transport.subscribe()` (see [4.1](./1-transport-protocol)) is the path for *other* side-channel observers, and the adapter forwards it to the inner transport so subscribing keeps working while replay is on.
 
 Most UIs only need `LLM_TEXT`, `THINKING`, `TOOL_START`, `TOOL_OUTPUT`, `TOOL_COMPLETE`, `TOOL_CONFIRMATION`, `AGENT_START`, `AGENT_END`, and `ERROR`.
 The rest are primarily for session replay, audit, metrics, and debugging.
@@ -65,7 +65,7 @@ The rest are primarily for session replay, audit, metrics, and debugging.
 |-------|-------------|
 | Trigger | Once at the start of each user-driven turn, **before** any LLM iteration |
 | `data` | `{"user_message": "..."}` |
-| Typical use | Open a new turn frame in the replay log / audit stream; subscribe via `Transport.subscribe()` |
+| Typical use | Open a new turn frame in an audit / observer stream via `Transport.subscribe()`. (The replay recorder is wired separately, through the `ReplayAdapter` splice — not this subscription.) |
 
 Distinct from `TURN_START` (which fires per LLM iteration). `TURN_BEGIN` carries the user input and pairs 1-to-1 with `TURN_END`.
 
@@ -74,8 +74,22 @@ Distinct from `TURN_START` (which fires per LLM iteration). `TURN_BEGIN` carries
 | Field | Description |
 |-------|-------------|
 | Trigger | Once at the end of each user-driven turn, after the final assistant reply (or on error / cancellation) |
-| `data` | `{"final_text": "...", "status": "ok"\|"error"\|"cancelled", "error": None, "tool_count": 3}` |
+| `data` | `{"final_text": "...", "status": "ok"\|"error"\|"cancelled", "error": None, "tool_count": 3, "incomplete_reason": None}` |
 | Typical use | Close the turn frame; flush per-turn metrics — `tool_count` is the number of tool calls the LLM made across all iterations of the turn, so a host can size a turn without replaying every `TOOL_START` |
+
+`incomplete_reason` is `None` on an ordinary turn. It is set when the turn ended without a complete, model-authored answer, and says why:
+
+| Value | Meaning |
+|---|---|
+| `no_output` | The model emitted nothing. |
+| `reasoning_only` | The model emitted reasoning but no answer text. |
+| `length_truncated` | Output was cut off at the token limit — either a tool call whose arguments were truncated (the harness then halts the turn) or a final answer cut off mid-sentence. |
+| `doom_loop` | The model repeated the same call until the detector halted the turn. |
+| `llm_error` | The LLM call itself failed (provider 5xx / rate limit / auth) after retries; `final_text` holds the harness's `[LLM API error: …]` notice, not a model answer. |
+
+This is a **single closed vocabulary**: every turn-ending path commits exactly one of these, or `None` for a real answer — there is no unclassified ending. The first two mean the turn ended normally with no answer; the middle two mean the harness stopped a turn that was not converging; the last means the provider call never yielded a turn. (`max_iterations` is a sixth way a turn ends without a complete answer, but it is a deliberately separate axis — a sticky transport flag with its own exit code 4 and its own `on_max_iterations` interaction, not a value here.)
+
+Prefer it over string-matching `final_text` — the harness substitutes a placeholder or a canned notice there (including the `[LLM API error: …]` notice, now classified `llm_error`), and a Stop hook may decorate it, so the text is not a reliable signal. A cancelled turn is never reported via `incomplete_reason` (it carries `status: "cancelled"`). `agentao run` maps a non-`None` value to a non-zero exit; other hosts are free to retry, prompt, or ignore.
 
 Replay recorders pair this with `TURN_BEGIN` to delimit a turn. Drives the runtime → replay handoff that used to be a direct call into the replay adapter.
 

--- a/developer-guide/zh/cli/12-non-interactive.md
+++ b/developer-guide/zh/cli/12-non-interactive.md
@@ -159,14 +159,28 @@ agentao run --spec .agentao/runs/review-pr.yaml \
 }
 ```
 
-失败时 `final_text` 为 `null`，`error` 字段携带 `{ type, message, tool_name?, tool_call_id?, question?, matched_rule? }`。`type` 取值：`permission_required`、`permission_denied`、`interaction_required`、`max_iterations`、`runtime_error`、`invalid_spec`、`interrupted`。消费方应把 envelope 视为前向兼容（多余字段直接忽略）。
+失败时 `final_text` 为 `null`，`error` 字段携带 `{ type, message, reason?, tool_name?, tool_call_id?, question?, matched_rule? }`。`type` 取值：`permission_required`、`permission_denied`、`interaction_required`、`max_iterations`、`runtime_error`、`invalid_spec`、`interrupted`、`empty_response`、`length_truncated`、`doom_loop`。消费方应把 envelope 视为前向兼容（多余字段直接忽略）。
+
+有三种 type 表示 turn 结束但没有可交回的答案，且它们的 `reason` 都携带运行时的精确分类——请基于 `reason` 分支，而不是 `message`：
+
+| `type` | `reason` | 含义 |
+|---|---|---|
+| `empty_response` | `no_output` | 模型什么都没输出。 |
+| `empty_response` | `reasoning_only` | 只有推理内容，没有答案正文。 |
+| `length_truncated` | `length_truncated` | 输出在 token 上限处被截断——要么是工具调用的参数被截断（harness 随即中止该 turn），要么是最终答案在半句处被切断。 |
+| `doom_loop` | `doom_loop` | 模型重复同一个调用，直至检测器 halt 了该 turn。 |
+| `runtime_error` | `llm_error` | LLM API 调用失败（provider 5xx / 限流 / 认证）且重试后仍失败；message 里带 provider 的真实报错。 |
+
+这样拆分是刻意的：`empty_response` 表示模型什么都没说，`length_truncated` / `doom_loop` 表示 harness 停掉了一个不收敛的 turn（往往值得用更小的任务重试，而前者通常不值得），`llm_error` 表示 provider 调用失败。四者退出码均为 `1`，且这套词表是封闭的——每一个没有完整答案就结束的 turn 都会被分类，流水线绝不会在退出码 `0` 处把它读成成功。
+
+注意：turn 可能在**执行过工具之后**以这种方式结束——模型可能已经完成了工作，只是没有做总结。同一 envelope 上的 `tool_calls` 会报告实际执行了多少次工具调用，其副作用**已经落盘**——`empty_response` 失败**不**代表工作区未被改动。
 
 ### 统一退出码（`agentao run` 与 `agentao -p` 共用）
 
 | 退出码 | 含义 |
 |--------|------|
 | `0`    | 正常完成 |
-| `1`    | 运行时错误 |
+| `1`    | 运行时错误，或 turn 没有产出答案（`runtime_error`、`empty_response`、`length_truncated`、`doom_loop`） |
 | `2`    | 用法错误 / spec 校验失败 / 未知 spec 字段 |
 | `3`    | 需要权限或交互（非交互环境无人审批） |
 | `4`    | 达到最大工具迭代数，回答可能不完整 |

--- a/developer-guide/zh/part-4/2-agent-events.md
+++ b/developer-guide/zh/part-4/2-agent-events.md
@@ -52,7 +52,7 @@ TURN_BEGIN -> (用户消息到达——turn 开始；携带 user 文本)
 TURN_END   -> (turn 结束；携带最终 assistant 文本 + status/error)
 ```
 
-`TURN_BEGIN` / `TURN_END` **每个用户驱动的 turn 各发一次**；`TURN_START` 是 turn 内**每次 LLM 迭代**都发（一个 turn 内可能很多次）。Replay 录制器通过 `Transport.subscribe()`（见 [4.1](./1-transport-protocol)）订阅外层这一对，替代了过去从 agent 内部状态直接调用 replay adapter 的路径。
+`TURN_BEGIN` / `TURN_END` **每个用户驱动的 turn 各发一次**；`TURN_START` 是 turn 内**每次 LLM 迭代**都发（一个 turn 内可能很多次）。Replay 录制器是通过把一个 `ReplayAdapter` 拼接到 `agent.transport` 前面来接线的——由它把外层这一对翻译成录制器的 turn 写入（`ReplayAdapter._mirror`），并不是靠订阅。`Transport.subscribe()`（见 [4.1](./1-transport-protocol)）是留给*其他*旁路观察者的路径，且该 adapter 会把 subscribe 转发给内层 transport，所以 replay 开启时订阅照样有效。
 
 大多数 UI 只需要处理 `LLM_TEXT`、`THINKING`、`TOOL_START`、`TOOL_OUTPUT`、`TOOL_COMPLETE`、`TOOL_CONFIRMATION`、`AGENT_START`、`AGENT_END` 和 `ERROR`。
 其他事件主要服务于 session replay、审计、指标和调试。
@@ -65,7 +65,7 @@ TURN_END   -> (turn 结束；携带最终 assistant 文本 + status/error)
 |------|------|
 | 触发时机 | 每个用户驱动 turn 开始时**一次**，在任何 LLM 迭代之前 |
 | `data` | `{"user_message": "..."}` |
-| 典型用法 | 在 replay 日志 / 审计流中开一个新的 turn 帧；通过 `Transport.subscribe()` 订阅 |
+| 典型用法 | 通过 `Transport.subscribe()` 在审计 / 观察者流中开一个新的 turn 帧。（replay 录制器是另行接线的——走 `ReplayAdapter` 拼接，不是这个订阅。） |
 
 与 `TURN_START`（每个 LLM 迭代各发一次）语义不同。`TURN_BEGIN` 携带用户输入，并与 `TURN_END` 1:1 配对。
 
@@ -74,8 +74,22 @@ TURN_END   -> (turn 结束；携带最终 assistant 文本 + status/error)
 | 字段 | 说明 |
 |------|------|
 | 触发时机 | 每个用户驱动 turn 结束时**一次**，在最终 assistant 回复之后（或出错 / 被取消时） |
-| `data` | `{"final_text": "...", "status": "ok"\|"error"\|"cancelled", "error": None, "tool_count": 3}` |
+| `data` | `{"final_text": "...", "status": "ok"\|"error"\|"cancelled", "error": None, "tool_count": 3, "incomplete_reason": None}` |
 | 典型用法 | 关闭 turn 帧；刷出 per-turn 指标 —— `tool_count` 是这个 turn 内所有迭代里 LLM 发起的工具调用总数，宿主无需重放每个 `TOOL_START` 就能掂量这一 turn 的规模 |
+
+`incomplete_reason` 在普通 turn 上为 `None`。当 turn 结束但没有拿到完整的、模型撰写的答案时它会被置位，并说明原因：
+
+| 取值 | 含义 |
+|---|---|
+| `no_output` | 模型什么都没输出。 |
+| `reasoning_only` | 只有推理内容，没有答案正文。 |
+| `length_truncated` | 输出在 token 上限处被截断——要么是工具调用的参数被截断（harness 随即中止该 turn），要么是最终答案在半句处被切断。 |
+| `doom_loop` | 模型重复同一个调用，直至检测器 halt 了该 turn。 |
+| `llm_error` | LLM 调用本身失败（provider 5xx / 限流 / 认证）且重试后仍失败；`final_text` 里是 harness 的 `[LLM API error: …]` 提示，不是模型答案。 |
+
+这是**一套单一封闭的词表**：每一条 turn 结束路径都恰好提交其中一个取值，或对真实答案提交 `None`——不存在未被分类的结束。前两者表示 turn 正常结束但没有答案；中间两者表示 harness 停掉了一个不收敛的 turn；最后一个表示 provider 调用根本没产出一个 turn。（`max_iterations` 是第六种"结束但无完整答案"的方式，但它是刻意独立的一根轴——一个带自己退出码 4 和 `on_max_iterations` 交互的粘性 transport 标志，不是这里的取值。）
+
+优先用它来判断，而不要去字符串匹配 `final_text` —— harness 会在那里替换占位符或固定话术（包括现已被分类为 `llm_error` 的 `[LLM API error: …]` 提示），而 Stop hook 还可能装饰它，所以文本并不是可靠信号。被取消的 turn 不会通过 `incomplete_reason` 上报（它携带 `status: "cancelled"`）。`agentao run` 会把非 `None` 的值映射为非零退出码；其他宿主可以自行选择重试、追问或忽略。
 
 Replay 录制器靠它和 `TURN_BEGIN` 配对来界定一个 turn。它替代了运行时直接调用 replay adapter 的旧路径。
 

--- a/docs/guides/date-context.md
+++ b/docs/guides/date-context.md
@@ -1,47 +1,60 @@
-# Current Date Context Feature
+# 日期时间上下文注入
 
 ## 概述
 
-在系统提示词中自动添加当前日期和时间信息，帮助 LLM 理解时间上下文，提高时间相关任务的准确性。
+每个 turn 都会把当前日期和时间告诉 LLM，帮助它理解时间上下文，提高时间相关任务的准确性。
+
+日期**不在系统提示词里**——它作为 `<system-reminder>` 前置到**用户消息**上。这个区分是刻意的，见下文「为什么不放进系统提示词」。
 
 ## 实现
 
-### 修改内容
+**文件**: `agentao/runtime/chat_loop/_runner.py::ChatLoopRunner.run()`
 
-**文件**: `agentao/agent.py`
+每个 turn 开始时构造 reminder，前置到该 turn 的用户消息：
 
-1. **导入 datetime 模块**
-   ```python
-   from datetime import datetime
-   ```
+```python
+now = datetime.now()
+system_reminder = (
+    f"<system-reminder>\n"
+    f"Current Date/Time: {now.strftime('%Y-%m-%d %H:%M:%S')} ({now.strftime('%A')})\n"
+    f"</system-reminder>\n"
+)
+```
 
-2. **在 `_build_system_prompt()` 方法中添加日期信息**
-   ```python
-   # Get current date and time
-   now = datetime.now()
-   current_date = now.strftime("%Y-%m-%d")
-   current_time = now.strftime("%H:%M:%S")
-   current_datetime = now.strftime("%Y-%m-%d %H:%M:%S")
-   day_of_week = now.strftime("%A")
-   ```
+模型看到的用户消息形如：
 
-3. **将日期信息注入到系统提示词**
-   ```
-   Current Date and Time: 2026-02-11 14:40:58 (Wednesday)
-   ```
+```
+<system-reminder>
+Current Date/Time: 2026-02-11 14:40:58 (Wednesday)
+</system-reminder>
+今天的活动记一个日志文件
+```
+
+## 为什么不放进系统提示词
+
+系统提示词的**稳定前缀**（identity、operational guidelines、`<memory-stable>` 等）被刻意维持成逐 turn **逐字节相同**，好让 provider 的 prompt cache 能复用它（见 `agentao/prompts/builder.py::_build_sections()`）。
+
+时间每秒都在变。把它放进前缀，等于每个 turn 都让缓存失效——为了一行字，付掉整个前缀的缓存收益。放在用户消息里，前缀保持稳定，日期照样每 turn 刷新。
+
+这也是为什么 `tests/test_date_in_prompt.py` 同时断言两边：日期**必须**出现在用户消息里，且**必须不**出现在系统提示词里。任何把它挪回前缀的改动都会让测试变红。
 
 ## 日期格式
 
 - **完整格式**: `YYYY-MM-DD HH:MM:SS (Day of Week)`
 - **示例**: `2026-02-11 14:40:58 (Wednesday)`
 - **组成部分**:
-  - 日期: `2026-02-11` (ISO 8601 格式)
-  - 时间: `14:40:58` (24 小时制)
-  - 星期: `Wednesday` (英文全称)
+  - 日期: `2026-02-11`（ISO 8601）
+  - 时间: `14:40:58`（24 小时制）
+  - 星期: `Wednesday`（英文全称）
+
+取的是**本地时间**（`datetime.now()`，不带时区），即宿主进程所在时区。
 
 ## 使用场景
 
-### 1. 时间敏感任务
+时间敏感任务——「今天的日志」「这周的报告」「三天前那次提交」——模型不必猜今天几号，也不必调工具去问。
 
-```
-You: Create a log file for today's activities
+## 相关
+
+- `agentao/runtime/chat_loop/_runner.py` —— 注入点
+- `agentao/prompts/builder.py` —— 系统提示词分段与缓存边界
+- `tests/test_date_in_prompt.py` —— 双向断言

--- a/docs/guides/embed-for-agents.md
+++ b/docs/guides/embed-for-agents.md
@@ -358,6 +358,46 @@ For streaming assistant *text/tokens* (not on the stable contract),
 you must consume the internal `Transport` — accept that it may change
 between releases.
 
+### 6.1 `chat()` returning a string is not proof the model answered
+
+`chat()` / `arun()` hand back a `str`. On a turn where the model
+produced nothing, that string is the placeholder `[No response]` (or
+`[No text response]` for reasoning-without-answer); when the harness
+halts a turn that will not converge — tool calls repeatedly cut off at
+the token limit, or the same call looping — it is a canned abort
+string; and when the LLM call itself fails, it is a `[LLM API error: …]`
+notice. **All of these arrive as an ordinary return value.** A host that
+logs, stores, or returns the reply to a user will serve them as if the
+model had answered.
+
+Read `agent.last_turn` — the structured companion to the string return —
+before treating the reply as the model's:
+
+```python
+from agentao import TurnOutcome  # for the type hint; optional
+
+reply = agent.chat(prompt)
+outcome: TurnOutcome = agent.last_turn
+if not outcome.is_answer:
+    ...  # do not present `reply` as the model's answer;
+         # outcome.incomplete_reason says why (or outcome.status
+         # for a cancelled / errored turn)
+```
+
+`agent.last_turn` mirrors the `TURN_END` payload — `text`, `status`,
+`incomplete_reason` (a single closed vocabulary: `no_output` /
+`reasoning_only` / `length_truncated` / `doom_loop` / `llm_error`, or
+`None` for a real answer), `tool_count`, `error` — as a synchronous
+read-after, no subscription required. `outcome.is_answer` is the one
+check that folds all of it together: `True` only when the turn ended
+`"ok"` with nothing classifying it incomplete.
+
+This is a pull surface: it answers "how did the turn I just awaited
+end?". If instead you need the outcome *pushed* to an async observer
+that does not drive the turn, that is not projected onto the stable
+event contract yet — see the known gap in
+[`host-api.md`](../reference/host-api.md#known-gaps-neither-channel-covers-these-today).
+
 ---
 
 ## 7. Opt-in subsystems
@@ -439,6 +479,7 @@ must pass `logger=`. ([`EMBEDDING.md` §2](embedding.md#2-pure-injection-constru
 - [ ] LLM creds supplied (`llm_client` or `api_key`+`base_url`+`model`).
 - [ ] Every code path calls `agent.close()` (use `try/finally`).
 - [ ] Async host uses `arun()`, not `chat()` on the loop thread.
+- [ ] A turn that produced no answer is not presented as one (§6.1) — the reply string alone does not tell you.
 - [ ] If the host forwards images: `data`/`mimeType` validated, size/count capped host-side, and consumers of `agent.messages` tolerate the `<attachment …/>` degradation rewrite (§2).
 - [ ] Imports come from `agentao`, `agentao.embedding`, `agentao.host`, `agentao.host.protocols` only — no `agentao.runtime.*` / `AgentEvent` / `agentao.harness`.
 - [ ] Permission posture set explicitly; untrusted input → `sandbox_policy`.
@@ -457,10 +498,15 @@ agent = Agentao(working_directory=Path("/tmp/agentao-smoke"),
                 api_key=..., base_url=..., model=..., transport=NullTransport())
 try:
     out = agent.chat("Reply with the single word: ok")
-    assert "ok" in out.lower()
+    assert "ok" in out.lower()     # also rejects the §6.1 placeholders
 finally:
     agent.close()
 ```
+
+Assert on *content*, not truthiness. `assert out` or `assert len(out)`
+would pass on the `[No response]` placeholder — the string is
+non-empty, it just isn't an answer (§6.1). Matching expected content is
+what makes this smoke test able to fail.
 
 For the host-facing API and event contract specifics, the canonical
 reference is [`docs/reference/host-api.md`](../reference/host-api.md); for everything not

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -382,11 +382,35 @@ Full schema, tables, and lifecycle → [memory-management.md](../guides/memory-m
 | Code | Meaning |
 |---|---|
 | 0 | OK |
-| 1 | Runtime error |
+| 1 | Runtime error, or a turn that produced no answer (`runtime_error`, `empty_response`, `length_truncated`, `doom_loop`) |
 | 2 | Invalid usage / invalid spec |
 | 3 | Permission denied or interaction required |
 | 4 | Max iterations |
 | 130 | Interrupted (SIGINT) |
+
+`error.type` discriminates outcomes that share an exit code. Every turn the
+runtime classifies as having no complete answer (the five `reason` values
+below) exits 1 rather than 0, so a pipeline cannot read those as success — this
+is a single closed vocabulary with no unclassified ending. `error.reason`
+carries the exact variant — branch on `reason`, not on `message`:
+
+| `type` | `reason` | Meaning |
+|---|---|---|
+| `empty_response` | `no_output` | The model emitted nothing. |
+| `empty_response` | `reasoning_only` | Reasoning, but no answer text. |
+| `length_truncated` | `length_truncated` | Output cut off at the token limit — a tool call whose arguments were truncated (the harness then halts the turn), or a final answer cut off mid-sentence. |
+| `doom_loop` | `doom_loop` | The model repeated one call until the detector halted the turn. |
+| `runtime_error` | `llm_error` | The LLM API call failed (provider error / rate limit / auth) after retries; the message carries the provider's actual error. |
+
+`empty_response` means the model said nothing; `length_truncated` / `doom_loop`
+mean the harness halted a non-converging turn; `llm_error` means the provider
+call failed. All are classified last, so a rejection, max-iterations,
+cancellation, or raised error keeps its own more specific code.
+
+A turn can end this way *after* running tools — the model may do the work and
+then fail to summarize it. `tool_calls` reports how many ran and their side
+effects have already landed, so an `empty_response` failure does **not** imply
+the workspace is untouched.
 
 Full design rationale → [run-spec-parameters.md](../design/run-spec-parameters.md).
 

--- a/docs/reference/configuration.zh.md
+++ b/docs/reference/configuration.zh.md
@@ -353,11 +353,25 @@ prompt 组成规则与约定见 [CHATAGENT_MD_FEATURE.md](../guides/chatagent-md
 | Code | 含义 |
 |---|---|
 | 0 | OK |
-| 1 | 运行时错误 |
+| 1 | 运行时错误，或 turn 没有产出答案（`runtime_error`、`empty_response`、`length_truncated`、`doom_loop`） |
 | 2 | 无效用法 / 无效 spec |
 | 3 | 权限拒绝或需要交互 |
 | 4 | 达到最大迭代次数 |
 | 130 | 被打断（SIGINT） |
+
+`error.type` 用于区分共用同一退出码的不同结果。每一个被运行时分类为无完整答案的 turn（下表五种 `reason`）退出码都为 1 而不是 0——这样流水线就不会把它们当成成功；这是一套单一封闭的词表，不存在未被分类的结束。`error.reason` 携带精确变体——请基于 `reason` 分支，而不是 `message`：
+
+| `type` | `reason` | 含义 |
+|---|---|---|
+| `empty_response` | `no_output` | 模型什么都没输出。 |
+| `empty_response` | `reasoning_only` | 只有推理，没有答案正文。 |
+| `length_truncated` | `length_truncated` | 输出在 token 上限处被截断——要么是工具调用的参数被截断（harness 随即中止该 turn），要么是最终答案在半句处被切断。 |
+| `doom_loop` | `doom_loop` | 模型重复同一个调用，直至检测器 halt 了该 turn。 |
+| `runtime_error` | `llm_error` | LLM API 调用失败（provider 错误 / 限流 / 认证）且重试后仍失败；message 里带 provider 的真实报错。 |
+
+`empty_response` 表示模型什么都没说；`length_truncated` / `doom_loop` 表示 harness 停掉了一个不收敛的 turn；`llm_error` 表示 provider 调用失败。三者都在最后判定，因此权限拒绝、max-iterations、取消或抛出的错误都会保留各自更具体的退出码。
+
+turn 可能在**执行过工具之后**以这种方式结束——模型可能已经完成工作，只是没有做总结。`tool_calls` 会报告实际执行了多少次，其副作用**已经落盘**，因此 `empty_response` 失败**不**意味着工作区未被改动。
 
 完整设计动机 → [run-spec-parameters.zh.md](../design/run-spec-parameters.zh.md)。
 

--- a/docs/reference/host-api.md
+++ b/docs/reference/host-api.md
@@ -300,7 +300,7 @@ of this writing:
 
 | Family | Members |
 |---|---|
-| Turn / loop | `TURN_START` |
+| Turn / loop | `TURN_START`, `TURN_BEGIN`, `TURN_END` |
 | Tool execution (raw) | `TOOL_START`, `TOOL_OUTPUT`, `TOOL_COMPLETE`, `TOOL_RESULT` |
 | LLM call | `LLM_CALL_STARTED`, `LLM_CALL_COMPLETED`, `LLM_CALL_DELTA`, `LLM_CALL_IO`, `LLM_TEXT`, `THINKING` |
 | Sub-agent (raw) | `AGENT_START`, `AGENT_END` |
@@ -311,14 +311,20 @@ of this writing:
 | Errors | `ERROR` |
 
 Every `AgentEvent` carries a `schema_version: int` field; bumps are
-the *only* signal that a payload's shape changed.
+the *only* signal that a payload's shape changed. It is a **single
+value shared by every event type**, not a per-payload version — so a
+bump moves all of them at once, and a consumer pinned to the old value
+starts rejecting events it could otherwise have read. That asymmetry is
+why *additive* fields ship without a bump: an unknown key is free to
+ignore, whereas a bump is not. Reserve it for a field whose shape or
+meaning changed under a name consumers already read.
 
 ### Stability — the part that actually matters
 
 |  | `HostEvent` (this contract) | `AgentEvent` (`Transport`) |
 |---|---|---|
 | Schema snapshot in `docs/schema/`? | ✅ `host.events.v1.json` | ❌ |
-| Field rename / removal triggers version bump? | ✅ enforced by `tests/test_host_schema.py` | ⚠️ best-effort `schema_version` bump on the affected payload only |
+| Field rename / removal triggers version bump? | ✅ enforced by `tests/test_host_schema.py` | ⚠️ best-effort `schema_version` bump — global, so it moves every event type |
 | Redaction / projection layer? | ✅ `agentao/host/projection.py` strips raw input/output | ❌ raw payloads (LLM_CALL_IO can contain full prompts and tool I/O) |
 | Cross-version compatibility audit before release? | ✅ part of the release checklist | ❌ |
 | Safe to forward over a long-lived wire? | ✅ | ⚠️ only after you pin `schema_version` and own the upgrade path |
@@ -345,6 +351,23 @@ the *only* signal that a payload's shape changed.
 - **LLM rate-limit signal.** Provider-side 429 surfaces only as
   `ERROR` text. Promotion to a structured `LLMCallEvent` with
   `error_type="rate_limited"` is part of the same plan.
+- **Turn outcome as a streamed event (push).** The outcome itself —
+  whether the model actually answered — *is* available synchronously:
+  `agent.last_turn` returns a `TurnOutcome` (`text`, `status`,
+  `incomplete_reason` over a single closed vocabulary — `no_output`,
+  `reasoning_only`, `length_truncated`, `doom_loop`, `llm_error`, or
+  `None`; `tool_count`; `error`), and `.is_answer` folds it into one
+  check. That is a **pull** surface: it answers "how did the turn I just
+  awaited end?", which covers `chat()` / `arun()` callers, `agentao
+  run`, and any embedder. What is **not** on the stable contract is the
+  **push** shape — a `HostEvent` an async observer that does *not* drive
+  the turn could subscribe to. `HostEvent` covers tool, sub-agent, and
+  permission lifecycle only, so such an observer must fall back to the
+  internal `Transport`'s `TURN_END` (unprojected, `schema_version`
+  caveat above). This is **not** currently tracked in
+  [PUBLIC_EVENT_PROMOTION_PLAN](../history/implementation/public-event-promotion-plan.md);
+  that plan is scoped to `MCPLifecycleEvent` and `LLMCallEvent`, and a
+  turn-outcome event would be a new pillar rather than a scope tweak.
 
 ## Non-goals
 

--- a/docs/reference/host-api.zh.md
+++ b/docs/reference/host-api.zh.md
@@ -245,7 +245,7 @@ for ev in events:
 
 | 家族 | 成员 |
 |---|---|
-| Turn / loop | `TURN_START` |
+| Turn / loop | `TURN_START`、`TURN_BEGIN`、`TURN_END` |
 | 工具执行（原始） | `TOOL_START`、`TOOL_OUTPUT`、`TOOL_COMPLETE`、`TOOL_RESULT` |
 | LLM 调用 | `LLM_CALL_STARTED`、`LLM_CALL_COMPLETED`、`LLM_CALL_DELTA`、`LLM_CALL_IO`、`LLM_TEXT`、`THINKING` |
 | 子 Agent（原始） | `AGENT_START`、`AGENT_END` |
@@ -256,14 +256,18 @@ for ev in events:
 | 错误 | `ERROR` |
 
 每个 `AgentEvent` 都带 `schema_version: int` 字段；这是载荷形状变化
-的**唯一**信号。
+的**唯一**信号。它是**所有事件类型共用的单个值**，不是按载荷分版本的
+——bump 一次就把全部事件一起推高，而 pin 在旧值上的消费方会因此开始
+拒收本来读得懂的事件。正是这种不对称决定了**新增**字段不 bump：未知的
+键忽略掉就是了，bump 却没这个退路。只有当消费方已经在读的某个名字下、
+形状或语义发生了变化，才动它。
 
 ### 稳定性——真正决定怎么用的部分
 
 |  | `HostEvent`（本合约） | `AgentEvent`（`Transport`） |
 |---|---|---|
 | `docs/schema/` 下有 schema 快照？ | ✅ `host.events.v1.json` | ❌ |
-| 字段重命名/删除会触发版本 bump？ | ✅ 由 `tests/test_host_schema.py` 强制 | ⚠️ 受影响载荷上 best-effort `schema_version` bump |
+| 字段重命名/删除会触发版本 bump？ | ✅ 由 `tests/test_host_schema.py` 强制 | ⚠️ best-effort `schema_version` bump —— 全局的，一动就动所有事件类型 |
 | 有脱敏/投影层？ | ✅ `agentao/host/projection.py` 剥掉原始 input/output | ❌ 原始载荷（LLM_CALL_IO 可含完整 prompt 与工具 I/O） |
 | 发布前跨版本兼容性审计？ | ✅ 是发布检查表项 | ❌ |
 | 适合走长期稳定的 wire 协议？ | ✅ | ⚠️ 仅当你 pin 住 `schema_version` 并自负升级路径 |
@@ -287,6 +291,19 @@ for ev in events:
 - **LLM 速率限制信号。** Provider 端 429 只能从 `ERROR` 的文本里
   嗅出来。promote 成结构化的 `LLMCallEvent(error_type="rate_limited")`
   也在同一份 plan 里。
+- **Turn 结果作为流式事件（push）。** 结果本身——模型到底答没答——已经
+  可以同步拿到：`agent.last_turn` 返回一个 `TurnOutcome`（`text`、`status`、
+  一套单一封闭词表的 `incomplete_reason`——`no_output`、`reasoning_only`、
+  `length_truncated`、`doom_loop`、`llm_error`，或 `None`；`tool_count`；
+  `error`），`.is_answer` 把它折成一个判断。这是一个 **pull** 面：它回答
+  "我刚 await 完的这个 turn 是怎么结束的"，覆盖 `chat()` / `arun()` 调用方、
+  `agentao run` 和任何嵌入方。**尚未**进稳定契约的是 **push** 形态——一个
+  不驱动 turn 的异步观察者可以订阅的 `HostEvent`。`HostEvent` 只覆盖工具、
+  子 agent、权限三类生命周期，所以这类观察者只能退回到内部 `Transport` 的
+  `TURN_END`（未投射，且有上文的 `schema_version` 警告）。这条 **尚未**记录在
+  [PUBLIC_EVENT_PROMOTION_PLAN](../history/implementation/public-event-promotion-plan.md)
+  里；那份 plan 的范围是 `MCPLifecycleEvent` 和 `LLMCallEvent`，turn 结果
+  事件属于新开一根支柱，不是范围微调。
 
 ## 非目标
 

--- a/tests/test_empty_final_response.py
+++ b/tests/test_empty_final_response.py
@@ -4,12 +4,17 @@ Byte-level reasoning backends (Kimi, GLM, Qwen-via-Ollama) occasionally end a
 turn with no text and no tool calls. Persisting ``{"role": "assistant",
 "content": ""}`` leaves a contentless message that strict API proxies reject on
 the next turn. The chat loop substitutes a neutral placeholder instead.
+
+The placeholder keeps history valid but is not an answer, so TURN_END also
+classifies the turn via ``incomplete_reason`` — that is what lets ``agentao
+run`` exit non-zero instead of handing a pipeline the placeholder as a result.
 """
 
 from pathlib import Path
 from types import SimpleNamespace
 
 from agentao import Agentao
+from agentao.transport import EventType
 
 
 def _fake_response(content, *, reasoning=None):
@@ -25,6 +30,18 @@ def _make_agent() -> Agentao:
         model="test-model",
         working_directory=Path.cwd(),
     )
+
+
+def _capture_incomplete_reason(agent: Agentao) -> list:
+    """Collect the ``incomplete_reason`` field of every TURN_END the agent emits."""
+    seen: list = []
+
+    def _observer(event) -> None:
+        if getattr(event, "type", None) == EventType.TURN_END:
+            seen.append((getattr(event, "data", None) or {}).get("incomplete_reason"))
+
+    agent.transport.subscribe(_observer)
+    return seen
 
 
 def _assert_no_contentless_assistant_message(agent: Agentao) -> None:
@@ -73,9 +90,360 @@ def test_nonempty_final_content_passes_through():
     assert response == "the answer is 42"
 
 
+# ---------------------------------------------------------------------------
+# TURN_END classification — the signal ``agentao run`` exits non-zero on
+# ---------------------------------------------------------------------------
+
+
+def test_turn_end_reports_no_output():
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _fake_response("   \n  ")
+    seen = _capture_incomplete_reason(agent)
+
+    agent.chat("hi")
+
+    assert seen == ["no_output"]
+
+
+def test_turn_end_distinguishes_reasoning_only_turn():
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _fake_response(
+        "", reasoning="thought hard"
+    )
+    seen = _capture_incomplete_reason(agent)
+
+    agent.chat("hi")
+
+    assert seen == ["reasoning_only"]
+
+
+def test_turn_end_reports_none_for_real_answer():
+    """The guard against false failures: a normal turn must never classify.
+
+    ``agentao run`` maps a non-None ``incomplete_reason`` to a non-zero exit, so
+    a turn that actually answered leaking a classification here would fail runs
+    that succeeded.
+    """
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _fake_response("the answer is 42")
+    seen = _capture_incomplete_reason(agent)
+
+    agent.chat("hi")
+
+    assert seen == [None]
+
+
+def test_answer_matching_placeholder_prefix_is_not_classified_empty():
+    """Only the exact placeholder counts — an answer that merely starts with it
+    is real model output and must not be reported as empty."""
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _fake_response(
+        "[No response] was received from the upstream service, so I retried."
+    )
+    seen = _capture_incomplete_reason(agent)
+
+    agent.chat("hi")
+
+    assert seen == [None]
+
+
+# ---------------------------------------------------------------------------
+# Harness-halted turns — the other family of "no complete answer". These end
+# with a canned harness string, which without a classification `agentao run`
+# would serve to a pipeline at exit 0 as if the model had said it.
+# ---------------------------------------------------------------------------
+
+
+def _tool_call_response(finish_reason="stop"):
+    tc = SimpleNamespace(
+        id="call_0", type="function",
+        function=SimpleNamespace(name="read_file", arguments='{"path": "x"}'),
+    )
+    message = SimpleNamespace(content="", tool_calls=[tc], reasoning_content=None)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+        usage=None, model="test-model",
+    )
+
+
+def test_repeated_length_truncation_abort_is_classified():
+    """The model keeps getting cut off mid-tool-call; the harness gives up.
+
+    Nothing ran, and the returned text is the harness's own explanation — not
+    a model answer — so the turn must not read as a success.
+    """
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _tool_call_response("length")
+    seen = _capture_incomplete_reason(agent)
+
+    final = agent.chat("hi")
+
+    assert "cut off at the output-token limit" in final
+    assert seen == ["length_truncated"]
+
+
+def test_doom_loop_halt_is_classified(monkeypatch):
+    """The doom-loop detector halts the turn; the canned halt notice is not an
+    answer the model gave."""
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _tool_call_response()
+    # Report the loop as tripped on the first execute, which is what the real
+    # detector does once an identical call repeats past its threshold.
+    monkeypatch.setattr(
+        agent.tool_runner, "execute",
+        lambda calls, cancellation_token=None: (True, []),
+    )
+    seen = _capture_incomplete_reason(agent)
+
+    final = agent.chat("hi")
+
+    assert "doom-loop" in final
+    assert seen == ["doom_loop"]
+
+
+def _text_response(content, *, finish_reason="stop", reasoning=None):
+    message = SimpleNamespace(content=content, tool_calls=None, reasoning_content=reasoning)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+        usage=None, model="test-model",
+    )
+
+
+def test_truncated_final_text_is_classified_length_truncated():
+    """A final answer with no tool calls, cut off mid-sentence at the output-
+    token limit (``finish_reason=length``), is a partial answer — it must not
+    exit 0 as a complete one. The partial text is kept in history."""
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _text_response(
+        "Here is the summary of the migra", finish_reason="length",
+    )
+    seen = _capture_incomplete_reason(agent)
+
+    final = agent.chat("hi")
+
+    assert final == "Here is the summary of the migra"  # partial text preserved
+    assert seen == ["length_truncated"]
+
+
+def test_truncated_final_text_survives_vendor_finish_reason_variants():
+    """Provider-neutral: gateways spell output-limit truncation differently."""
+    for fr in ("max_tokens", "model_length", "MAX_TOKENS"):
+        agent = _make_agent()
+        agent._llm_call = lambda messages, tools, token, _fr=fr: _text_response(
+            "partial", finish_reason=_fr,
+        )
+        seen = _capture_incomplete_reason(agent)
+
+        agent.chat("hi")
+
+        assert seen == ["length_truncated"], f"finish_reason={fr!r}"
+
+
+def test_empty_reasoning_truncation_prefers_length_over_reasoning_only():
+    """A reasoning model that exhausts the token budget mid-reasoning returns
+    empty content + reasoning + ``finish_reason=length``. The actionable fact is
+    "ran out of tokens" (retry smaller), so it classifies length_truncated, not
+    reasoning_only — otherwise the diff's own retry guidance is inverted."""
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _text_response(
+        "", finish_reason="length", reasoning="thinking so hard I ran out of room",
+    )
+    seen = _capture_incomplete_reason(agent)
+
+    response = agent.chat("hi")
+
+    assert response == "[No text response]"  # placeholder still substituted
+    assert seen == ["length_truncated"]
+
+
+def test_complete_final_text_is_not_classified():
+    """The false-failure guard for the truncation path: a normal ``stop`` finish
+    on real content must never classify, even for a long answer."""
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _text_response(
+        "a complete answer", finish_reason="stop",
+    )
+    seen = _capture_incomplete_reason(agent)
+
+    assert agent.chat("hi") == "a complete answer"
+    assert seen == [None]
+
+
+def test_llm_api_error_is_classified_llm_error():
+    """The LLM call failing outright (provider 5xx / rate limit / auth after
+    retries) is swallowed into a ``[LLM API error: …]`` notice and returned.
+
+    That notice is the harness's, not a model answer, so the turn must classify
+    ``llm_error`` — otherwise ``agentao run`` serves the notice at exit 0. This
+    return path bypasses ``_resolve_stop_hook``, so it is the one most likely to
+    be forgotten; the classification is committed at the return site itself.
+    """
+    agent = _make_agent()
+
+    def _boom(messages, tools, token):
+        raise RuntimeError("502 Bad Gateway")
+
+    agent._llm_call = _boom
+    seen = _capture_incomplete_reason(agent)
+
+    final = agent.chat("hi")
+
+    assert final.startswith("[LLM API error:")
+    assert "502 Bad Gateway" in final
+    assert seen == ["llm_error"]
+
+
+# ---------------------------------------------------------------------------
+# Stop-hook interaction — the classification must survive decoration, and must
+# not survive the hook actually supplying an answer.
+# ---------------------------------------------------------------------------
+
+
+def _stub_stop(monkeypatch, *results):
+    """Patch the runner's Stop dispatch to yield ``results`` in order (the last
+    repeats), so a test can drive block / force-continue / decorate."""
+    from agentao.runtime.chat_loop._runner import ChatLoopRunner
+
+    calls = {"n": 0}
+
+    def _dispatch(self, *, turn_end_reason, last_assistant_message):
+        i = min(calls["n"], len(results) - 1)
+        calls["n"] += 1
+        return results[i]
+
+    monkeypatch.setattr(ChatLoopRunner, "_dispatch_stop", _dispatch)
+
+
+def test_additional_contexts_decoration_stays_classified_empty(monkeypatch):
+    """A Stop hook that decorates the placeholder has not answered the turn.
+
+    The hook appends a ``<stop-hook>`` block to "[No response]", so the
+    returned text is no longer the bare placeholder — but the model still
+    never answered, and the run must still report the turn empty.
+    """
+    from agentao.plugins.models import StopHookResult
+
+    _stub_stop(monkeypatch, StopHookResult(
+        matched_rule_count=1, additional_contexts=["audit-note"],
+    ))
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _fake_response("")
+    seen = _capture_incomplete_reason(agent)
+
+    final = agent.chat("hi")
+
+    assert "audit-note" in final, "expected the hook to decorate the answer"
+    assert final.startswith("[No response]")
+    assert seen == ["no_output"], "decoration must not mask an empty turn"
+
+
+def test_blocking_stop_hook_clears_empty_classification(monkeypatch):
+    """A blocking hook replaces the text the caller receives, so the turn is
+    no longer answerless and must not be reported empty."""
+    from agentao.plugins.models import StopHookResult
+
+    _stub_stop(monkeypatch, StopHookResult(
+        matched_rule_count=1, blocking_error="not so fast",
+    ))
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _fake_response("")
+    seen = _capture_incomplete_reason(agent)
+
+    final = agent.chat("hi")
+
+    assert "[Blocked by Stop hook]" in final
+    assert seen == [None]
+
+
+def test_blocking_stop_hook_does_not_mask_a_doom_loop_halt(monkeypatch):
+    """A blocking hook substitutes its own text, but a doom-looped turn still
+    never converged — hook text is not a model answer, so the halt
+    classification must survive and keep ``agentao run`` at exit 1."""
+    from agentao.plugins.models import StopHookResult
+
+    _stub_stop(monkeypatch, StopHookResult(
+        matched_rule_count=1, blocking_error="policy gate",
+    ))
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _tool_call_response()
+    monkeypatch.setattr(
+        agent.tool_runner, "execute",
+        lambda calls, cancellation_token=None: (True, []),
+    )
+    seen = _capture_incomplete_reason(agent)
+
+    final = agent.chat("hi")
+
+    assert "[Blocked by Stop hook]" in final
+    assert seen == ["doom_loop"], "a blocking hook must not mask a harness halt"
+
+
+def test_blocking_stop_hook_does_not_mask_length_truncation(monkeypatch):
+    """The length-truncation twin of the doom-loop block case."""
+    from agentao.plugins.models import StopHookResult
+
+    _stub_stop(monkeypatch, StopHookResult(
+        matched_rule_count=1, blocking_error="policy gate",
+    ))
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _tool_call_response("length")
+    seen = _capture_incomplete_reason(agent)
+
+    final = agent.chat("hi")
+
+    assert "[Blocked by Stop hook]" in final
+    assert seen == ["length_truncated"]
+
+
+def test_force_continue_to_a_real_answer_is_not_reported_empty(monkeypatch):
+    """An empty iteration that the hook forces past must not stick to a turn
+    that goes on to answer."""
+    from agentao.plugins.models import StopHookResult
+
+    _stub_stop(
+        monkeypatch,
+        StopHookResult(matched_rule_count=1, force_continue=True,
+                       follow_up_message="try again"),
+        StopHookResult(matched_rule_count=1),
+    )
+    replies = iter([_fake_response(""), _fake_response("the answer is 42")])
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: next(replies)
+    seen = _capture_incomplete_reason(agent)
+
+    final = agent.chat("hi")
+
+    assert final == "the answer is 42"
+    assert seen == [None], "an earlier empty iteration must not stick"
+
+
+def test_cancelled_stream_is_not_reported_as_an_empty_answer():
+    """A token cancelled mid-stream makes the LLM return a normally-built
+    empty message without raising, so the turn reaches the ordinary ending
+    site with status "ok" — it must be reported as interrupted, not empty."""
+    from agentao.cancellation import CancellationToken
+
+    agent = _make_agent()
+    token = CancellationToken()
+
+    def _llm(messages, tools, cancellation_token):
+        token.cancel("sigint")
+        return _fake_response("")
+
+    agent._llm_call = _llm
+    seen = _capture_incomplete_reason(agent)
+
+    agent.chat("hi", cancellation_token=token)
+
+    assert seen == [None], "a cancelled turn must not be reported empty"
+
+
 if __name__ == "__main__":
-    test_empty_final_content_substituted_with_placeholder()
-    test_none_final_content_treated_as_empty()
-    test_empty_final_content_with_reasoning_gets_distinct_marker()
-    test_nonempty_final_content_passes_through()
-    print("ok")
+    # Half the tests here take a ``monkeypatch`` fixture and cannot run outside
+    # pytest, so a hand-rolled call list would silently skip them and still
+    # print "ok". Delegate to pytest so direct invocation runs the whole file.
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_last_turn_outcome.py
+++ b/tests/test_last_turn_outcome.py
@@ -1,0 +1,151 @@
+"""``agent.last_turn`` — the structured read-after companion to ``chat()``.
+
+``chat()`` returns the turn's text as a ``str``; ``last_turn`` is how a host
+that cannot subscribe to the internal Transport tells a real answer from a
+placeholder / canned notice / LLM-error string. It must mirror the gated
+``TURN_END`` classification exactly.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from agentao import Agentao, TurnOutcome
+from agentao.cancellation import CancellationToken
+
+
+def _make_agent() -> Agentao:
+    return Agentao(
+        api_key="test-key",
+        base_url="https://example.test/v1",
+        model="test-model",
+        working_directory=Path.cwd(),
+    )
+
+
+def _text_response(content, *, finish_reason="stop", reasoning=None):
+    message = SimpleNamespace(content=content, tool_calls=None, reasoning_content=reasoning)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+        usage=None, model="test-model",
+    )
+
+
+def test_top_level_export():
+    """``from agentao import TurnOutcome`` works and needs no LLM stack."""
+    assert TurnOutcome.__name__ == "TurnOutcome"
+
+
+def test_last_turn_is_none_before_first_turn():
+    agent = _make_agent()
+    assert agent.last_turn is None
+
+
+def test_real_answer_is_reported_as_an_answer():
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _text_response("the answer is 42")
+
+    reply = agent.chat("hi")
+
+    outcome = agent.last_turn
+    assert isinstance(outcome, TurnOutcome)
+    assert outcome.text == reply == "the answer is 42"
+    assert outcome.status == "ok"
+    assert outcome.incomplete_reason is None
+    assert outcome.is_answer is True
+
+
+def test_empty_turn_is_not_an_answer():
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _text_response("")
+
+    agent.chat("hi")
+
+    outcome = agent.last_turn
+    assert outcome.incomplete_reason == "no_output"
+    assert outcome.is_answer is False
+    assert outcome.text == "[No response]"
+
+
+def test_llm_error_turn_is_not_an_answer():
+    """A swallowed LLM failure ends with status "ok" (no exception propagates),
+    so ``is_answer`` must lean on ``incomplete_reason``, not status alone."""
+    agent = _make_agent()
+
+    def _boom(messages, tools, token):
+        raise RuntimeError("502 Bad Gateway")
+
+    agent._llm_call = _boom
+
+    agent.chat("hi")
+
+    outcome = agent.last_turn
+    assert outcome.status == "ok"
+    assert outcome.incomplete_reason == "llm_error"
+    assert outcome.is_answer is False
+    assert "502 Bad Gateway" in outcome.text
+
+
+def test_cancelled_turn_is_not_reported_as_incomplete():
+    """A mid-stream cancellation carries status "cancelled" and, per the wire
+    gate, a ``None`` incomplete_reason — not a misclassification as empty."""
+    agent = _make_agent()
+    token = CancellationToken()
+
+    def _llm(messages, tools, cancellation_token):
+        token.cancel("sigint")
+        return _text_response("")
+
+    agent._llm_call = _llm
+
+    agent.chat("hi", cancellation_token=token)
+
+    outcome = agent.last_turn
+    assert outcome.status == "cancelled"
+    assert outcome.incomplete_reason is None
+    assert outcome.is_answer is False
+
+
+def test_last_turn_mirrors_the_turn_end_wire_field():
+    """The read-after and the TURN_END event must never disagree — both are
+    fed from the same single gated value in ``runtime/turn.py``."""
+    from agentao.transport import EventType
+
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _text_response(
+        "partial", finish_reason="length",
+    )
+    seen = []
+    agent.transport.subscribe(
+        lambda ev: seen.append((getattr(ev, "data", None) or {}))
+        if getattr(ev, "type", None) == EventType.TURN_END else None
+    )
+
+    agent.chat("hi")
+
+    wire = [d for d in seen if d][0]
+    outcome = agent.last_turn
+    assert wire["incomplete_reason"] == outcome.incomplete_reason == "length_truncated"
+    assert wire["status"] == outcome.status
+    assert wire["final_text"] == outcome.text
+    assert wire["tool_count"] == outcome.tool_count
+
+
+def test_frozen():
+    """``TurnOutcome`` is immutable — a host cannot mutate a reported fact."""
+    import dataclasses
+
+    outcome = TurnOutcome(text="x", status="ok", incomplete_reason=None, tool_count=0)
+    try:
+        outcome.text = "y"  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("TurnOutcome should be frozen")
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -311,6 +311,36 @@ def _make_adapter(tmp_path: Path):
     return ReplayAdapter(inner, rec), rec
 
 
+def test_adapter_forwards_subscribe_to_inner(tmp_path):
+    """Splicing the adapter over ``agent.transport`` (replay on) must not strip
+    the inner transport's subscriber channel.
+
+    ``incomplete_reason`` rides on TURN_END, which a host observes via
+    ``agent.transport.subscribe``. If the adapter omitted ``subscribe``, that
+    call would raise (or, after the documented ``getattr`` probe, silently
+    register nothing) the moment replay was enabled — losing the only signal
+    that distinguishes an answerless turn.
+    """
+    from agentao.transport.base import Transport
+
+    adapter, rec = _make_adapter(tmp_path)
+    # Restores Protocol conformance — subscribe is part of the interface.
+    assert isinstance(adapter, Transport)
+
+    seen = []
+    unsubscribe = adapter.subscribe(lambda e: seen.append(e))
+    adapter.emit(AgentEvent(
+        EventType.TURN_END,
+        {"final_text": "[No response]", "status": "ok", "incomplete_reason": "no_output"},
+    ))
+    assert [e.data.get("incomplete_reason") for e in seen] == ["no_output"]
+
+    unsubscribe()
+    adapter.emit(AgentEvent(EventType.TURN_END, {"final_text": "x", "status": "ok"}))
+    assert len(seen) == 1, "unsubscribe must stop delivery"
+    rec.close()
+
+
 def test_adapter_turn_lifecycle(tmp_path):
     adapter, rec = _make_adapter(tmp_path)
     tid = adapter.begin_turn("hello")
@@ -332,6 +362,42 @@ def test_adapter_turn_lifecycle(tmp_path):
     # All events share the same turn_id for this chat()-equivalent turn.
     turn_ids = {e["turn_id"] for e in events if e.get("turn_id")}
     assert turn_ids == {tid}
+
+
+def test_adapter_records_empty_response_from_turn_end(tmp_path):
+    """A turn the model never answered must be identifiable in the replay.
+
+    ``status`` stays "ok" — the runtime completed the turn normally — so
+    without the discriminator a triager opening the replay of a run that
+    exited non-zero would see a successful turn carrying a placeholder.
+    """
+    adapter, rec = _make_adapter(tmp_path)
+    adapter.begin_turn("hello")
+    adapter.emit(AgentEvent(EventType.TURN_END, {
+        "final_text": "[No response]", "status": "ok", "error": None,
+        "tool_count": 2, "incomplete_reason": "no_output",
+    }))
+    rec.close()
+
+    tc = [e for e in ReplayReader(rec.path).events()
+          if e["kind"] == "turn_completed"][0]
+    assert tc["payload"]["incomplete_reason"] == "no_output"
+    assert tc["payload"]["status"] == "ok"
+    assert tc["payload"]["tool_count"] == 2
+
+
+def test_adapter_omits_empty_response_on_a_normal_turn(tmp_path):
+    adapter, rec = _make_adapter(tmp_path)
+    adapter.begin_turn("hello")
+    adapter.emit(AgentEvent(EventType.TURN_END, {
+        "final_text": "the answer is 42", "status": "ok", "error": None,
+        "tool_count": 0, "incomplete_reason": None,
+    }))
+    rec.close()
+
+    tc = [e for e in ReplayReader(rec.path).events()
+          if e["kind"] == "turn_completed"][0]
+    assert "incomplete_reason" not in tc["payload"]
 
 
 def test_adapter_multiple_tools_share_turn_id(tmp_path):

--- a/tests/test_run_subcommand.py
+++ b/tests/test_run_subcommand.py
@@ -18,6 +18,7 @@ import io
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List
 from unittest.mock import patch
 
@@ -282,6 +283,304 @@ def test_format_json_emits_structured_envelope(
     assert payload["final_text"] == "stub final text"
     assert payload["cwd"]
     assert payload["model"] == "stub-model"
+
+
+# ---------------------------------------------------------------------------
+# Empty model turn — must not read as success
+# ---------------------------------------------------------------------------
+
+
+def _emit_incomplete_turn(kind: str, final_text: str):
+    """Build a ``chat`` stub that ends the turn the way the runtime does when
+    the model returns no usable answer."""
+    from agentao.transport import AgentEvent, EventType
+
+    def chat(self, prompt, max_iterations=100, cancellation_token=None):
+        self.transport.emit(AgentEvent(EventType.TURN_END, {
+            "final_text": final_text,
+            "status": "ok",
+            "error": None,
+            "tool_count": 0,
+            "incomplete_reason": kind,
+        }))
+        return final_text
+
+    return chat
+
+
+def _real_turn_end_payload(content, *, reasoning=None) -> Dict[str, Any]:
+    """Drive a real Agentao turn and return the TURN_END payload it emits.
+
+    The other tests here hand-write that payload, which leaves the producer
+    (``runtime/turn.py``) and this module's reader (``run.py``) agreeing only
+    by coincidence of a string literal. This reaches for the real thing so the
+    seam is covered.
+    """
+    from agentao import Agentao
+    from agentao.transport import EventType
+
+    agent = Agentao(
+        api_key="test-key", base_url="https://example.test/v1",
+        model="test-model", working_directory=Path.cwd(),
+    )
+    message = SimpleNamespace(
+        content=content, tool_calls=None, reasoning_content=reasoning,
+    )
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        usage=None, model="test-model",
+    )
+    agent._llm_call = lambda messages, tools, token: response
+
+    seen: List[Dict[str, Any]] = []
+    agent.transport.subscribe(
+        lambda ev: seen.append(dict(getattr(ev, "data", None) or {}))
+        if getattr(ev, "type", None) == EventType.TURN_END else None
+    )
+    agent.chat("hi")
+    assert seen, "real turn emitted no TURN_END"
+    return seen[-1]
+
+
+def test_run_consumes_the_real_runtime_turn_end_payload(
+    monkeypatch, tmp_path, stub_pipeline, capsys,
+):
+    """Bind the producer to the consumer.
+
+    Feeding run.py the payload the *real* runtime emits means renaming the
+    field in turn.py breaks this test, instead of silently disabling the guard
+    while every hand-written-payload test stays green.
+    """
+    payload = _real_turn_end_payload("   \n  ")
+    assert payload["incomplete_reason"] == "no_output", (
+        "real runtime stopped classifying an empty turn"
+    )
+
+    captured, StubAgent = stub_pipeline
+    from agentao.transport import AgentEvent, EventType
+
+    def chat(self, prompt, max_iterations=100, cancellation_token=None):
+        self.transport.emit(AgentEvent(EventType.TURN_END, payload))
+        return payload["final_text"]
+
+    monkeypatch.setattr(StubAgent, "chat", chat)
+    _no_stdin(monkeypatch)
+    from agentao.cli import run
+
+    rc = run._execute_with_args(_build_args(prompt="hi", output_format="json"))
+
+    assert rc == run.EXIT_RUNTIME_ERROR
+    assert json.loads(capsys.readouterr().out)["error"]["type"] == "empty_response"
+
+
+def test_empty_turn_exits_non_zero_with_envelope(
+    monkeypatch, tmp_path, stub_pipeline, capsys,
+):
+    """The regression this guards: an empty model turn used to exit 0 with the
+    bare placeholder as ``final_text``, indistinguishable from a real answer."""
+    captured, StubAgent = stub_pipeline
+    monkeypatch.setattr(
+        StubAgent, "chat", _emit_incomplete_turn("no_output", "[No response]"),
+    )
+    _no_stdin(monkeypatch)
+    from agentao.cli import run
+
+    args = _build_args(prompt="hi", output_format="json")
+    rc = run._execute_with_args(args)
+
+    assert rc == run.EXIT_RUNTIME_ERROR
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "error"
+    assert payload["error"]["type"] == "empty_response"
+    # The placeholder must never be served as the result.
+    assert payload.get("final_text") is None
+
+
+def test_reasoning_only_turn_reports_distinct_diagnostic(
+    monkeypatch, tmp_path, stub_pipeline, capsys,
+):
+    captured, StubAgent = stub_pipeline
+    monkeypatch.setattr(
+        StubAgent, "chat",
+        _emit_incomplete_turn("reasoning_only", "[No text response]"),
+    )
+    _no_stdin(monkeypatch)
+    from agentao.cli import run
+
+    args = _build_args(prompt="hi", output_format="json")
+    rc = run._execute_with_args(args)
+
+    assert rc == run.EXIT_RUNTIME_ERROR
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["type"] == "empty_response"
+    # Structural discriminator, not a substring of a human-facing sentence.
+    assert payload["error"]["reason"] == "reasoning_only"
+
+
+def test_empty_turn_text_mode_writes_stderr_diagnostic(
+    monkeypatch, tmp_path, stub_pipeline, capsys,
+):
+    """Text mode suppresses ``final_text`` on error, so without the stderr
+    diagnostic a non-zero exit would carry no explanation at all."""
+    captured, StubAgent = stub_pipeline
+    monkeypatch.setattr(
+        StubAgent, "chat", _emit_incomplete_turn("no_output", "[No response]"),
+    )
+    _no_stdin(monkeypatch)
+    from agentao.cli import run
+
+    args = _build_args(prompt="hi", output_format="text")
+    rc = run._execute_with_args(args)
+
+    assert rc == run.EXIT_RUNTIME_ERROR
+    streams = capsys.readouterr()
+    assert streams.out.strip() == ""
+    assert "empty response" in streams.err
+
+
+@pytest.mark.parametrize(
+    "reason, expected_type, expected_phrase",
+    [
+        ("length_truncated", "length_truncated", "cut off at the token limit"),
+        ("doom_loop", "doom_loop", "doom-loop detector"),
+    ],
+)
+def test_harness_halted_turn_exits_non_zero_with_own_type(
+    monkeypatch, tmp_path, stub_pipeline, capsys,
+    reason, expected_type, expected_phrase,
+):
+    """A turn the harness halted must not exit 0 serving its canned string.
+
+    These get their own ``type`` rather than ``empty_response``: the model did
+    answer-ish things, the harness cut the turn short, and a pipeline may want
+    to retry those differently from "the model said nothing".
+    """
+    captured, StubAgent = stub_pipeline
+    monkeypatch.setattr(
+        StubAgent, "chat", _emit_incomplete_turn(reason, "[halted]"),
+    )
+    _no_stdin(monkeypatch)
+    from agentao.cli import run
+
+    rc = run._execute_with_args(_build_args(prompt="hi", output_format="json"))
+
+    assert rc == run.EXIT_RUNTIME_ERROR
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["type"] == expected_type
+    assert payload["error"]["reason"] == reason
+    assert expected_phrase in payload["error"]["message"]
+    assert payload.get("final_text") is None
+
+
+def test_llm_error_turn_exits_non_zero_and_surfaces_provider_message(
+    monkeypatch, tmp_path, stub_pipeline, capsys,
+):
+    """An LLM call that failed outright must not exit 0 serving its own
+    ``[LLM API error: …]`` notice as the model's answer. It exits 1 as
+    ``runtime_error`` with ``reason: "llm_error"``, and the envelope surfaces
+    the provider's actual message rather than a generic stem.
+    """
+    captured, StubAgent = stub_pipeline
+    monkeypatch.setattr(
+        StubAgent, "chat",
+        _emit_incomplete_turn("llm_error", "[LLM API error: 502 Bad Gateway]"),
+    )
+    _no_stdin(monkeypatch)
+    from agentao.cli import run
+
+    rc = run._execute_with_args(_build_args(prompt="hi", output_format="json"))
+
+    assert rc == run.EXIT_RUNTIME_ERROR
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["type"] == "runtime_error"
+    assert payload["error"]["reason"] == "llm_error"
+    assert "502 Bad Gateway" in payload["error"]["message"]
+    assert payload.get("final_text") is None
+
+
+def test_incomplete_outcomes_covers_every_runtime_reason():
+    """The CLI outcome table must key on exactly the runtime's wire vocabulary.
+
+    ``_INCOMPLETE_OUTCOMES`` hand-copies the ``INCOMPLETE_*`` values as literals
+    to avoid importing runtime internals at module scope (see its comment). That
+    duplication is safe only while the two vocabularies stay in lockstep: a
+    runtime value with no table entry falls through to the generic
+    ``empty_response`` stem instead of its own ``type``. Bind them here so a
+    future rename/addition on either side fails loudly rather than silently
+    misclassifying.
+    """
+    from agentao.cli.run import _INCOMPLETE_OUTCOMES
+    from agentao.runtime.chat_loop import INCOMPLETE_ANSWER_REASONS
+
+    assert set(_INCOMPLETE_OUTCOMES) == INCOMPLETE_ANSWER_REASONS
+
+
+def test_normal_turn_still_exits_ok(monkeypatch, tmp_path, stub_pipeline, capsys):
+    """A turn that emits TURN_END without a classification stays a success."""
+    captured, StubAgent = stub_pipeline
+    monkeypatch.setattr(
+        StubAgent, "chat", _emit_incomplete_turn(None, "the answer is 42"),
+    )
+    _no_stdin(monkeypatch)
+    from agentao.cli import run
+
+    args = _build_args(prompt="hi", output_format="json")
+    rc = run._execute_with_args(args)
+
+    assert rc == run.EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ok"
+    assert payload["final_text"] == "the answer is 42"
+
+
+# ``empty_response`` is checked last, so any outcome that explains the missing
+# answer keeps its own more specific exit code.
+def test_cancelled_empty_turn_reports_interrupted_not_empty():
+    """A stream cancelled before its first token returns a normally-built empty
+    response (``llm/client.py`` breaks out without raising), so both signals are
+    live at once — cancellation must win."""
+    from agentao.cli import run
+
+    transport = SimpleNamespace(rejection=None, max_iterations_hit=False)
+    token = SimpleNamespace(is_cancelled=True, reason="sigint")
+
+    error, exit_code, status = run._classify_outcome(
+        transport=transport, token=token, runtime_error=None,
+        max_iterations=10, incomplete_reason="no_output",
+    )
+
+    assert exit_code == run.EXIT_INTERRUPTED
+    assert error.type == "interrupted"
+
+
+def test_max_iterations_empty_turn_reports_max_iterations():
+    from agentao.cli import run
+
+    transport = SimpleNamespace(rejection=None, max_iterations_hit=True)
+    token = SimpleNamespace(is_cancelled=False, reason=None)
+
+    error, exit_code, status = run._classify_outcome(
+        transport=transport, token=token, runtime_error=None,
+        max_iterations=10, incomplete_reason="no_output",
+    )
+
+    assert exit_code == run.EXIT_MAX_ITERATIONS
+    assert error.type == "max_iterations"
+
+
+def test_runtime_error_empty_turn_reports_runtime_error():
+    from agentao.cli import run
+
+    transport = SimpleNamespace(rejection=None, max_iterations_hit=False)
+    token = SimpleNamespace(is_cancelled=False, reason=None)
+
+    error, exit_code, status = run._classify_outcome(
+        transport=transport, token=token, runtime_error=RuntimeError("boom"),
+        max_iterations=10, incomplete_reason="no_output",
+    )
+
+    assert error.type == "runtime_error"
+    assert "boom" in error.message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`agentao run` exited **0** and served a non-answer as the model's reply whenever a turn ended without a complete, model-authored answer:

- an empty assistant message (`[No response]` / `[No text response]`)
- a harness abort after repeated length truncation or a doom loop (canned notice)
- a **final answer truncated mid-sentence** at the token limit
- an outright **LLM API failure** (`[LLM API error: …]`) — the most common no-answer cause

Automation reading `final_text` could not distinguish any of these from a real answer.

## What changed

**1. One closed classification vocabulary.** `TURN_END.incomplete_reason` now answers a single question — *why this turn has no complete model answer* — with five values (`no_output`, `reasoning_only`, `length_truncated`, `doom_loop`, `llm_error`; `None` for a real answer), committed at **every** turn-ending path with no unclassified bypass. `agentao run` maps each to **exit 1** with a precise `error.type` + machine-readable `error.reason`. `max_iterations` stays a deliberately separate axis (sticky transport flag + exit 4).

**2. Surface the outcome on the call.** `agent.last_turn` returns a frozen `TurnOutcome` (`text`, `status`, `incomplete_reason`, `tool_count`, `error`, plus `is_answer`), fed from the **same gated value** as the wire event so the two never disagree. An embedder can branch on the result without subscribing to the internal `Transport`. `from agentao import TurnOutcome` (lightweight, no LLM stack). `chat()`/`arun()` still return `str` — additive, non-breaking.

## Correctness fixes surfaced by review

- a blocking Stop hook / re-entry cap no longer **clears a halted-family classification** (was an exit-0 leak)
- a final answer truncated at the token limit is now classified (previously exited 0)
- a turn **cancelled mid-stream** now reports `status: "cancelled"` (the LLM can return a normally-built empty message without raising)
- `ReplayAdapter` forwards `subscribe()` to the inner transport — enabling replay no longer strips the channel `incomplete_reason` rides on
- drop a PEP 526 annotation on a non-self attribute (mypy `[misc]`)

## Docs & tests

- EN+ZH: agent-events, non-interactive, configuration, host-api, embed-for-agents §6.1; CHANGELOG.
- Also fixes two unrelated doc drifts found in passing: the CLAUDE.md system-prompt date claim, and the obsolete `date-context` guide.
- Tests: `+TurnOutcome`, `+llm_error`, `+truncated-text`, `+blocking-hook-halt`, `+subscribe-passthrough`, `+vocabulary parity`. **3394 passed, 2 skipped** locally; two exit-0-leak fixes teeth-verified (broke each, confirmed the test caught it).

## Not included

Promoting turn outcome to a **push** `HostEvent` (schema-frozen) — deliberately deferred until an async observer that does *not* drive the turn exists. The pull surface above covers every current consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)