### PR TITLE
chore(release): prepare 0.4.15 — session integrity, atomic writes, secret hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-_Targeting 0.4.15. Add entries under the relevant heading as work lands._
+_Add entries under the relevant heading as work lands._
+
+---
+
+## [0.4.15] — 2026-07-19
+
+A **hardening release** on top of 0.4.14. The through-line is that the harness
+must not lie about what happened, and must not leave you worse off than if it
+had done nothing: an interrupted turn no longer bricks the session, `write_file`
+can no longer destroy the file it was updating, turns that produce no answer are
+classified rather than served as if they were answers, and the secret scanner
+that had been sitting behind a disabled-by-default subsystem now runs on the
+live path.
+
+**Two breaking changes**, both flagged `BREAKING` inline below:
+
+1. `SubagentLifecycleEvent(phase="failed")` now also means "returned without
+   answering", not only "raised". Hosts branching on it will see it fire on
+   ordinary non-answers.
+2. Child processes no longer inherit agentao's provider credentials. **If an
+   MCP or ACP server you configured relies on inheriting `OPENAI_API_KEY` (or
+   similar), it will now fail with 401** — declare the key in its `env` block,
+   or set `AGENTAO_SCRUB_CHILD_ENV=0`.
+
+Everything else upgrades in place.
 
 ### Added
 
@@ -24,12 +48,12 @@ _Targeting 0.4.15. Add entries under the relevant heading as work lands._
   Additive, so no `schema_version` bump (same precedent as `tool_count`).
   `max_iterations` is a sixth way a turn ends without a complete answer but is a
   deliberately separate axis — a sticky transport flag with its own exit code 4
-  and `on_max_iterations` interaction, not a value here.
+  and `on_max_iterations` interaction, not a value here. (#126)
 
 - **`error.reason` on the `agentao run` envelope** — the machine-readable
   discriminator behind `error.type`, carrying the `incomplete_reason` value
   verbatim so a caller can branch on `no_output` vs `reasoning_only` without
-  parsing `message`.
+  parsing `message`. (#126)
 
 - **`agent.last_turn` → `TurnOutcome`** — a structured read-after companion to
   `chat()` / `arun()`'s string return. `chat()` still returns the turn's text
@@ -39,7 +63,7 @@ _Targeting 0.4.15. Add entries under the relevant heading as work lands._
   subscribing to the internal `Transport`. `TurnOutcome` is importable from the
   top-level package (`from agentao import TurnOutcome`) without pulling the LLM
   stack. Mirrors the `TURN_END` payload field-for-field — both are fed from a
-  single gated value in `runtime/turn.py`, so they never disagree.
+  single gated value in `runtime/turn.py`, so they never disagree. (#126)
 
 - **`agentao/security/secret_scan.py`** — the credential-pattern scanner, moved
   out of `agentao/replay/` and put on the live path. It previously ran only
@@ -60,19 +84,57 @@ _Targeting 0.4.15. Add entries under the relevant heading as work lands._
   legitimate work. `.agentao/sessions/*.json` and `.agentao/background_tasks.json`
   are likewise not scanned — both are read back into `agent.messages`, so
   redacting them would corrupt a resumed conversation. Best-effort defense in
-  depth, not a seal.
+  depth, not a seal. (#128)
 
 ### Changed
 
-- **Child processes no longer inherit agentao's own provider credentials.**
-  Shell children, MCP server children, ACP server children, and everything
-  routed through `run_captured` (plugin hooks, `search_file_content`) now start
-  from `build_child_env()`, which drops `HARNESS_ENV_KEYS` — `OPENAI_API_KEY`,
-  `ANTHROPIC_API_KEY`, `LLM_EXTRA_BODY`, and friends — so a prompt-injected
-  `run_shell_command("env")` finds nothing worth stealing. The key for the
-  *configured* provider is derived the same way `embedding/factory.py` resolves
-  it (`LLM_PROVIDER=QWEN` → `QWEN_API_KEY`), so users on a provider outside the
-  static list are covered too rather than silently uncovered. The agent is a
+- **Tool calls from a length-truncated assistant message are no longer
+  executed.** When a response ends with `finish_reason == "length"` (or a
+  provider spelling of it, such as Gemini's `MAX_TOKENS`), any tool calls it
+  contains are cut off mid-serialization — the arguments may be *valid JSON and
+  still be wrong*, e.g. a `write_file` whose `content` stops halfway or a shell
+  command missing its final argument. Agentao used to run them. It now records
+  the assistant message, answers each call with a re-issue prompt instead of a
+  result, and lets the model send the call again with complete arguments. A
+  call truncated before its name arrived is stamped `"unknown"` so the
+  assistant/tool pairing stays valid. `LENGTH_TRUNCATION_ABORT_THRESHOLD = 3`
+  finalizes the turn through the Stop hook after three consecutive truncations,
+  so a model that keeps re-truncating an oversized call cannot burn the whole
+  `max_iterations` budget. `TURN_END.tool_count` counts the refused calls, so it
+  still matches the execute path. (#125)
+
+- **BREAKING — child processes no longer inherit agentao's own provider
+  credentials.** Shell children, MCP server children, ACP server children, and
+  everything routed through `run_captured` (plugin hooks, `search_file_content`)
+  now start from `build_child_env()`, which drops the 12 `HARNESS_ENV_KEYS`:
+  `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`,
+  `AZURE_OPENAI_API_KEY`, `DEEPSEEK_API_KEY`, `MOONSHOT_API_KEY`,
+  `GROQ_API_KEY`, `MISTRAL_API_KEY`, `OPENROUTER_API_KEY`, `XAI_API_KEY`,
+  `LLM_API_KEY`, `LLM_EXTRA_BODY`. A prompt-injected `run_shell_command("env")`
+  then finds nothing worth stealing. The key for the *configured* provider is
+  additionally derived the way `embedding/factory.py` resolves it
+  (`LLM_PROVIDER=QWEN` → `QWEN_API_KEY`), so users on a provider outside that
+  static list are covered rather than silently uncovered.
+
+  **What this breaks:** an **MCP or ACP server that relied on inheriting the
+  key now gets a 401** — declare it explicitly in that server's `env` block
+  (applied *after* the scrub), or set `AGENTAO_SCRUB_CHILD_ENV=0` to restore
+  full inheritance process-wide. Same for running `agentao run`, or any script
+  that calls the provider, from inside the agent's own shell.
+  `ShellRequest(env=None)` consequently no longer means "inherit everything" —
+  it means "inherit minus `HARNESS_ENV_KEYS`"; pass an explicit `env` for full
+  control.
+
+  **`GOOGLE_API_KEY` is deliberately NOT dropped.** It is the standard name for
+  Maps / Drive / YouTube credentials as well, and stripping it would break user
+  scripts the agent was asked to run, with a 401 pointing nowhere near agentao.
+  If you authenticate Gemini through `GOOGLE_API_KEY` rather than
+  `GEMINI_API_KEY`, that key still reaches child processes. Only agentao's own
+  keys are dropped; the user's other secrets (AWS, GitHub, `DATABASE_URL`) are
+  untouched — scrubbing those is the host's call. Defense in depth, not a seal:
+  `cat .env` still works. Also fixes a false comment at `mcp/client.py` that
+  had claimed a sanitized base environment while passing `dict(os.environ)`.
+  (#128) The agent is a
   distinct principal from the user, and nothing the LLM decides to run needs
   the key that pays for the LLM. Only agentao's keys are dropped; the user's
   other secrets (AWS, GitHub, `DATABASE_URL`) are untouched — scrubbing those
@@ -83,8 +145,8 @@ _Targeting 0.4.15. Add entries under the relevant heading as work lands._
   Also fixes a false comment at `mcp/client.py` that had claimed a sanitized
   base environment while passing `dict(os.environ)`.
 
-- **`SubagentLifecycleEvent(phase="failed")` now also covers "returned but
-  never answered".** It previously meant only "the sub-agent raised". A
+- **BREAKING — `SubagentLifecycleEvent(phase="failed")` now also covers
+  "returned but never answered".** It previously meant only "the sub-agent raised". A
   sub-agent that hit its iteration budget, produced no output, emitted only
   reasoning, was cut off at the token limit, doom-looped, or whose LLM call
   failed now reports `phase="failed"` with `error_type="incomplete:<reason>"`,
@@ -93,12 +155,25 @@ _Targeting 0.4.15. Add entries under the relevant heading as work lands._
   compliant consumer of `TurnOutcome` — previously the public host contract
   reported success for a sub-agent that had done nothing. **Hosts branching on
   `phase == "failed"` should expect it to fire on ordinary non-answers**, not
-  just exceptions; check `error_type` to distinguish.
+  just exceptions; check `error_type` to distinguish — a raised exception
+  reports `error_type=type(exc).__name__`, a non-answer reports
+  `incomplete:<reason>`.
+
+  Note the suffix vocabulary here is the five `incomplete_reason` values **plus
+  `max_iterations`**. `max_iterations` is deliberately *not* a
+  `TURN_END.incomplete_reason` value (see above — it is a separate axis with
+  its own exit code 4), but a sub-agent has no exit code and no
+  `on_max_iterations` channel of its own, so this surface folds it back in as a
+  sixth suffix. A host matching `error_type.split(":")[1]` against the
+  documented five will miss it. Defensively, `cancelled`, `error`, and
+  `unknown` can also appear when a `TurnOutcome` reports neither an answer nor
+  a reason; treat any unrecognized suffix as "stopped short, cause
+  unclassified" rather than matching exhaustively. (#128)
 
 - **`FileSystem.write_text` implementations must now replace existing files
   atomically.** The protocol docstring states the requirement; delegating
   wrappers inherit it from `LocalFileSystem`, but a from-scratch host
-  implementation owes the guarantee.
+  implementation owes the guarantee. (#128) (#128)
 
 ### Fixed
 
@@ -115,7 +190,7 @@ _Targeting 0.4.15. Add entries under the relevant heading as work lands._
   says the tool *may or may not* have run and warns against blind retry:
   results are committed per batch, so an interrupt during the last call of a
   batch discards its earlier siblings' results too, and re-running a
-  `write_file` that already succeeded is its own kind of damage.
+  `write_file` that already succeeded is its own kind of damage. (#128)
 
 - **`write_file` can no longer destroy a file it was only meant to update.**
   `LocalFileSystem.write_text` used a plain `open(path, "w")`, which truncates
@@ -125,7 +200,7 @@ _Targeting 0.4.15. Add entries under the relevant heading as work lands._
   read-only target still raises `PermissionError`: rename permission lives on
   the *directory*, so without an explicit check the change would have silently
   defeated `chmod 444`. Not fsync'd — this closes the process-death window,
-  not the power-loss one.
+  not the power-loss one. (#128)
 
 - **`edit_file` no longer hides that a match was ambiguous.** The tool counted
   occurrences of `old_text` and then discarded the count. First-match-wins is
@@ -133,13 +208,27 @@ _Targeting 0.4.15. Add entries under the relevant heading as work lands._
   now reports how many remain and, when `old_text` occurs in `new_text`,
   withholds the `replace_all=true` suggestion that would rewrite the
   just-edited site. An empty `old_text` is now refused outright — it matched at
-  every position and would have inserted `new_text` between every character.
+  every position and would have inserted `new_text` between every character. (#128)
 
 - **A failed background sub-agent no longer discards its work.** With
   incomplete runs now reported as `status="failed"`, `check_background_agent`'s
   failure branch returned only `error` — so a long background task that ran out
   of iterations lost everything it had produced. It now surfaces the partial
-  `result` alongside the reason.
+  `result` alongside the reason. Background records carry an explicit
+  `incomplete_reason` field so every reader — the tool, `/agent status`, the
+  dashboard, and any host reading `.agentao/background_tasks.json` — separates
+  "the sub-agent crashed" from "the sub-agent stopped short but produced work"
+  without guessing from the presence of `result`. `/agent status` prints the
+  partial output under a *Did not finish* header rather than only the error,
+  and the dashboard counts unfinished runs separately from genuine failures so
+  the red number keeps meaning something. (#128, #129)
+
+- **`agent.events()` silently registered nothing when replay was enabled.**
+  `ReplayAdapter` wraps the transport but had no `subscribe`, so a host that
+  turned on `replay.enabled` lost every `HostEvent` subscription it had made —
+  the adapter's own docstring admitted the gap. It now forwards to the inner
+  transport, returning a no-op unsubscribe when the inner transport has none.
+  Affects every embedder running with replay on. (#126)
 
 - **A turn cancelled mid-stream now reports `status: "cancelled"`.** When a
   cancellation token fired while the LLM was streaming, the model could return a
@@ -147,7 +236,7 @@ _Targeting 0.4.15. Add entries under the relevant heading as work lands._
   ending site and emitted `TURN_END` with `status: "ok"` though it was
   interrupted. `runtime/turn.py` now reflects the cancellation in `status`, so
   the wire event and `agent.last_turn` both report it honestly (and a
-  placeholder-vs-answer check does not read a cancelled turn as an answer).
+  placeholder-vs-answer check does not read a cancelled turn as an answer). (#126)
 
 - **`agentao run` no longer exits `0` on a turn that produced no answer.**
   A turn ending with an empty assistant message exited `0` and served the
@@ -163,7 +252,7 @@ _Targeting 0.4.15. Add entries under the relevant heading as work lands._
   the provider's actual message) when the LLM call failed. Note that such a
   turn may have run tools first: `tool_calls` reports how many, and their side
   effects have already landed, so a non-zero exit does **not** imply an
-  untouched workspace.
+  untouched workspace. (#126)
 
 ---
 

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.15.dev0"
+__version__ = "0.4.15"
 
 
 def _ensure_utf8() -> None:

--- a/agentao/agents/bg_store.py
+++ b/agentao/agents/bg_store.py
@@ -263,6 +263,14 @@ class BackgroundTaskStore:
                 "status": "pending",
                 "result": None,
                 "error": None,
+                # Set only alongside status="failed", and only when the run
+                # *finished without raising* but never produced an answer
+                # (budget exhausted, no output, doom loop, ...). Same closed
+                # vocabulary as TurnOutcome.incomplete_reason. Its presence is
+                # what separates "the sub-agent crashed" from "the sub-agent
+                # stopped short but produced work worth reading" — the latter
+                # still carries a `result`, and consumers must not discard it.
+                "incomplete_reason": None,
                 "created_at": time.time(),
                 "started_at": None,
                 "finished_at": None,
@@ -297,6 +305,7 @@ class BackgroundTaskStore:
         status: BgTaskStatus,
         result: Optional[str] = None,
         error: Optional[str] = None,
+        incomplete_reason: Optional[str] = None,
         turns: int = 0,
         tool_calls: int = 0,
         tokens: int = 0,
@@ -311,6 +320,7 @@ class BackgroundTaskStore:
                 rec["status"] = status
                 rec["result"] = result
                 rec["error"] = error
+                rec["incomplete_reason"] = incomplete_reason
                 rec["finished_at"] = time.time()
                 rec["turns"] = turns
                 rec["tool_calls"] = tool_calls

--- a/agentao/agents/tools/_bg_tools.py
+++ b/agentao/agents/tools/_bg_tools.py
@@ -101,7 +101,13 @@ class CheckBackgroundAgentTool(Tool):
             # doom-loop halted — which still carries whatever work it did.
             # Dropping ``result`` here would discard the entire output of a
             # long background task purely because it stopped short.
-            report = f"Agent '{name}' ({agent_id}) failed: {rec['error']}"
+            if rec.get("incomplete_reason"):
+                report = (
+                    f"Agent '{name}' ({agent_id}) did not finish "
+                    f"({rec['incomplete_reason']}): {rec['error']}"
+                )
+            else:
+                report = f"Agent '{name}' ({agent_id}) failed: {rec['error']}"
             if rec.get("result"):
                 report += f"\n\n{rec['result']}"
             return report

--- a/agentao/agents/tools/_wrapper.py
+++ b/agentao/agents/tools/_wrapper.py
@@ -727,6 +727,11 @@ class AgentToolWrapper(Tool):
                     status="completed" if incomplete is None else "failed",
                     result=formatted,
                     error=None if incomplete is None else incomplete.detail,
+                    # The record must say *which* kind of "failed" this is.
+                    # Without it every reader has to guess from the presence
+                    # of `result`, and the CLI guessed wrong — it printed the
+                    # error and discarded the work.
+                    incomplete_reason=None if incomplete is None else incomplete.reason,
                     turns=stats["turns"], tool_calls=stats["tool_calls"],
                     tokens=stats["tokens"], duration_ms=stats["duration_ms"],
                 )

--- a/agentao/cli/commands_ext/agents.py
+++ b/agentao/cli/commands_ext/agents.py
@@ -50,6 +50,10 @@ def _show_agents_dashboard(cli: AgentaoCLI) -> None:
             return Text(f"✓  {turns}t {calls}c {tok_s}  {dur_s}", style="green")
         if status == "cancelled":
             return Text("⊘  cancelled", style="dim")
+        if t.get("incomplete_reason"):
+            # Ran to a stop without answering — not a crash. Yellow, not red:
+            # there is usually a partial result worth reading.
+            return Text(f"◑  {t['incomplete_reason']}", style="yellow")
         return Text("✗  failed", style="red")
 
     def _make_panel() -> Panel:
@@ -57,7 +61,13 @@ def _show_agents_dashboard(cli: AgentaoCLI) -> None:
 
         n_run    = sum(1 for t in tasks if t["status"] == "running")
         n_ok     = sum(1 for t in tasks if t["status"] == "completed")
-        n_err    = sum(1 for t in tasks if t["status"] == "failed")
+        # "failed" spans two very different outcomes since 0.4.15. Counting a
+        # sub-agent that merely ran out of turns as an error trains the reader
+        # to ignore the red number, which is the one that means something.
+        n_incomp = sum(1 for t in tasks
+                       if t["status"] == "failed" and t.get("incomplete_reason"))
+        n_err    = sum(1 for t in tasks
+                       if t["status"] == "failed" and not t.get("incomplete_reason"))
         n_cancel = sum(1 for t in tasks if t["status"] == "cancelled")
 
         tbl = Table(box=rich_box.SIMPLE, show_header=True, pad_edge=False,
@@ -70,7 +80,9 @@ def _show_agents_dashboard(cli: AgentaoCLI) -> None:
         for t in sorted(tasks, key=lambda x: x.get("created_at", 0), reverse=True):
             status_cell = _fmt_status(t)
             err_hint = ""
-            if t["status"] == "failed" and t.get("error"):
+            if t["status"] == "failed" and t.get("incomplete_reason"):
+                err_hint = "  [dim yellow]partial result available[/dim yellow]"
+            elif t["status"] == "failed" and t.get("error"):
                 err_hint = f"  [dim red]{str(t['error'])[:60]}[/dim red]"
             task_cell = (t.get("task", "")[:55] or "") + err_hint
             tbl.add_row(t["id"], t["agent_name"], status_cell, task_cell)
@@ -78,7 +90,8 @@ def _show_agents_dashboard(cli: AgentaoCLI) -> None:
         summary = (
             f"[yellow]○ {n_run} running[/yellow]  "
             f"[green]✓ {n_ok} completed[/green]  "
-            f"{'[red]' if n_err else '[dim]'}✗ {n_err} failed{'[/red]' if n_err else '[/dim]'}  "
+            + (f"[yellow]◑ {n_incomp} unfinished[/yellow]  " if n_incomp else "")
+            + f"{'[red]' if n_err else '[dim]'}✗ {n_err} failed{'[/red]' if n_err else '[/dim]'}  "
             f"[dim]⊘ {n_cancel} cancelled[/dim]"
         )
         footer = "[dim]Press Ctrl+C to exit[/dim]" if n_run else ""
@@ -205,6 +218,18 @@ def handle_agent_command(cli: AgentaoCLI, args: str) -> None:
             if status == "completed" and rec.get("result"):
                 console.print("\n[info]Result:[/info]")
                 console.print(Markdown(rec["result"]))
+            elif status == "failed" and rec.get("incomplete_reason"):
+                # Stopped short, but it ran and produced work. Show the
+                # reason *and* the output: an agent that spent 40 minutes
+                # before exhausting its budget still did 40 minutes of work,
+                # and this is the only surface that can hand it back.
+                console.print(
+                    f"\n[warning]Did not finish:[/warning] "
+                    f"{rec.get('error') or rec['incomplete_reason']}"
+                )
+                if rec.get("result"):
+                    console.print("\n[info]Partial result:[/info]")
+                    console.print(Markdown(rec["result"]))
             elif status == "failed" and rec.get("error"):
                 console.print(f"\n[error]Error:[/error] {rec['error']}")
             elif status == "cancelled":

--- a/developer-guide/en/cli/11-sessions-agents.md
+++ b/developer-guide/en/cli/11-sessions-agents.md
@@ -44,7 +44,7 @@ Sub-agents are predefined capabilities that can run in the foreground or backgro
 | `/agent <name> <task>` | Run in the foreground; the REPL waits for the result |
 | `/agent bg <name> <task>` | Run in the background; status appears in the bottom toolbar |
 | `/agent status` | List background task status |
-| `/agent status <id>` | Show one background task's result or error |
+| `/agent status <id>` | Show one background task's result, or its failure. A task that ran but stopped short (budget exhausted, no output) reports *Did not finish* **and still prints its partial result** |
 | `/agent dashboard` or `/agents` | Open the live dashboard |
 | `/agent cancel <id>` | Cancel a background task |
 | `/agent delete <id>` | Remove a background-task record |

--- a/developer-guide/zh/cli/11-sessions-agents.md
+++ b/developer-guide/zh/cli/11-sessions-agents.md
@@ -44,7 +44,7 @@ agentao --resume a1b2c3   # 恢复指定前缀
 | `/agent <name> <task>` | 前台运行；当前 REPL 等结果 |
 | `/agent bg <name> <task>` | 后台运行；状态显示在底部 toolbar |
 | `/agent status` | 列出后台任务状态 |
-| `/agent status <id>` | 查看一个后台任务结果 / 错误 |
+| `/agent status <id>` | 查看一个后台任务的结果或失败原因。跑起来但没跑完的任务（预算耗尽、无输出）会显示 *Did not finish*，**并且照样打印它的部分结果** |
 | `/agent dashboard` 或 `/agents` | 打开实时刷新面板 |
 | `/agent cancel <id>` | 取消后台任务 |
 | `/agent delete <id>` | 从后台任务列表删除记录 |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -30,7 +30,7 @@ Internal state files (auto-managed; documented for awareness, not for editing):
 
 | Surface | Path | Owner | Notes |
 |---|---|---|---|
-| Background sub-agent task state | `.agentao/background_tasks.json` | `agents/bg_store.py::BackgroundTaskStore` | Anchored to `working_directory`; in-memory only when no `persistence_dir`. Hand-edits will desync running threads. **Not secret-scanned** — see the note below. |
+| Background sub-agent task state | `.agentao/background_tasks.json` | `agents/bg_store.py::BackgroundTaskStore` | Anchored to `working_directory`; in-memory only when no `persistence_dir`. Hand-edits will desync running threads. A record with `status: "failed"` carries `incomplete_reason` when the run finished without raising but never answered — its presence is what separates "crashed" (no `result`) from "stopped short" (`result` still present and worth reading). Absent on records written before 0.4.15. **Not secret-scanned** — see the note below. |
 | Replay events | `.agentao/replay/*.jsonl` | `replay/` | See [session-replay.md](../guides/session-replay.md). |
 | Sessions / plans | `.agentao/sessions/`, `.agentao/plan-history/` | various | Per-session artifacts. **Not secret-scanned** — see the note below. |
 | Tool outputs | `.agentao/tool-outputs/` | `runtime/tool_result_formatter.py::_save_and_truncate` | Oversized tool output spilled to disk, referenced from the in-context excerpt. **Secret-scanned before write.** |

--- a/docs/reference/configuration.zh.md
+++ b/docs/reference/configuration.zh.md
@@ -30,7 +30,7 @@
 
 | 配置面 | 路径 | 维护者 | 备注 |
 |---|---|---|---|
-| 后台子代理任务状态 | `.agentao/background_tasks.json` | `agents/bg_store.py::BackgroundTaskStore` | 锚定到 `working_directory`；未传 `persistence_dir` 时只在内存中。手改会与运行中的线程脱钩。**不做密钥扫描**——见下方注记。 |
+| 后台子代理任务状态 | `.agentao/background_tasks.json` | `agents/bg_store.py::BackgroundTaskStore` | 锚定到 `working_directory`；未传 `persistence_dir` 时只在内存中。手改会与运行中的线程脱钩。`status: "failed"` 的记录在"跑完未抛异常但没答出来"时会带 `incomplete_reason`——它的有无用来区分"崩溃"（无 `result`）与"没跑完"（`result` 仍在且值得读）。0.4.15 之前写入的记录没有该字段。**不做密钥扫描**——见下方注记。 |
 | 回放事件 | `.agentao/replay/*.jsonl` | `replay/` | 见 [session-replay.md](../guides/session-replay.md)。 |
 | 会话 / 计划 | `.agentao/sessions/`、`.agentao/plan-history/` | 多模块 | 单次会话产物。**不做密钥扫描**——见下方注记。 |
 | 工具产物 | `.agentao/tool-outputs/` | `runtime/tool_result_formatter.py::_save_and_truncate` | 超长工具输出溢写到磁盘，由上下文中的摘录引用其路径。**落盘前会做密钥扫描。** |

--- a/docs/releases/v0.4.15.md
+++ b/docs/releases/v0.4.15.md
@@ -1,0 +1,248 @@
+# Agentao 0.4.15
+
+A **hardening release** on top of 0.4.14. No new features. The through-line is
+that the harness must not lie about what happened, and must not leave you worse
+off than if it had done nothing.
+
+It upgrades in place via `pip install -U agentao`, with **two** caveats — both
+in [Breaking changes](#breaking-changes) below, and the second one will bite
+anyone whose MCP or ACP server inherits the provider key from the environment.
+
+The headline:
+
+- **An interrupted turn no longer bricks the session.** `Ctrl+C` at the wrong
+  moment used to make every subsequent turn fail with a 400 until `/new`.
+- **`write_file` can no longer destroy the file it was updating.** Existing
+  files are replaced atomically instead of truncated in place.
+- **Turns that produce no answer are classified**, not served as if they were
+  answers — and `agentao run` exits non-zero for them.
+- **The secret scanner moved onto the live path.** It had been reachable only
+  through replay, which is off by default, so `agentao.log` and cached tool
+  outputs were unscanned in every default install.
+- **Tool calls from a length-truncated message are refused rather than run.**
+
+## Why this release
+
+Every item here is the same bug wearing different clothes: the harness reported
+something that wasn't true, or destroyed something on its way to failing.
+
+A turn that produced nothing returned a `[No response]` placeholder that
+automation could not distinguish from a real answer. A sub-agent that did
+nothing was reported to the host contract as `completed`. A tool call cut off
+mid-serialization was executed with arguments that were valid JSON and still
+wrong. An interrupt left the conversation in a state the provider would reject
+forever after. A write that was interrupted between truncate and write left the
+user's source file empty.
+
+None of these is exotic. They are what happens on an ordinary Tuesday when you
+hit `Ctrl+C`, or the model hits a token limit, or a background agent runs out of
+turns. 0.4.15 is the release that stops each of them from being silent.
+
+## Session and file integrity
+
+**Interrupted turns.** The Chat-Completions contract requires every assistant
+`tool_calls` entry to have a matching `role: "tool"` reply. `Ctrl+C` between
+the assistant message and the results landing in history left orphans, so every
+later turn 400'd — and `/sessions resume` faithfully restored the broken state.
+Agentao already upheld this invariant on the doom-loop and length-truncation
+paths; interrupt was the one hole. All three abnormal exits now backfill
+placeholder results.
+
+The placeholder says the tool **may or may not** have run, and warns against
+blind retry. That wording is deliberate: results are committed per batch, so an
+interrupt during the last call of a batch discards its siblings' results too.
+Re-running a `write_file` that already succeeded is its own kind of damage.
+
+**Atomic writes.** `LocalFileSystem.write_text` used a plain `open(path, "w")`,
+which truncates *before* writing. Existing files are now staged as a sibling
+temp file and `os.replace`d — atomic at the VFS level. A read-only target now
+raises `PermissionError` explicitly, because rename permission lives on the
+*directory* and an atomic write would otherwise have silently defeated
+`chmod 444`.
+
+Not fsync'd: this closes the process-death window, not the power-loss one.
+Durability beyond process death is the host's concern and would cost an fsync
+on every write.
+
+> **Host implementors:** the `FileSystem` protocol now *requires* atomic
+> replacement. Delegating wrappers inherit it; a from-scratch implementation
+> owes the guarantee.
+
+## Turn outcomes
+
+`agent.last_turn` returns a `TurnOutcome` with `text`, `status`,
+`incomplete_reason`, `tool_count`, `error`, and an `is_answer` convenience —
+the structured companion to `chat()`'s string return.
+
+```python
+reply = agent.chat("...")
+if not agent.last_turn.is_answer:
+    log.warning("no answer: %s", agent.last_turn.incomplete_reason)
+```
+
+`incomplete_reason` is a closed vocabulary: `no_output`, `reasoning_only`,
+`length_truncated`, `doom_loop`, `llm_error`. `agentao run` now exits `1` with a
+precise `error.type` for each instead of exiting `0` and serving the
+placeholder. Note such a turn may have run tools first — `tool_calls` reports
+how many, and their side effects have already landed, so a non-zero exit does
+**not** imply an untouched workspace.
+
+## Length-truncated tool calls
+
+When a response ends with `finish_reason == "length"`, its tool calls are cut
+off mid-serialization. The arguments may be **valid JSON and still wrong** — a
+`write_file` whose `content` stops halfway, a shell command missing its last
+argument. Agentao used to run them.
+
+They are now refused: the assistant message is recorded, each call is answered
+with a re-issue prompt rather than a result, and the model sends it again with
+complete arguments. Three consecutive truncations finalize the turn through the
+Stop hook, so a model that keeps re-truncating an oversized call cannot burn the
+whole `max_iterations` budget.
+
+## Secret hygiene
+
+The redactor existed but was reachable only through replay, which is off by
+default. It now runs on the live path.
+
+| Surface | Scanned? |
+|---|---|
+| `agentao.log` | **yes** — via a `Formatter` on the file handler |
+| `.agentao/tool-outputs/*.txt` | **yes** — before write, and the tool result says so |
+| `.agentao/sessions/*.json` | **no** — deliberately |
+| `.agentao/background_tasks.json` | **no** — deliberately |
+| The conversation sent to your provider | **no** — deliberately |
+
+The exclusions are not oversights. Session files round-trip back into
+`agent.messages`, so redacting them would corrupt a resumed conversation. And a
+scanner cannot distinguish a live credential from a test fixture — redacting the
+model's view breaks legitimate work.
+
+Redaction uses a `logging.Formatter`, **not** a `Filter`. A `Filter` mutates the
+shared `LogRecord`, so it leaks into every other handler on the logger — an
+embedded host's own handlers included. If a previous version of the developer
+guide led you to install `addFilter(ScrubSecretsFilter())`, remove it.
+
+This is defense in depth, not a seal. It is pattern-based: a secret that does
+not look like one passes through, and `cat .env` still works.
+
+## Fixes
+
+- Sub-agent outcome propagation — the wrapper never read `last_turn`, so the
+  background path reported `status="completed"` for a sub-agent that had done
+  nothing. (#128)
+- A failed background sub-agent no longer discards its work; `/agent status`
+  shows the partial output under a *Did not finish* header, and the dashboard
+  counts unfinished runs separately from genuine crashes. (#128, #129)
+- `agent.events()` silently registered nothing when replay was enabled —
+  `ReplayAdapter` had no `subscribe` passthrough. (#126)
+- `edit_file` surfaces match ambiguity instead of discarding the count, and
+  refuses an empty `old_text` (which matched at every position). (#128)
+- A turn cancelled mid-stream now reports `status: "cancelled"` rather than
+  `"ok"`. (#126)
+- `memory/guards.py` no longer keeps a weaker private copy of the secret
+  patterns that missed `sk-ant-`, JWTs, Slack, and most GitHub variants. (#128)
+
+## Breaking changes
+
+**1. `SubagentLifecycleEvent(phase="failed")` widened.** It previously meant
+"the sub-agent raised". It now also means "returned without answering".
+
+```python
+# before — every "failed" was an exception
+if ev.phase == "failed":
+    page_oncall(ev.error_type)
+
+# after — distinguish the two shapes
+if ev.phase == "failed":
+    if (ev.error_type or "").startswith("incomplete:"):
+        log.info("sub-agent stopped short: %s", ev.error_type)
+    else:
+        page_oncall(ev.error_type)
+```
+
+The `incomplete:` suffix is the five `incomplete_reason` values **plus
+`max_iterations`** — a sub-agent has no exit code of its own, so this surface
+folds that separate axis back in. Treat an unrecognized suffix as "stopped
+short, cause unclassified" rather than matching exhaustively.
+
+**2. Child processes no longer inherit agentao's provider credentials.** Shell,
+MCP, and ACP children, plus everything through `run_captured`, start from a
+scrubbed environment that drops 12 `HARNESS_ENV_KEYS` plus the key implied by
+`LLM_PROVIDER`. A prompt-injected `run_shell_command("env")` then finds nothing
+worth stealing.
+
+**If an MCP or ACP server relied on inheriting the key, it now gets a 401.**
+Declare it in that server's `env` block, which is applied *after* the scrub:
+
+```json
+{"mcpServers": {"my-server": {"env": {"GEMINI_API_KEY": "${GEMINI_API_KEY}"}}}}
+```
+
+Or set `AGENTAO_SCRUB_CHILD_ENV=0` to restore full inheritance process-wide —
+also what you want if you run `agentao run` from inside the agent's own shell.
+
+`GOOGLE_API_KEY` is deliberately **not** dropped: it names Maps / Drive /
+YouTube credentials too, and stripping it would break user scripts with a 401
+pointing nowhere near agentao. If you authenticate Gemini through it rather than
+`GEMINI_API_KEY`, that key still reaches children.
+
+`ShellRequest(env=None)` consequently means "inherit minus `HARNESS_ENV_KEYS`",
+not "inherit everything". Pass an explicit `env` for full control.
+
+## Tests & review
+
+3505 passed, 2 skipped, on Python 3.10 / 3.11 / 3.12, plus `mypy --strict` on
+the host surface, schema-drift checks, clean-install smoke tests, and six
+example integrations.
+
+New test files: `test_interrupt_history_integrity.py`,
+`test_filesystem_atomic_write.py`, `test_secret_hygiene.py`,
+`test_subagent_outcome_propagation.py`, `test_agent_status_render.py`,
+`test_length_truncated_tool_calls.py`, `test_last_turn_outcome.py`.
+
+Every new guard was teeth-checked: the fix was neutered, the tests confirmed
+failing, then restored. The five original fixes were then put through a
+multi-agent adversarial review that found 15 confirmed defects **in the fixes
+themselves** — including an `os.replace` that silently defeated `chmod 444`, an
+`except OSError` that truncated the file it existed to protect when the disk was
+full, and an empty-`old_text` path that would have inserted text between every
+character. A subsequent documentation pass found two more: ACP children were
+never scrubbed, and users on a provider outside the static key list got no
+scrubbing at all while the docs claimed coverage.
+
+## Upgrade
+
+```bash
+pip install -U agentao          # library
+pip install -U 'agentao[cli]'   # interactive CLI
+pip install -U 'agentao[full]'  # all optional extras
+```
+
+Migration from 0.4.14:
+
+1. Audit any host code branching on `SubagentLifecycleEvent.phase == "failed"`
+   and add the `error_type` check shown above.
+2. If an MCP or ACP server needs your provider key, add it to that server's
+   `env` block — or set `AGENTAO_SCRUB_CHILD_ENV=0`.
+3. If you followed the old developer-guide advice and installed a
+   `logging.Filter` to scrub secrets, remove it — it double-redacts and
+   corrupts other handlers.
+
+## Out of scope (deferred)
+
+- **ACP `stopReason` still reports only `end_turn` / `cancelled`.** The
+  structured termination metadata its TODO was waiting on shipped in this
+  release, so the blocker is gone — but `agentao run` and the sub-agent path
+  were migrated to `TurnOutcome` and the ACP surface was not. Queued.
+- **The interrupt backfill is partial.** It stamps placeholders on calls that
+  may already have run, because `ToolRunner.execute` commits a batch's results
+  together. The durable fix is incremental commits, which changes the batch
+  contract.
+- **Redaction is not applied to the model's view or to session files**, by
+  design — see the table above.
+- **0.5.0 removals unchanged:** `agentao.harness`, the eight legacy
+  `Agentao.__init__` callbacks, and the no-op `ToolRunner` kwargs all still warn
+  and still work.
+- **Code Mode / PTC** (#127) remains a decision record only — analysed,
+  explicitly not approved and not implemented.

--- a/tests/test_agent_status_render.py
+++ b/tests/test_agent_status_render.py
@@ -1,0 +1,140 @@
+"""Render-path tests for `/agent status` and the background dashboard.
+
+These exist because of a real regression. When incomplete sub-agent runs
+started being recorded as ``status="failed"`` (0.4.15), the CLI's status
+view still read that as "crashed" and printed only ``error`` — silently
+discarding the ``result`` of a background agent that had run for a long
+time before stopping short.
+
+``test_bg_task_store.py`` covers the store; nothing covered the *display*,
+which is exactly where the bug lived. A record can be perfectly correct on
+disk and still have its contents thrown away on the way to the screen.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentao.agents.bg_store import BackgroundTaskStore
+from agentao.cli.commands_ext.agents import handle_agent_command
+
+
+PARTIAL = "# Findings\n\nAudited 41 of 60 modules before stopping."
+
+
+def _cli_with(record_kwargs: dict) -> tuple[object, str]:
+    """A CLI stub whose store holds one finished task."""
+    store = BackgroundTaskStore()
+    store.register("bg-1", "auditor", "audit the codebase")
+    store.mark_running("bg-1")
+    store.update("bg-1", **record_kwargs)
+    cli = SimpleNamespace(agent=SimpleNamespace(bg_store=store))
+    return cli, "bg-1"
+
+
+def _render(capsys, cli, args: str) -> str:
+    handle_agent_command(cli, args)
+    return capsys.readouterr().out
+
+
+class TestStatusShowsPartialWork:
+    def test_incomplete_run_surfaces_its_result(self, capsys):
+        """The regression: budget exhausted, work done, output reachable."""
+        cli, tid = _cli_with(dict(
+            status="failed",
+            result=PARTIAL,
+            error="reached its iteration budget",
+            incomplete_reason="max_iterations",
+        ))
+        out = _render(capsys, cli, f"status {tid}")
+
+        assert "Audited 41 of 60 modules" in out, (
+            "the partial result was discarded -- this is the regression"
+        )
+        assert "max_iterations" in out or "iteration budget" in out
+
+    def test_incomplete_run_is_not_framed_as_an_error(self, capsys):
+        cli, tid = _cli_with(dict(
+            status="failed",
+            result=PARTIAL,
+            error="reached its iteration budget",
+            incomplete_reason="max_iterations",
+        ))
+        out = _render(capsys, cli, f"status {tid}")
+        assert "Did not finish" in out
+        assert "Error:" not in out
+
+    def test_a_real_crash_still_reads_as_an_error(self, capsys):
+        """The distinction has to cut both ways or it is not a distinction."""
+        cli, tid = _cli_with(dict(
+            status="failed",
+            error="ZeroDivisionError: division by zero",
+        ))
+        out = _render(capsys, cli, f"status {tid}")
+        assert "Error:" in out
+        assert "ZeroDivisionError" in out
+        assert "Did not finish" not in out
+
+    def test_completed_run_is_unchanged(self, capsys):
+        cli, tid = _cli_with(dict(status="completed", result=PARTIAL))
+        out = _render(capsys, cli, f"status {tid}")
+        assert "Audited 41 of 60 modules" in out
+        assert "Did not finish" not in out
+
+    def test_incomplete_with_no_result_still_reports_the_reason(self, capsys):
+        """A run that stopped short having produced nothing must not go silent."""
+        cli, tid = _cli_with(dict(
+            status="failed",
+            error="produced no output",
+            incomplete_reason="no_output",
+        ))
+        out = _render(capsys, cli, f"status {tid}")
+        assert "Did not finish" in out
+        assert "no output" in out
+
+
+class TestLegacyRecordsStillRender:
+    """Records written before 0.4.15 have no `incomplete_reason` key at all."""
+
+    def test_missing_key_is_treated_as_a_crash_not_a_KeyError(self, capsys):
+        store = BackgroundTaskStore()
+        store.register("bg-old", "auditor", "audit")
+        store.mark_running("bg-old")
+        store.update("bg-old", status="failed", error="boom")
+        # Simulate a record loaded from an older on-disk snapshot.
+        rec = store.get("bg-old")
+        rec.pop("incomplete_reason", None)
+        cli = SimpleNamespace(agent=SimpleNamespace(bg_store=store))
+
+        out = _render(capsys, cli, "status bg-old")
+        assert "Error:" in out
+        assert "boom" in out
+
+
+class TestStoreCarriesTheReason:
+    def test_reason_round_trips(self):
+        store = BackgroundTaskStore()
+        store.register("bg-2", "a", "t")
+        store.update("bg-2", status="failed", result="x",
+                     error="d", incomplete_reason="doom_loop")
+        assert store.get("bg-2")["incomplete_reason"] == "doom_loop"
+
+    def test_reason_defaults_to_none(self):
+        store = BackgroundTaskStore()
+        store.register("bg-3", "a", "t")
+        store.update("bg-3", status="completed", result="x")
+        assert store.get("bg-3")["incomplete_reason"] is None
+
+    def test_orphan_recovery_is_a_crash_not_an_incomplete_run(self):
+        """`process exited before task finished` is a genuine failure.
+
+        It must NOT acquire an incomplete_reason, or a killed process would
+        masquerade as an agent that merely ran out of turns.
+        """
+        store = BackgroundTaskStore()
+        store.register("bg-4", "a", "t")
+        store.mark_running("bg-4")
+        rec = store.get("bg-4")
+        assert rec.get("incomplete_reason") is None


### PR DESCRIPTION
Cuts **0.4.15**, plus one regression fix that has to land with it.

## 1. Regression fix (`8c48830`)

PR #128 routed incomplete sub-agent runs to `status="failed"` so the host contract would stop reporting them as successes. But `"failed"` already meant *"raised"*, and the CLI read it that way — `/agent status` printed `rec["error"]` and returned. **A background agent that ran 40 minutes before exhausting its iteration budget showed one line of explanation and its entire output became unreachable.**

Same defect I fixed in `_bg_tools.py` for the LLM-facing tool, on the human-facing surface I missed. It survived #128 because the tests cover the *store*, not the *render path*.

Rather than have every reader infer the distinction from whether `result` happens to be present, records now carry an explicit `incomplete_reason` (same closed vocabulary as `TurnOutcome`). Presence is the discriminator:

- `/agent status` prints `Did not finish: <reason>` **and** the partial result.
- The dashboard counts unfinished runs separately from crashes — lumping them together trains the reader to ignore the red number, which is the one that means something.
- Orphan recovery (`process exited before task finished`) deliberately sets no reason: a killed process is a crash, not a short run.

Pre-0.4.15 records have no such key; every read goes through `.get()` and falls back to the crash path. New `tests/test_agent_status_render.py` covers the gap that let this through (teeth-checked: 3 fail when the fix is reverted).

## 2. Release cut (`ce605ec`)

Version bump, `[Unreleased]` → `[0.4.15]`, and `docs/releases/v0.4.15.md`.

**The changelog needed real work before it could be promoted.** An audit against every commit since v0.4.14 found:

- **PR #125 had no entry at all** — the only change this cycle that can stop a tool from running. The section even forward-referenced it (*"not only truncated tool calls"*) while never explaining it.
- **Zero `BREAKING` markers despite two breaks.** 0.4.14 flagged its single break twice.
- **The likeliest real-world breakage was unstated:** an MCP or ACP server that inherits the provider key now gets a 401.
- **The `max_iterations` entry contradicted itself** — `Added` insists it is "deliberately not a value here" while the sub-agent surface emits `incomplete:max_iterations` as a sixth suffix. Both are true; now explained.
- **`GOOGLE_API_KEY`'s deliberate exclusion** from the scrub was unmentioned, so a user authenticating Gemini through it would wrongly assume coverage.
- **`ReplayAdapter.subscribe` (#126)** fixed a host-contract bug — `agent.events()` silently registered nothing when replay was on — with no entry.
- **No entry carried a `(#NNN)` ref**; every prior release does. All 15 do now.

Release notes characterise 0.4.15 honestly as a **hardening release with no new features**, and carry both breaking changes with before/after host code, the scanned-vs-not-scanned table, and the deferred items.

## Verification

**3505 passed, 2 skipped.** `uv build` produces `agentao-0.4.15`, matching what `publish.yml` validates against the tag.

## Known-deferred, stated in the notes

- **ACP `stopReason` still reports only `end_turn` / `cancelled`.** The structured termination metadata its TODO waited on shipped in *this* release, so the blocker is gone — but `agentao run` and the sub-agent path were migrated and ACP was not. Queued rather than rushed into a release cut.
- **The interrupt backfill is partial** — it stamps placeholders on calls that may already have run, because `ToolRunner.execute` commits a batch's results together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)