### PR TITLE
feat(acp): report structured stopReason instead of always end_turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,45 @@ _Targeting 0.4.16. Add entries under the relevant heading as work lands._
 
 ### Changed
 
+- **ACP `session/prompt` now reports why a turn actually ended.** It could only
+  answer `end_turn` or `cancelled`; its own TODO said the richer reasons were
+  unreachable because `agent.chat()` returned no structured termination
+  metadata. `TurnOutcome` shipped that metadata in 0.4.15, and two of the three
+  host surfaces (`agentao run`, the sub-agent path) were migrated onto it while
+  ACP was not — so a DeepChat-style client got `end_turn` for a turn that
+  doom-looped, exhausted its iteration budget, or was cut off at the token
+  limit. The mapping is now:
+
+  | Outcome | `stopReason` |
+  |---|---|
+  | client cancelled | `cancelled` (wins over everything) |
+  | iteration budget exhausted | `max_turn_requests` |
+  | `doom_loop` | `max_turn_requests` |
+  | `length_truncated` | `max_tokens` |
+  | `no_output` / `reasoning_only` / `llm_error` / healthy | `end_turn` |
+
+  `no_output` and `reasoning_only` stay `end_turn` deliberately — the turn did
+  end normally, the model simply produced no prose, and ACP's enum describes
+  why a turn *stopped*, not whether it said anything. `llm_error` also stays
+  `end_turn` as the least-bad option: the closed enum has no member for "the
+  model call failed", and `refusal` means the agent declined on content
+  grounds, so reporting an API outage that way would trade a vague answer for a
+  false one. The failure is still visible — the `[LLM API error: …]` notice is
+  the turn's streamed content. Surfacing it as a JSON-RPC error would be more
+  truthful but changes the response *shape*, so it needs its own decision.
+
+  Budget exhaustion cannot be recovered from `TurnOutcome` (it is deliberately
+  a separate axis), so `ACPTransport` records it as it happens and
+  `session/prompt` clears the flag before each turn — otherwise one exhausted
+  turn would make every later turn on that session report `max_turn_requests`.
+
+- **`AcpSessionPromptResponse.stopReason` gained `max_tokens`.** The local enum
+  had drifted from ACP v1, listing only four of the five members, so the schema
+  could not express a token-limit stop even once the runtime could detect one.
+  `docs/schema/host.acp.v1.json` regenerated. Additive to a response enum: a
+  spec-conformant client already handles all five, but a client that hardcoded
+  the previous four will see a value it did not expect.
+
 ### Fixed
 
 ---

--- a/agentao/acp/_transport_interaction.py
+++ b/agentao/acp/_transport_interaction.py
@@ -59,6 +59,13 @@ class _InteractionMixin:
     the concrete transport.
     """
 
+    #: Set by :meth:`on_max_iterations`; read by ``session/prompt`` to answer
+    #: ``max_turn_requests``. A class-level default keeps it readable on a
+    #: transport whose ``__init__`` predates this attribute, and the session
+    #: is responsible for clearing it before each turn — a sticky flag would
+    #: make every later turn on a long-lived session inherit the verdict.
+    max_iterations_hit: bool = False
+
     # -- Request-response interactions -------------------------------------
 
     def confirm_tool(self, tool_name: str, description: str, args: dict) -> bool:
@@ -373,7 +380,16 @@ class _InteractionMixin:
         """Conservative default: stop the turn when max iterations is reached.
 
         ACP mode has no interactive menu, so the safe default is to stop.
+
+        The flag is what lets ``session/prompt`` answer ``max_turn_requests``
+        instead of ``end_turn``. Budget exhaustion is deliberately *not* a
+        ``TurnOutcome.incomplete_reason`` value (it is a separate axis with its
+        own exit code on the automation surface), so it cannot be recovered
+        from the outcome after the fact — it has to be recorded here, as it
+        happens. ``NonInteractiveTransport`` keeps the same flag for the same
+        reason.
         """
+        self.max_iterations_hit = True
         logger.info(
             "acp: max iterations (%d) reached on session %s — stopping",
             count,

--- a/agentao/acp/schema.py
+++ b/agentao/acp/schema.py
@@ -290,13 +290,21 @@ class AcpSessionPromptRequest(BaseModel):
 class AcpSessionPromptResponse(BaseModel):
     """``session/prompt`` response result.
 
-    ``stopReason`` is the ACP enum: ``end_turn``, ``cancelled``,
-    ``max_turn_requests``, ``refusal``. The agent currently emits only
-    ``end_turn`` and ``cancelled``; the other values are listed in the
-    enum so hosts that consume the schema can rely on the closed set.
+    ``stopReason`` is the ACP v1 enum, all five members: ``end_turn``,
+    ``cancelled``, ``max_tokens``, ``max_turn_requests``, ``refusal``.
+
+    ``max_tokens`` was missing here until 0.4.16 — the local enum had
+    drifted from the spec, so the schema could not express a turn the
+    harness halted at the token limit even once the runtime could detect
+    one. The agent emits ``end_turn``, ``cancelled``, ``max_tokens``, and
+    ``max_turn_requests``; ``refusal`` is spec-listed but never emitted —
+    agentao has no content-refusal detection, and reporting an
+    infrastructure failure as a refusal would be a different lie.
     """
 
-    stopReason: Literal["end_turn", "cancelled", "max_turn_requests", "refusal"]
+    stopReason: Literal[
+        "end_turn", "cancelled", "max_tokens", "max_turn_requests", "refusal"
+    ]
 
     model_config = ConfigDict(extra="forbid")
 

--- a/agentao/acp/session_prompt.py
+++ b/agentao/acp/session_prompt.py
@@ -210,6 +210,69 @@ def _parse_prompt(raw: Any) -> Tuple[str, List[Dict[str, str]]]:
 
 
 # ---------------------------------------------------------------------------
+# Stop reason
+# ---------------------------------------------------------------------------
+
+#: ``TurnOutcome.incomplete_reason`` → ACP ``StopReason``.
+#:
+#: Only the two reasons that describe a *budget* the harness enforced map to a
+#: non-``end_turn`` value:
+#:
+#: * ``length_truncated`` → ``max_tokens``. The turn stopped because the model
+#:   hit the token limit, which is precisely what ACP's ``max_tokens`` names.
+#: * ``doom_loop`` → ``max_turn_requests``. The harness halted a turn that kept
+#:   re-issuing the same call. ACP has no "the agent was going in circles"
+#:   member, and ``max_turn_requests`` ("maximum number of model requests in a
+#:   single turn was exceeded") is the honest neighbour: both are the harness
+#:   capping requests within one turn.
+#:
+#: ``no_output`` and ``reasoning_only`` are deliberately absent, so they fall
+#: through to ``end_turn``. That is not a shortfall: the turn genuinely *did*
+#: end normally, the model simply produced no prose. ACP's enum describes why a
+#: turn *stopped*, not whether it said anything useful — a client that needs
+#: that distinction reads the streamed content, which is empty.
+#:
+#: ``llm_error`` is also absent. See :func:`_stop_reason_for`.
+_INCOMPLETE_TO_STOP_REASON = {
+    "length_truncated": "max_tokens",
+    "doom_loop": "max_turn_requests",
+}
+
+
+def _stop_reason_for(
+    *,
+    cancelled: bool,
+    outcome: Any,
+    max_iterations_hit: bool,
+) -> str:
+    """Map a finished turn onto the ACP ``StopReason`` enum.
+
+    Precedence matters. ``cancelled`` wins over everything: the client asked
+    for the turn to stop, and that fact outranks whatever state the turn was in
+    when it noticed. ``max_iterations_hit`` is checked next because budget
+    exhaustion is a separate axis from ``incomplete_reason`` — a turn can hit
+    the iteration cap *and* carry a reason, and the cap is the more specific
+    account of why it ended.
+
+    ``llm_error`` maps to ``end_turn``, which is the least-bad option rather
+    than a good one: ACP v1's closed enum has no member for "the model call
+    failed". ``refusal`` is the only remaining value and it means the agent
+    declined on content grounds — reporting an API outage as a refusal would
+    trade a vague answer for a false one. The failure is not hidden: the
+    ``[LLM API error: …]`` notice is the turn's text and has already been
+    streamed to the client. Surfacing it as a JSON-RPC error instead would be
+    more truthful, but it changes the response *shape* for a case that
+    currently returns a result, so it needs its own decision.
+    """
+    if cancelled:
+        return "cancelled"
+    if max_iterations_hit:
+        return "max_turn_requests"
+    reason = getattr(outcome, "incomplete_reason", None)
+    return _INCOMPLETE_TO_STOP_REASON.get(reason, "end_turn")
+
+
+# ---------------------------------------------------------------------------
 # Handler
 # ---------------------------------------------------------------------------
 
@@ -275,6 +338,15 @@ def handle_session_prompt(server: "AcpServer", params: Any) -> Dict[str, Any]:
 
     token = CancellationToken()
     session.cancel_token = token
+    # Clear before the turn, not after: the flag is set from inside the chat
+    # loop, and a session serves many turns. Leaving it set would make every
+    # later turn on a long-lived session report max_turn_requests.
+    _transport = getattr(session.agent, "transport", None)
+    if _transport is not None:
+        try:
+            _transport.max_iterations_hit = False
+        except AttributeError:  # transport that does not accept the attribute
+            pass
     try:
         reply = session.agent.chat(
             user_text, cancellation_token=token, images=images or None
@@ -284,11 +356,13 @@ def handle_session_prompt(server: "AcpServer", params: Any) -> Dict[str, Any]:
             session_id,
             len(reply) if isinstance(reply, str) else -1,
         )
-        # TODO(Issue 07): surface max_tokens / max_turn_requests / refusal
-        # once agent.chat() returns structured termination metadata. For
-        # now we can only distinguish "cancelled" (via the token state)
-        # from "normal completion".
-        stop_reason = "cancelled" if token.is_cancelled else "end_turn"
+        stop_reason = _stop_reason_for(
+            cancelled=token.is_cancelled,
+            outcome=getattr(session.agent, "last_turn", None),
+            max_iterations_hit=bool(
+                getattr(_transport, "max_iterations_hit", False)
+            ),
+        )
     finally:
         session.cancel_token = None
         session.turn_lock.release()

--- a/docs/design/acp-server-conformance-review.md
+++ b/docs/design/acp-server-conformance-review.md
@@ -235,6 +235,15 @@ acceptable but lossy.
 
 ### G3 — `stopReason` is impoverished *(runtime + schema drift)*
 
+> **RESOLVED in 0.4.16.** Both layers are closed. `max_tokens` was added to the
+> local enum and the snapshot regenerated; the runtime now maps
+> `TurnOutcome.incomplete_reason` (which shipped in 0.4.15 — the metadata the
+> TODO below was waiting on) plus a per-turn `max_iterations_hit` flag on the
+> ACP transport onto `end_turn` / `cancelled` / `max_tokens` /
+> `max_turn_requests`. `refusal` stays unemitted by design. See
+> `session_prompt.py::_stop_reason_for` and `docs/guides/acp.md`. The analysis
+> below is kept as the record of why.
+
 Two layers, not one:
 - **Runtime**: `session_prompt.py:287-291` returns only `end_turn` or `cancelled`.
   The code's own TODO admits the richer reasons are not surfaced because

--- a/docs/design/acp-server-conformance-review.zh.md
+++ b/docs/design/acp-server-conformance-review.zh.md
@@ -189,6 +189,13 @@ schema 拒绝的值。因此实现 G2 意味着：更新 `agentao/acp/schema.py`
 
 ### G3 —— `stopReason` 贫乏 *(运行时 + schema 漂移)*
 
+> **已在 0.4.16 解决。** 两层都已闭合。`max_tokens` 已加入本地 enum 并重新生成快照；
+> 运行时现在把 `TurnOutcome.incomplete_reason`（0.4.15 交付，正是下方 TODO 等待的那份
+> 元数据）与 ACP transport 上的每轮 `max_iterations_hit` 标志，映射到 `end_turn` /
+> `cancelled` / `max_tokens` / `max_turn_requests`。`refusal` 按设计不发出。见
+> `session_prompt.py::_stop_reason_for` 与 `docs/guides/acp.md`。下方分析保留为"为什么"
+> 的记录。
+
 是两层，不是一层：
 - **运行时**：`session_prompt.py:287-291` 只返回 `end_turn` 或 `cancelled`。代码自己的 TODO
   承认更丰富的原因未上报，因为 `agent.chat()` 没返回结构化终止元数据。于是 ACP client 无法

--- a/docs/guides/acp.md
+++ b/docs/guides/acp.md
@@ -85,7 +85,7 @@ The same shape works for any client that launches an ACP agent over stdio: pass 
 |---|---|---|
 | `initialize` | ✅ | Echoes the client's `protocolVersion` if supported (currently `1`); falls back to ours otherwise. Records `clientCapabilities` per connection. |
 | `session/new` | ✅ | Creates a fresh session bound to a per-session `cwd` and (optionally) per-session MCP servers. Returns `{"sessionId": "sess_…", "configOptions": [...]}` (model/provider selection options — see `session/set_config_option`). |
-| `session/prompt` | ✅ | Runs one Agentao turn against the named session; returns `{"stopReason": "end_turn" \| "cancelled"}`. |
+| `session/prompt` | ✅ | Runs one Agentao turn against the named session; returns `{"stopReason": …}` — `end_turn`, `cancelled`, `max_tokens`, or `max_turn_requests` (see [stop reasons](#sessionprompt-stop-reasons) below). |
 | `session/cancel` | ✅ | Fires the session's active `CancellationToken`. Idempotent; no-op on closed sessions or sessions with no active turn. Accepted both as a notification (no `id`) and as a request. |
 | `session/load` | ✅ | Reuses `agentao/session.py`'s persistence layer, hydrates the runtime's message history, and replays each persisted message as a `session/update` notification before responding. Response includes `configOptions` (same as `session/new`). |
 | `session/set_config_option` | ✅ | ACP-standard model/provider switch (`configId="model"`, `value="provider/model"` or bare `model`). Credentials resolve **server-side** via an injectable `provider_resolver` — `apiKey`/`baseUrl`/`_meta` are rejected. Returns refreshed `configOptions`. |
@@ -186,8 +186,14 @@ Source: `agentao/acp/session_prompt.py`.
 
 | `stopReason` | Meaning |
 |---|---|
-| `end_turn` | The Agentao chat loop returned normally. |
-| `cancelled` | The session's `CancellationToken` was fired (via `session/cancel`, connection close, or session teardown) before the loop returned. |
+| `end_turn` | The Agentao chat loop returned normally. Also covers a turn where the model produced no prose (`no_output` / `reasoning_only`) — the turn genuinely ended, it just said nothing — and a turn whose LLM call failed, because the ACP enum has no error member (the `[LLM API error: …]` notice is the turn's streamed content). |
+| `cancelled` | The session's `CancellationToken` was fired (via `session/cancel`, connection close, or session teardown) before the loop returned. Takes precedence over every other reason. |
+| `max_tokens` | The turn was halted after the model's response was cut off at the token limit (`TurnOutcome.incomplete_reason == "length_truncated"`). |
+| `max_turn_requests` | The harness capped requests within the turn — either the tool-iteration budget was exhausted, or a doom loop (repeated identical calls) was halted. |
+| `refusal` | Listed in the ACP enum and accepted by the schema, but **never emitted**: Agentao has no content-refusal detection, and reporting an infrastructure failure as a refusal would be a different kind of lie. |
+
+Precedence is `cancelled` → iteration budget → `incomplete_reason`. An
+unrecognized future reason degrades to `end_turn` rather than failing the turn.
 
 ACP defines additional stop reasons (`max_tokens`, `max_turn_requests`, `refusal`) that v1 does not surface — `agent.chat()` currently returns a string without structured termination metadata. Adding them is a follow-up, not a v1 promise.
 

--- a/docs/schema/host.acp.v1.json
+++ b/docs/schema/host.acp.v1.json
@@ -1185,12 +1185,13 @@
     },
     "AcpSessionPromptResponse": {
       "additionalProperties": false,
-      "description": "``session/prompt`` response result.\n\n``stopReason`` is the ACP enum: ``end_turn``, ``cancelled``,\n``max_turn_requests``, ``refusal``. The agent currently emits only\n``end_turn`` and ``cancelled``; the other values are listed in the\nenum so hosts that consume the schema can rely on the closed set.",
+      "description": "``session/prompt`` response result.\n\n``stopReason`` is the ACP v1 enum, all five members: ``end_turn``,\n``cancelled``, ``max_tokens``, ``max_turn_requests``, ``refusal``.\n\n``max_tokens`` was missing here until 0.4.16 \u2014 the local enum had\ndrifted from the spec, so the schema could not express a turn the\nharness halted at the token limit even once the runtime could detect\none. The agent emits ``end_turn``, ``cancelled``, ``max_tokens``, and\n``max_turn_requests``; ``refusal`` is spec-listed but never emitted \u2014\nagentao has no content-refusal detection, and reporting an\ninfrastructure failure as a refusal would be a different lie.",
       "properties": {
         "stopReason": {
           "enum": [
             "end_turn",
             "cancelled",
+            "max_tokens",
             "max_turn_requests",
             "refusal"
           ],

--- a/tests/test_acp_session_prompt.py
+++ b/tests/test_acp_session_prompt.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import io
 import json
 import threading
+from types import SimpleNamespace
 from typing import Any, Callable, List, Optional, Tuple
 
 import pytest
@@ -584,6 +585,52 @@ def test_stop_reason_cancelled_when_token_fired(session_with_agent):
     fake.side_effect = cancel_during_chat
     result = acp_session_prompt.handle_session_prompt(server, _prompt_params(sid))
     assert result == {"stopReason": "cancelled"}
+
+
+def test_stop_reason_reads_max_iterations_from_the_transport(session_with_agent):
+    """Budget exhaustion is not a TurnOutcome reason -- it rides a flag."""
+    server, sid, fake = session_with_agent
+    fake.transport = SimpleNamespace(max_iterations_hit=False)
+
+    def exhaust_budget(token: CancellationToken) -> None:
+        fake.transport.max_iterations_hit = True
+
+    fake.side_effect = exhaust_budget
+    result = acp_session_prompt.handle_session_prompt(server, _prompt_params(sid))
+    assert result == {"stopReason": "max_turn_requests"}
+
+
+def test_max_iterations_flag_does_not_leak_into_the_next_turn(session_with_agent):
+    """The regression this reset exists to prevent.
+
+    The flag is set from inside the chat loop and the transport outlives
+    the turn, so without an explicit clear every subsequent prompt on a
+    long-lived session would keep reporting max_turn_requests -- turning
+    one exhausted turn into a permanently broken session.
+    """
+    server, sid, fake = session_with_agent
+    fake.transport = SimpleNamespace(max_iterations_hit=False)
+
+    def exhaust_budget(token: CancellationToken) -> None:
+        fake.transport.max_iterations_hit = True
+
+    fake.side_effect = exhaust_budget
+    first = acp_session_prompt.handle_session_prompt(server, _prompt_params(sid))
+    assert first == {"stopReason": "max_turn_requests"}
+
+    fake.side_effect = None          # a healthy second turn
+    second = acp_session_prompt.handle_session_prompt(
+        server, _prompt_params(sid, "second turn")
+    )
+    assert second == {"stopReason": "end_turn"}
+
+
+def test_stop_reason_reads_last_turn_outcome(session_with_agent):
+    """The metadata TurnOutcome shipped for -- consumed here at last."""
+    server, sid, fake = session_with_agent
+    fake.last_turn = SimpleNamespace(incomplete_reason="length_truncated")
+    result = acp_session_prompt.handle_session_prompt(server, _prompt_params(sid))
+    assert result == {"stopReason": "max_tokens"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_acp_stop_reason.py
+++ b/tests/test_acp_stop_reason.py
@@ -1,0 +1,146 @@
+"""ACP ``stopReason`` mapping (G3).
+
+Until 0.4.16 `session/prompt` could only answer ``end_turn`` or
+``cancelled`` — its own TODO said the richer reasons were unavailable
+because ``agent.chat()`` returned no structured termination metadata.
+``TurnOutcome`` shipped in 0.4.15, so the blocker is gone.
+
+What is asserted here is the *mapping*, including the cases that
+deliberately stay ``end_turn``. A mapping is only meaningful if the
+values it declines to produce are pinned too — otherwise a later change
+that returns ``max_tokens`` for everything would still pass.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentao.acp.schema import AcpSessionPromptResponse
+from agentao.acp.session_prompt import _stop_reason_for
+
+
+def _outcome(reason=None):
+    return SimpleNamespace(incomplete_reason=reason)
+
+
+class TestBudgetReasonsMap:
+    def test_length_truncated_is_max_tokens(self):
+        assert _stop_reason_for(
+            cancelled=False, outcome=_outcome("length_truncated"),
+            max_iterations_hit=False,
+        ) == "max_tokens"
+
+    def test_doom_loop_is_max_turn_requests(self):
+        assert _stop_reason_for(
+            cancelled=False, outcome=_outcome("doom_loop"),
+            max_iterations_hit=False,
+        ) == "max_turn_requests"
+
+    def test_iteration_budget_is_max_turn_requests(self):
+        """Not an incomplete_reason -- it rides the transport flag."""
+        assert _stop_reason_for(
+            cancelled=False, outcome=_outcome(None), max_iterations_hit=True,
+        ) == "max_turn_requests"
+
+
+class TestReasonsThatStayEndTurn:
+    """These are decisions, not gaps -- pin them so they can't drift."""
+
+    @pytest.mark.parametrize("reason", ["no_output", "reasoning_only"])
+    def test_silent_turns_still_ended_normally(self, reason):
+        assert _stop_reason_for(
+            cancelled=False, outcome=_outcome(reason), max_iterations_hit=False,
+        ) == "end_turn"
+
+    def test_llm_error_is_end_turn_not_refusal(self):
+        """`refusal` means the agent declined on content grounds.
+
+        Reporting an API outage as a refusal trades a vague answer for a
+        false one. The error text is the turn's content and has already
+        been streamed.
+        """
+        assert _stop_reason_for(
+            cancelled=False, outcome=_outcome("llm_error"),
+            max_iterations_hit=False,
+        ) == "end_turn"
+
+    def test_healthy_turn(self):
+        assert _stop_reason_for(
+            cancelled=False, outcome=_outcome(None), max_iterations_hit=False,
+        ) == "end_turn"
+
+    def test_unknown_future_reason_degrades_to_end_turn(self):
+        """A new incomplete_reason must not crash an ACP turn."""
+        assert _stop_reason_for(
+            cancelled=False, outcome=_outcome("some_future_reason"),
+            max_iterations_hit=False,
+        ) == "end_turn"
+
+    def test_missing_outcome_degrades(self):
+        assert _stop_reason_for(
+            cancelled=False, outcome=None, max_iterations_hit=False,
+        ) == "end_turn"
+
+
+class TestPrecedence:
+    def test_cancelled_beats_every_other_signal(self):
+        """The client asked to stop; that outranks the turn's own state."""
+        assert _stop_reason_for(
+            cancelled=True, outcome=_outcome("length_truncated"),
+            max_iterations_hit=True,
+        ) == "cancelled"
+
+    def test_iteration_budget_beats_incomplete_reason(self):
+        """Both can be true; the cap is the more specific account."""
+        assert _stop_reason_for(
+            cancelled=False, outcome=_outcome("no_output"),
+            max_iterations_hit=True,
+        ) == "max_turn_requests"
+
+
+class TestEveryEmittedValueIsSchemaValid:
+    """A stopReason the frozen response model rejects is a wire break."""
+
+    @pytest.mark.parametrize("kwargs", [
+        dict(cancelled=True, outcome=None, max_iterations_hit=False),
+        dict(cancelled=False, outcome=_outcome(None), max_iterations_hit=True),
+        dict(cancelled=False, outcome=_outcome("length_truncated"), max_iterations_hit=False),
+        dict(cancelled=False, outcome=_outcome("doom_loop"), max_iterations_hit=False),
+        dict(cancelled=False, outcome=_outcome("no_output"), max_iterations_hit=False),
+        dict(cancelled=False, outcome=_outcome("llm_error"), max_iterations_hit=False),
+    ])
+    def test_validates(self, kwargs):
+        AcpSessionPromptResponse(stopReason=_stop_reason_for(**kwargs))
+
+    def test_max_tokens_is_in_the_enum(self):
+        """It was missing until 0.4.16 -- the local enum had drifted from
+        ACP v1, so the schema could not express a token-limit stop even
+        once the runtime could detect one."""
+        AcpSessionPromptResponse(stopReason="max_tokens")
+
+    def test_all_five_acp_v1_members_accepted(self):
+        for v in ("end_turn", "cancelled", "max_tokens",
+                  "max_turn_requests", "refusal"):
+            AcpSessionPromptResponse(stopReason=v)
+
+    def test_invented_value_rejected(self):
+        with pytest.raises(Exception):
+            AcpSessionPromptResponse(stopReason="ran_out_of_patience")
+
+
+class TestTransportFlag:
+    def test_acp_transport_records_iteration_exhaustion(self):
+        """The signal cannot be recovered from TurnOutcome after the fact,
+        so it has to be recorded as it happens."""
+        from agentao.acp._transport_interaction import _InteractionMixin
+
+        class T(_InteractionMixin):
+            _session_id = "s1"
+            _server = None
+
+        t = T()
+        assert t.max_iterations_hit is False, "must default to False"
+        assert t.on_max_iterations(10, []) == {"action": "stop"}
+        assert t.max_iterations_hit is True


### PR DESCRIPTION
Closes **G3** from `docs/design/acp-server-conformance-review.md` — both layers it identified.

`session/prompt` could only answer `end_turn` or `cancelled`. Its own TODO said the richer reasons were unreachable because `agent.chat()` returned no structured termination metadata. **`TurnOutcome` shipped exactly that in 0.4.15** — and two of the three host surfaces (`agentao run`, the sub-agent path) were migrated onto it while ACP was not. So a DeepChat-style client got `end_turn` for a turn that doom-looped, exhausted its iteration budget, or was cut off at the token limit.

## Schema layer

The local `StopReason` enum had drifted from ACP v1, listing four of five members — **`max_tokens` was missing entirely**, so the schema could not express a token-limit stop even once the runtime could detect one. Added; `docs/schema/host.acp.v1.json` regenerated.

## Runtime layer

Precedence is `cancelled` → iteration budget → `incomplete_reason`:

| Outcome | `stopReason` |
|---|---|
| client cancelled | `cancelled` — wins over everything |
| iteration budget exhausted | `max_turn_requests` |
| `doom_loop` | `max_turn_requests` |
| `length_truncated` | `max_tokens` |
| `no_output` / `reasoning_only` / `llm_error` / healthy | `end_turn` |

## Three deliberate non-mappings

These are decisions, not gaps, and they're pinned by tests so a later change can't quietly widen them:

- **`no_output` / `reasoning_only` stay `end_turn`.** The turn genuinely ended; the model just produced no prose. ACP's enum describes why a turn *stopped*, not whether it said anything useful — a client needing that reads the streamed content, which is empty.
- **`llm_error` stays `end_turn`**, as the least-bad option rather than a good one. The closed enum has no member for "the model call failed", and `refusal` means the agent declined *on content grounds* — reporting an API outage that way would trade a vague answer for a false one. The failure isn't hidden: the `[LLM API error: …]` notice is the turn's streamed content. **Surfacing it as a JSON-RPC error would be more truthful, but it changes the response shape for a case that currently returns a result — that needs its own decision, and I didn't want to smuggle it in here.**
- **`refusal` is never emitted.** Agentao has no content-refusal detection.

## The subtle part

Budget exhaustion is deliberately *not* a `TurnOutcome.incomplete_reason` (separate axis, own exit code on the automation surface), so it can't be recovered after the fact. `ACPTransport` records it as it happens, mirroring `NonInteractiveTransport`.

`session/prompt` clears the flag **before** each turn, not after. The transport outlives the turn, so a sticky flag would make one exhausted turn poison every later turn on that session — a permanently broken session from one bad turn. That reset has its own regression test.

## Verification

**3529 passed, 2 skipped** (from 3505). New `tests/test_acp_stop_reason.py` (21) plus 4 handler-level tests. Teeth-checked: removing the reset and the flag makes exactly the two intended tests fail.

Also fixed `docs/guides/acp.md` (the stop-reason table listed only two values) and marked G3 resolved in the design doc, EN + ZH — design docs drifting stale in the *implemented* direction is how a future reader re-does shipped work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)