### PR TITLE
chore: open 0.4.16 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-_Add entries under the relevant heading as work lands._
+_Targeting 0.4.16. Add entries under the relevant heading as work lands._
+
+### Added
+
+### Changed
+
+### Fixed
 
 ---
 

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.15"
+__version__ = "0.4.16.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Routine cycle-open after the 0.4.15 ship.

- `__version__` → `0.4.16.dev0`
- `[Unreleased]` gets its empty `Added` / `Changed` / `Fixed` headings back

## On the version literal

Uses the PEP 440 canonical `0.4.16.dev0`, **not** `0.4.16-dev`. The 0.4.10 and 0.4.11 cycles drifted to the hyphenated spelling — hatchling normalizes it in the wheel metadata, so it builds identically and nothing fails, but `agentao.__version__` then reports a string that disagrees with the distribution version. That drift was corrected in #97; this avoids reintroducing it.

Verified locally: `uv build` produces `agentao-0.4.16.dev0`, and `packaging.version.Version("0.4.16.dev0")` round-trips unchanged.

## Carried into 0.4.16

Two items the 0.4.15 notes list as deferred, both already scoped:

- **ACP `stopReason` reports only `end_turn` / `cancelled`.** The structured termination metadata its TODO was waiting on shipped in 0.4.15, so the blocker is gone — `agentao run` and the sub-agent path consume `TurnOutcome`, ACP does not. `agentao/acp/session_prompt.py:287`.
- **The interrupt backfill is partial** — it stamps placeholders on tool calls that may already have run, because `ToolRunner.execute` commits a batch's results together. The durable fix is incremental commits, which changes the batch contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)