### PR TITLE
feat(cli): inject agent_factory into AgentaoCLI and cli.main() (#132)

### DIFF
--- a/agentao/cli/app.py
+++ b/agentao/cli/app.py
@@ -13,11 +13,12 @@ methods, which now forward to the extracted helpers.
 
 from __future__ import annotations
 
+import functools
 import json
 import os
 import uuid as _uuid_mod
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import ANSI
@@ -37,20 +38,227 @@ from ._globals import console
 from ._utils import _SlashCompleter
 
 
+AgentFactory = Callable[..., Agentao]
+"""Signature: ``(transport, max_context_tokens, plan_session) -> Agentao``.
+
+All three are passed as keyword arguments and are **CLI-owned**: the transport
+*is* the ``AgentaoCLI`` instance, and the plan session is the object the CLI's
+``PlanController`` drives. A factory must forward them to the runtime rather
+than substituting its own.
+
+``transport`` and ``plan_session`` are enforced by
+:func:`_check_agent_postconditions`. ``max_context_tokens`` is **not** — the
+runtime folds it into a context manager rather than storing it verbatim, so
+there is nothing cheap to compare against.
+
+Distinct from ``agentao.acp.session_new.AgentFactory``, which has an
+incompatible signature (``cwd``, ``client_capabilities``, ``transport``,
+``permission_engine``, ``mcp_servers``, ``model``). Kept module-internal for
+now so the two names cannot be confused at an import site; see
+``docs/design/cli-host-agent-factory.md`` §11 Q1.
+"""
+
+
+# Attributes ``AgentaoCLI`` and its command handlers bind off the returned
+# runtime. Checked up-front so a non-conforming factory fails with one pointed
+# error instead of an unrelated AttributeError several steps — or several slash
+# commands — later. Design: ``docs/design/cli-host-agent-factory.md`` §3.1.
+#
+# Bound during __init__:
+_REQUIRED_AGENT_ATTRS = (
+    "transport",
+    "working_directory",
+    "permission_engine",
+    "tools",
+    "tool_runner",
+    # Driven by the input loop and slash commands (/clear, /new, /sessions,
+    # /replay, /model). Listed here so a runtime missing them fails at startup
+    # rather than mid-session, after on_session_end() has already fired.
+    "messages",
+    "memory_manager",
+    "context_manager",
+    "skill_manager",
+    "clear_history",
+    "get_current_model",
+)
+
+# CLI-owned kwargs a factory must not pre-bind — see _reject_prebound_kwargs.
+_CLI_OWNED_KWARGS = frozenset({"transport", "max_context_tokens", "plan_session"})
+
+_FACTORY_DOC = "docs/design/cli-host-agent-factory.md"
+
+
+def _transport_chain(transport, *, limit: int = 16):
+    """Yield ``transport`` and each transport it wraps, outermost first.
+
+    Agentao's own decorator convention exposes the wrapped transport as
+    ``inner`` (``agentao.replay.adapter.ReplayAdapter.inner``); ``_inner`` is
+    accepted as the private spelling. ``limit`` bounds a pathological or cyclic
+    chain rather than hanging startup.
+    """
+    seen = []
+    current = transport
+    for _ in range(limit):
+        if current is None or any(current is s for s in seen):
+            return
+        seen.append(current)
+        yield current
+        current = getattr(current, "inner", None) or getattr(current, "_inner", None)
+
+
+def _reject_prebound_kwargs(factory) -> None:
+    """Reject a ``functools.partial`` that pre-binds a CLI-owned kwarg.
+
+    ``partial(f, transport=host)`` does **not** win over the CLI's call-time
+    ``transport=self`` — Python resolves ``partial(f, k=v)(k=w)`` to ``w``. So
+    the host's value is silently discarded, the runtime is correctly bound to
+    the CLI, and every post-condition below passes. Nothing downstream can
+    detect it, which is why it has to be caught here, before the call.
+
+    Only ``functools.partial`` is inspected because that is the shape the API
+    documents and recommends. A hand-written wrapper that hard-codes one of
+    these is caught later by the post-conditions (for ``transport`` and
+    ``plan_session``) or not at all (``max_context_tokens``).
+    """
+    keywords = getattr(factory, "keywords", None)
+    if not isinstance(factory, functools.partial) or not keywords:
+        return
+    clash = sorted(_CLI_OWNED_KWARGS & set(keywords))
+    if clash:
+        raise TypeError(
+            f"agent_factory pre-binds CLI-owned keyword(s): {', '.join(clash)}. "
+            "functools.partial keywords are overridden by the CLI's call-time "
+            "values, so these would be silently discarded rather than applied. "
+            f"Remove them from the partial (see {_FACTORY_DOC} §3.2)"
+        )
+
+
+def _check_agent_postconditions(agent, cli: "AgentaoCLI") -> None:
+    """Validate the runtime returned by an ``agent_factory``.
+
+    The CLI cannot operate on an arbitrary object: it binds ``working_directory``
+    and ``permission_engine`` off the agent, registers the plan tools into
+    ``agent.tools``, and drives ``agent.tool_runner``. A factory that omits any
+    of those produces an error far from its cause — most sharply a bare
+    ``AttributeError: 'NoneType' object has no attribute 'set_mode'`` when
+    ``permission_engine`` is left at its ``None`` default.
+
+    **Transport (§3.2).** The CLI must be *reachable* from the runtime's
+    transport — either directly, or through a chain of wrappers exposing
+    ``inner``. Reachability rather than identity because wrapping is agentao's
+    own convention: ``ReplayManager.start()`` sets
+    ``agent.transport = ReplayAdapter(agent.transport, recorder)``, so a factory
+    that enables recording before returning is legitimate and an ``is``
+    comparison would reject it. What is rejected is a transport with no path
+    back to the CLI at all — that runtime's streaming output, permission
+    prompts, and events never reach the terminal, and the CLI simply appears to
+    hang.
+
+    ``tool_runner._transport`` is checked separately: ``ToolRunner`` captures
+    the transport at construction (``runtime/tool_runner.py``) and routes
+    permission prompts through its own copy, so a runtime whose two transport
+    fields disagree hangs at the first confirmation even though
+    ``agent.transport`` looks correct.
+
+    **Limits worth knowing.** These are ``hasattr``/``is`` probes, not proof of
+    a working runtime. A ``Mock`` or a ``__getattr__`` proxy satisfies every
+    attribute probe vacuously; ``_session_id`` assignability is not checked at
+    all, because a proxy that stores the write on itself accepts it silently
+    (the design doc records the resulting symptom: events carry the runtime's
+    construction-time UUID instead of the CLI session id). Making these
+    airtight would require ``isinstance(agent, Agentao)``, which would also
+    forbid the host wrappers this seam exists to serve — see
+    ``docs/design/cli-host-agent-factory.md`` §11 Q6.
+
+    Raises:
+        TypeError: with a message naming the specific violated post-condition.
+    """
+    where = f"see {_FACTORY_DOC} §3.1"
+
+    if agent is None:
+        raise TypeError(
+            f"agent_factory returned None; it must return an Agentao runtime ({where})"
+        )
+
+    missing = [name for name in _REQUIRED_AGENT_ATTRS if not hasattr(agent, name)]
+    if missing:
+        raise TypeError(
+            f"agent_factory returned {type(agent).__name__}, which is missing "
+            f"required attribute(s): {', '.join(missing)}. The interactive CLI "
+            f"needs a real Agentao runtime ({where})"
+        )
+
+    for label, transport in (
+        ("transport", agent.transport),
+        ("tool_runner._transport", getattr(agent.tool_runner, "_transport", None)),
+    ):
+        if not any(node is cli for node in _transport_chain(transport)):
+            raise TypeError(
+                f"agent_factory returned a runtime whose {label} does not reach "
+                "the CLI. transport= is CLI-owned: forward it unchanged, or wrap "
+                "it in an adapter exposing the wrapped transport as `inner`. "
+                "Otherwise streaming output, permission prompts, and events never "
+                f"reach the terminal and the CLI appears to hang (see {_FACTORY_DOC} §3.2)"
+            )
+
+    if agent.permission_engine is None:
+        raise TypeError(
+            "agent_factory returned a runtime with permission_engine=None. The "
+            "CLI drives permission modes through it; build_from_environment() "
+            "supplies one automatically, so pass permission_engine= explicitly "
+            f"if constructing Agentao() directly ({where})"
+        )
+
+    agent_plan_session = getattr(agent, "_plan_session", None)
+    if agent_plan_session is not cli._plan_session:
+        raise TypeError(
+            "agent_factory returned a runtime bound to a different PlanSession. "
+            "plan_session= is CLI-owned and must be forwarded unchanged — "
+            "otherwise /plan switches the CLI into plan mode while the runtime "
+            "stays out of it, hiding plan_save/plan_finalize from the model and "
+            f"leaving no way to finish the plan ({where})"
+        )
+
+
 class AgentaoCLI:
     """CLI interface for Agentao."""
 
-    def __init__(self):
-        """Initialize CLI."""
+    def __init__(self, *, agent_factory: Optional[AgentFactory] = None):
+        """Initialize CLI.
+
+        Args:
+            agent_factory: Optional host-supplied runtime builder, called as
+                ``factory(transport=self, max_context_tokens=..., plan_session=...)``.
+                Lets a host embed the stock interactive CLI while supplying
+                ``extra_tools`` / ``filesystem`` / ``shell`` / any other
+                ``Agentao`` constructor contract, normally via
+                ``functools.partial(build_from_environment, ...)``. ``None``
+                (default) takes the exact existing ``build_from_environment``
+                path. The returned runtime is validated by
+                :func:`_check_agent_postconditions`.
+
+                Caveat — ``llm_client=``: an injected client is used by the
+                main runtime but **not** inherited by sub-agents.
+                ``AgentToolWrapper`` re-resolves the LLM from the raw
+                ``api_key``/``base_url``/``model`` scalars and builds a stock
+                client, so ``/agent <name> <task>`` bypasses a host's proxy /
+                auth / instrumentation, and a duck-typed client without an
+                ``api_key`` attribute raises there. Pre-existing behavior, not
+                introduced by this seam; do not advertise ``llm_client=``
+                through the CLI as fully supported until that is fixed.
+
+                The three kwargs above must not be pre-bound into a
+                ``functools.partial`` — see :func:`_reject_prebound_kwargs`.
+        """
         safe_load_dotenv()
 
-        # Resolved project root for ``.agentao/`` lookups. Mirrors the
-        # factory's ``(working_directory or Path.cwd()).expanduser().resolve()``
-        # (the CLI passes no ``working_directory``) so settings reads/writes
-        # target the *same* ``settings.json`` the agent's frozen
-        # ``working_directory`` points at — not a process-cwd-relative one that
-        # the factory never reads. Re-bound to ``self.agent.working_directory``
-        # once the agent is built (the authoritative frozen root).
+        # Provisional project root for ``.agentao/`` lookups, mirroring the
+        # factory's ``(working_directory or Path.cwd()).expanduser().resolve()``.
+        # Re-bound below to ``self.agent.working_directory`` — the authoritative
+        # frozen root — once the agent is built. The two used to be guaranteed
+        # equal because the CLI passed no ``working_directory``; ``agent_factory``
+        # invalidated that, so anything read from disk before the factory runs
+        # must be re-read afterwards if the root moved (see ``_saved`` below).
         self._project_root: Path = Path.cwd().expanduser().resolve()
 
         self.current_session_id: Optional[str] = str(_uuid_mod.uuid4())
@@ -75,21 +283,44 @@ class AgentaoCLI:
         self._streaming_started: bool = False
 
         from ..permissions import PermissionMode as _PM
-        _saved = self._load_settings().get("mode", "workspace-write")
-        try:
-            self.current_mode: _PM = _PM(_saved)
-        except ValueError:
-            self.current_mode = _PM.WORKSPACE_WRITE
 
-        self.agent = build_from_environment(
+        def _load_saved_mode() -> "_PM":
+            saved = self._load_settings().get("mode", "workspace-write")
+            try:
+                return _PM(saved)
+            except ValueError:
+                return _PM.WORKSPACE_WRITE
+
+        # Provisional: the authoritative read happens after the factory returns,
+        # once ``_project_root`` is known. Set now so ``current_mode`` exists for
+        # anything the factory triggers through ``transport=self``.
+        self.current_mode: _PM = _load_saved_mode()
+
+        # Resolved here rather than in the signature default so the default
+        # stays explicit and a replaceable callable is not captured in a
+        # default argument. Patching ``agentao.cli.app.build_from_environment``
+        # is not a supported seam — pass ``agent_factory=`` instead.
+        factory = build_from_environment if agent_factory is None else agent_factory
+        _reject_prebound_kwargs(factory)
+        self.agent = factory(
             transport=self,
             max_context_tokens=context_limit,
             plan_session=self._plan_session,
         )
+        # Runs on the default path too: the checks are cheap probes, and keeping
+        # them unconditional makes the default path a live regression test for
+        # the contract host factories are held to.
+        _check_agent_postconditions(self.agent, self)
         # Re-bind to the agent's frozen working_directory — the authoritative
-        # resolved root for ``.agentao/`` reads/writes (factory resolved it the
-        # same way, but bind to the source of truth in case that ever changes).
+        # resolved root for ``.agentao/`` reads/writes.
+        _provisional_root = self._project_root
         self._project_root = self.agent.working_directory
+        if self._project_root != _provisional_root:
+            # A factory supplied its own ``working_directory=``, so the mode
+            # read above came from the wrong ``settings.json``. Re-read before
+            # anything applies it: otherwise the project's saved posture is
+            # ignored at startup and then overwritten on the next ``/mode``.
+            self.current_mode = _load_saved_mode()
         # Hold a reference so the CLI can switch modes / inspect rules
         # without going through the agent.
         self.permission_engine = self.agent.permission_engine

--- a/agentao/cli/entrypoints.py
+++ b/agentao/cli/entrypoints.py
@@ -6,13 +6,18 @@ import atexit
 import os
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from dotenv import load_dotenv
 from rich.panel import Panel
 from rich.prompt import Confirm, Prompt
 
 from ._globals import console, _plugin_inline_dirs
+
+if TYPE_CHECKING:
+    # Type-only: importing .app at module scope would pull prompt_toolkit and
+    # defeat this module's import-lightness.
+    from .app import AgentFactory
 
 
 def run_print_mode(prompt: str) -> int:
@@ -26,8 +31,25 @@ def run_print_mode(prompt: str) -> int:
     return _run_execute(["--format", "text", "--prompt", prompt])
 
 
-def main(resume_session: Optional[str] = None):
-    """Main entry point."""
+def main(
+    resume_session: Optional[str] = None,
+    *,
+    agent_factory: Optional["AgentFactory"] = None,
+):
+    """Main entry point.
+
+    Args:
+        resume_session: Session selector — ``None`` starts fresh, ``""``
+            resumes the latest, a string resumes that session.
+        agent_factory: Optional host-supplied runtime builder forwarded
+            verbatim to :class:`~agentao.cli.app.AgentaoCLI`. See that
+            class and ``docs/design/cli-host-agent-factory.md``.
+
+    Note for embedders: a factory exception is caught by the broad handler
+    below and rendered as a single ``Fatal error:`` line with no traceback,
+    then ``sys.exit(1)``. Construct :class:`AgentaoCLI` directly if you need
+    the exception to propagate to your own code.
+    """
     try:
         import termios
         _HAS_TERMIOS = True
@@ -71,7 +93,7 @@ def main(resume_session: Optional[str] = None):
 
     try:
         from .app import AgentaoCLI
-        cli = AgentaoCLI()
+        cli = AgentaoCLI(agent_factory=agent_factory)
         if resume_session is not None:
             from .commands import resume_session as _resume
             _resume(cli, resume_session if resume_session else None)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -26,6 +26,7 @@ Start here — strategy and the host/ACP surface boundary.
 
 The live backlog of work — proposed, in progress, or impl-deferred. New build work usually starts from one of these.
 
+- **cli-host-agent-factory** — *shipped* — instance-scoped `agent_factory` on `AgentaoCLI` / `cli.main()` so thin Python hosts reach `extra_tools` and the existing runtime construction contract without monkey-patching; validates the returned runtime (#132, 2026-07-19).
 - **acp-g4-plan-modes-commands** — *proposal* — surface plan / modes / commands as ACP `session/update` (chat-target now-work).
 - **deepchat-acp-patch-revision** — *impl in progress* — DeepChat/TensorChat ACP integration; what upstreams vs stays in the fork.
 - **host-fs-policy** — *proposal* — path-domain write boundary over the single fs chokepoint (incl. shell).

--- a/docs/design/cli-host-agent-factory.md
+++ b/docs/design/cli-host-agent-factory.md
@@ -1,0 +1,488 @@
+# Interactive CLI host injection: `agent_factory`
+
+**Status:** **Implemented** 2026-07-19 for [issue #132](https://github.com/jin-bo/agentao/issues/132) — the seam (§3), the post-condition checks (§3.1), and the transport guard (§3.2, resolving Q3) all landed. Still open: Q1 (type-alias export — currently module-internal), Q2 (parameter naming — currently `agent_factory`), Q4 (`main()` error rendering — unchanged), Q5 (`agentao run` — out of scope). The decision proposed here is a keyword-only `agent_factory` seam on `AgentaoCLI` and `cli.main()`; it does not extend plugins or introduce a global tool registry.
+**Audience:** maintainers and Python hosts that reuse Agentao's interactive CLI while supplying a host-configured `Agentao` runtime.
+**Companions:**
+- `docs/design/cli-host-agent-factory.zh.md` — Chinese version
+- `docs/design/host-tool-injection.md` — landed construction-time `extra_tools` / `disable_tools` contract
+- `docs/design/runtime-tool-injection.md` — landed runtime `add_tool` / `remove_tool` contract
+- `docs/reference/host-api.md` — stable in-process host API
+- `agentao/acp/session_new.py` — existing `agent_factory` dependency-injection precedent
+
+---
+
+## 1. Problem
+
+Agentao has a working host tool-injection contract, but a Python host that embeds
+the **interactive CLI** cannot reach it through a supported API.
+
+Verified on `main@8266de1`:
+
+| Fact | Evidence | Result |
+|---|---|---|
+| `Agentao` accepts `extra_tools`, `disable_tools`, and `enabled_tools` | `agentao/agent.py:53-104` | Direct embedding works |
+| `build_from_environment(..., **overrides)` forwards constructor overrides | `agentao/embedding/factory.py:124-127,253-262` | Factory embedding works |
+| `Agentao.add_tool()` is the runtime dual | `agentao/agent.py:853` | Works only after the host obtains the instance |
+| `AgentaoCLI.__init__()` accepts no host injection | `agentao/cli/app.py:43` | The interactive CLI closes the construction seam |
+| `AgentaoCLI` calls the factory with a fixed kwarg set | `agentao/cli/app.py:84-88` | `extra_tools` cannot be forwarded |
+| `main()` constructs `AgentaoCLI()` and immediately runs it | `agentao/cli/entrypoints.py:29,74-78` | It neither accepts a builder nor exposes the agent before the first turn |
+| The CLI's own test suite already patches a dead name | `agentao/cli/app.py:30`, `tests/test_menu_confirmation.py:12` | The silent-failure mode below is not hypothetical — it is present in-repo |
+
+The current workaround patches module globals. It is fragile because
+`cli/app.py:33` imports the factory by name:
+
+```python
+from ..embedding import build_from_environment
+```
+
+Replacing `agentao.embedding.build_from_environment` later does not update the
+already-bound `agentao.cli.app.build_from_environment` name. A host must know the
+CLI's internal import topology, mutate process-global state, and update the patch
+whenever another bound import site is added. A missed site fails silently: the CLI
+still starts, but the host's tools are absent.
+
+That silent-failure mode is already demonstrable inside this repository.
+`agentao/cli/app.py:30` imports `Agentao` and never references it — the import is
+dead, left over from an earlier construction path. The interactive CLI tests
+(`tests/test_menu_confirmation.py`, `tests/test_status_pause.py`,
+`tests/test_clear_resets_confirm.py`, `tests/test_readchar_confirmation.py`)
+patch exactly that name via `patch('agentao.cli.app.Agentao')`, but construction
+goes through `build_from_environment`, which imports `Agentao` locally from
+`..agent`. The patch therefore intercepts nothing; those tests build a real
+runtime and pass anyway (`uv run python -m pytest tests/test_menu_confirmation.py`
+→ 7 passed). A patch-based seam that stopped working produced no failure signal
+at all. That is the outcome this design is meant to make impossible for hosts.
+
+This is an API-boundary gap, not a failure in tool validation or registration.
+The existing construction-time and runtime injection tests pass; the missing
+piece is a stable way to control the runtime constructed by the interactive CLI.
+
+## 2. Goals and non-goals
+
+### Goals
+
+1. Let a Python host reuse the stock interactive CLI with a host-configured
+   `Agentao` instance.
+2. Preserve CLI-owned lifecycle objects: the CLI transport, `PlanSession`, and
+   context limit must still be supplied to runtime construction.
+3. Keep default `agentao` console behavior unchanged.
+4. Keep injection per CLI instance, with no process-global registry or patch.
+5. Reuse an existing repository pattern rather than introduce a second
+   dependency-injection vocabulary.
+
+### Non-goals
+
+- No JSON/settings representation of Python tool implementations.
+- No plugin-manifest `tools` field and no change to plugin trust semantics.
+- No change to `extra_tools`, `add_tool`, MCP, plan-tool, or plugin precedence.
+- No general-purpose post-construction callback pipeline.
+- No change to `agentao run` in this issue; see §8.
+- No guarantee that an arbitrary object pretending to be `Agentao` works with
+  the CLI. The factory returns a real, CLI-compatible `Agentao` runtime.
+
+## 3. Decision: inject the agent factory
+
+Add a keyword-only `agent_factory` parameter to both public interactive entry
+points:
+
+```python
+# agentao/cli/app.py
+AgentFactory = Callable[..., Agentao]
+
+
+class AgentaoCLI:
+    def __init__(self, *, agent_factory: Optional[AgentFactory] = None):
+        ...
+        factory = (
+            build_from_environment
+            if agent_factory is None
+            else agent_factory
+        )
+        self.agent = factory(
+            transport=self,
+            max_context_tokens=context_limit,
+            plan_session=self._plan_session,
+        )
+```
+
+```python
+# agentao/cli/entrypoints.py
+def main(
+    resume_session: Optional[str] = None,
+    *,
+    agent_factory: Optional[AgentFactory] = None,
+):
+    ...
+    cli = AgentaoCLI(agent_factory=agent_factory)
+```
+
+`None`, rather than the factory function as the signature default, keeps default
+resolution explicit and avoids capturing a replaceable callable in a default
+argument. The supported extension mechanism is still the parameter, not patching
+that module name. This deliberately diverges from the ACP precedent cited in
+§5.1, which uses `agent_factory: AgentFactory = default_agent_factory`
+(`agentao/acp/session_new.py:302,475`); the shape is the same, the default is
+not, and the divergence is a considered choice rather than an oversight.
+
+The factory is called with exactly the CLI-owned construction kwargs:
+
+| Kwarg | Owner | Required behavior |
+|---|---|---|
+| `transport` | `AgentaoCLI` | Forward to `Agentao` so prompts, streaming, permission requests, and events use the interactive CLI |
+| `max_context_tokens` | CLI environment policy | Forward as the runtime context limit |
+| `plan_session` | `AgentaoCLI` | Forward so runtime and CLI plan state share one object |
+
+A host normally composes the environment factory with `functools.partial`:
+
+```python
+from functools import partial
+
+from agentao.cli import main
+from agentao.embedding import build_from_environment
+
+main(
+    agent_factory=partial(
+        build_from_environment,
+        extra_tools=[NewsSearchTool(), PublishTool()],
+        disable_tools={"web_search"},
+    )
+)
+```
+
+The same seam also supports existing constructor contracts without growing the
+CLI signature once per contract:
+
+```python
+factory = partial(
+    build_from_environment,
+    working_directory=host_project_root,
+    filesystem=host_filesystem,
+    shell=host_shell,
+    extra_tools=host_tools,
+)
+cli = AgentaoCLI(agent_factory=factory)
+cli.run()
+```
+
+`llm_client=` is deliberately absent from this example: it works for the main
+runtime but is not inherited by sub-agents, so `/agent` bypasses it. See §11 Q7.
+
+The host-supplied factory must accept the three keyword arguments above. It may
+accept `**kwargs`, wrap `build_from_environment`, or construct `Agentao`
+directly. Ignoring or replacing CLI-owned dependencies is outside the contract;
+the CLI does not silently repair a non-conforming result.
+
+### 3.1 Post-conditions on the returned runtime
+
+The kwarg table above is the *input* half of the contract. The CLI also has hard
+requirements on what comes back, because it binds several attributes off the
+returned agent immediately after construction. A factory that wraps
+`build_from_environment` satisfies all of these for free; a factory that
+constructs `Agentao` directly — which §3 explicitly permits — must not omit them.
+
+| Required on the returned agent | Consumed at | Failure if absent |
+|---|---|---|
+| `working_directory` | `app.py:317` | `.agentao/` reads/writes target the wrong root |
+| `permission_engine`, **non-`None`** | `app.py:326,374` | `AttributeError: 'NoneType' object has no attribute 'set_mode'` during CLI init |
+| `tools` (a `ToolRegistry`) | `app.py:336-337` | `plan_save` / `plan_finalize` cannot be registered; plan mode is broken |
+| `tool_runner` | `app.py:340,382` | Session id and read-only mode cannot be bound |
+| `_plan_session`, **identical to the CLI's** | `agent.py:503`, `agent.py:1126` | `/plan` switches the CLI but not the runtime; the model never sees `plan_save` / `plan_finalize` and cannot finish the plan |
+| assignable `_session_id` | `app.py:339` | Events carry the construction-time UUID instead of the CLI session id |
+| `messages`, `memory_manager`, `context_manager`, `skill_manager`, `clear_history`, `get_current_model` | `input_loop.py`, `commands/sessions.py` | Slash commands (`/clear`, `/new`, `/sessions`, `/replay`, `/model`) raise mid-session, after `on_session_end()` has already fired |
+
+`permission_engine` is the sharp edge: `build_from_environment` always builds
+one, so the requirement is invisible until a host constructs `Agentao(...)`
+itself and leaves it at its `None` default. Without a check the resulting error
+surfaces after step 3 of §4 and names neither the factory nor the missing kwarg.
+
+**Implemented** as `agentao/cli/app.py::_check_agent_postconditions`, called
+immediately after the factory returns. Missing attributes are reported together
+in one `TypeError` rather than one per run. The checks run on the default
+(`agent_factory=None`) path as well — they are cheap probes and make stock
+startup a live regression test for the contract hosts are held to.
+
+**What these checks are not.** They are `hasattr` / `is` probes, not proof of a
+working runtime. A `Mock` or any `__getattr__`-backed proxy satisfies every
+attribute probe vacuously, and `_session_id` assignability is not checked at all
+(a proxy that stores the write on itself accepts it silently — the failure is
+the wrong-value row in the table above, not an exception). Closing that would
+require `isinstance(agent, Agentao)`, which would also forbid the wrapper and
+proxy runtimes this seam exists to serve. Left open as Q6 rather than decided
+unilaterally.
+
+### 3.2 Overriding a CLI-owned kwarg fails silently
+
+The recommended `functools.partial` composition has one footgun worth stating
+outright, and it comes in two independent directions that need two different
+mitigations.
+
+**Direction 1 — the host's value is discarded.** `partial` keywords are
+*overridden* by call-time keywords, so
+`partial(build_from_environment, transport=host_transport)` does not raise: the
+CLI's `transport=self` wins, the host's transport is dropped, and the runtime is
+bound correctly to the CLI. Every post-condition then passes. **Nothing
+downstream can detect this** — a post-construction check structurally cannot,
+because the resulting object is indistinguishable from a correct one. The same
+applies to a pre-bound `max_context_tokens` (the host's limit is silently
+ignored) and `plan_session`.
+
+Mitigation: `_reject_prebound_kwargs` inspects the factory *before* calling it
+and raises `TypeError` if a `functools.partial` pre-binds `transport`,
+`max_context_tokens`, or `plan_session`. Only `partial` is inspected, because
+that is the shape this API documents and recommends.
+
+**Direction 2 — the CLI's value is discarded.** A wrapper that rebinds
+`kwargs["transport"]` before delegating returns a runtime wired to something
+other than the CLI. Streaming output, permission prompts, and events never reach
+the terminal; the CLI appears to hang rather than reporting a violation.
+
+Mitigation, **decided (Q3): the CLI checks it.** `_check_agent_postconditions`
+requires the CLI to be *reachable* from the runtime's transport — directly, or
+through a chain of wrappers exposing the wrapped transport as `inner`.
+
+Reachability rather than identity, because wrapping is agentao's own convention:
+`ReplayManager.start()` does exactly this — `agent.transport =
+ReplayAdapter(agent.transport, recorder)` (`agentao/replay/manager.py:104-107`,
+with `ReplayAdapter.inner` at `agentao/replay/adapter.py:48-51`). A strict `is`
+test would reject a factory that enables recording before returning, and would
+reject a host tee adapter, for no safety gain: what actually breaks the CLI is a
+transport with *no path back to it at all*.
+
+The check covers **both** transport fields. `ToolRunner` captures the transport
+at construction and routes permission prompts through its own `_transport` copy,
+so a runtime whose two fields disagree hangs at the first confirmation even
+though `agent.transport` looks right — which is why `ReplayManager` sets both.
+
+## 4. Lifecycle and precedence
+
+The change only replaces the callable used at the existing construction point.
+Startup order remains:
+
+1. Initialize CLI state and its `PlanSession`, and provisionally read the saved
+   permission mode from the process cwd.
+2. Reject a factory that pre-binds a CLI-owned kwarg (§3.2), then invoke
+   `agent_factory(transport=self, max_context_tokens=..., plan_session=...)`.
+3. Validate the returned runtime (§3.1), then bind `_project_root` and
+   `permission_engine` from it. **If the factory supplied its own
+   `working_directory`, re-read the saved mode** — step 1 read it from a
+   different `.agentao/settings.json`, and without the re-read the project's
+   saved posture is ignored at startup and then overwritten by the next
+   `/mode`. This ordering hazard did not exist before the seam: the CLI passed
+   no `working_directory`, so the two roots were guaranteed equal.
+4. Register CLI-owned `plan_save` / `plan_finalize` tools.
+5. Bind the CLI session id to the agent and tool runner.
+6. Load CLI plugins.
+7. Create the prompt session and enter the input loop.
+
+Consequences:
+
+- `extra_tools` supplied by the host are registered during `Agentao`
+  construction and are visible on the first turn.
+- Existing `extra_tools` validation and capability binding remain authoritative;
+  the CLI does not register the tools itself.
+- Plan tool names remain reserved by the existing runtime guard, so a host
+  factory cannot replace the CLI plan-state tools through `extra_tools`.
+- Plugin loading order is unchanged. Plugin agents use namespace-qualified
+  runtime names (`<plugin>:<agent>`), and this design does not redefine plugin
+  collision or precedence semantics.
+- A factory is invoked once per `AgentaoCLI` instance. Two CLI instances may use
+  different factories and **host tool sets** without shared mutable registration
+  state. This isolation claim is scoped to tools built through the factory:
+  inline plugin directories remain process-global
+  (`agentao/cli/entrypoints.py:373` writes `_globals._plugin_inline_dirs`), so
+  plugin-contributed tools are still shared across instances in one process.
+  This design does not change that.
+
+## 5. Why this shape
+
+### 5.1 It matches the ACP precedent
+
+`agentao/acp/session_new.py` already defines `AgentFactory = Callable[...,
+Agentao]` and accepts it in `handle_session_new()` / `register()`. The ACP handler
+owns transport and permission/session state, then supplies those objects to the
+injected factory. The interactive CLI has the same ownership problem and should
+use the same dependency-injection shape.
+
+Two intentional deviations: the CLI defaults the parameter to `None` rather than
+to the default factory (§3), and the two `AgentFactory` aliases describe
+**different call contracts** — ACP's is `(cwd, client_capabilities, transport,
+permission_engine, mcp_servers, model)`, the CLI's is `(transport,
+max_context_tokens, plan_session)`. Reusing the same alias name for an
+incompatible signature is a real confusability risk; see §11 Q1.
+
+### 5.2 It resolves the construction cycle
+
+Passing a pre-built `Agentao` object is the wrong seam. The CLI transport is the
+`AgentaoCLI` instance itself, and the plan session is created by that instance.
+Neither exists before CLI construction. A factory delays runtime construction
+until the CLI-owned dependencies exist.
+
+### 5.3 It does not mirror every runtime kwarg
+
+A dedicated `extra_tools=` argument would solve issue #132 narrowly, but
+`disable_tools`, `enabled_tools`, `filesystem`, `shell`, `llm_client`, and future
+host contracts would remain unreachable. Repeating the `Agentao` constructor on
+`AgentaoCLI` creates two public signatures that drift. The factory forwards the
+existing contract instead.
+
+### 5.4 It preserves ownership boundaries
+
+An untyped `agent_overrides: Mapping[str, Any]` was considered and rejected. It
+would require merge-precedence rules for `transport`, `plan_session`, and
+`max_context_tokens`, and would turn misspelled constructor names into a
+stringly-typed CLI surface. A callable has an explicit responsibility: consume
+the CLI-owned dependencies and return the runtime.
+
+## 6. Compatibility and failure behavior
+
+- Both new parameters are keyword-only and optional: existing Python and console
+  callers are source-compatible.
+- With `agent_factory=None`, the exact existing
+  `build_from_environment(transport=..., max_context_tokens=...,
+  plan_session=...)` path runs.
+- `resume_session` keeps its existing meaning and positional compatibility.
+- `AgentaoCLI(...)` lets a factory exception propagate to its caller, as
+  construction errors do today.
+- `main(...)` keeps the existing top-level exception handling and fatal-error
+  rendering. This design does not change exit codes or make `main()` return the
+  agent. Note what that inherits: `agentao/cli/entrypoints.py:82-84` catches
+  bare `Exception` and prints a single `Fatal error: {e}` line with no traceback
+  before `sys.exit(1)`. A `TypeError` from a host factory with a wrong signature
+  is therefore reported as one line of text with no frame pointing at the host's
+  own code — poor ergonomics for a surface whose entire audience is embedders.
+  See §11 Q4.
+- The factory is instance-scoped. No locking or global cleanup is required.
+- The seam becomes a documented public CLI-embedding API and therefore requires
+  normal deprecation discipline if its call contract changes.
+
+## 7. Rejected alternatives
+
+| Alternative | Decision |
+|---|---|
+| Add only `extra_tools=` to `AgentaoCLI` / `main()` | Rejected as the primary design: fixes one constructor contract and guarantees signature repetition later |
+| Pass a pre-built `Agentao` | Rejected: cannot naturally receive `transport=self` and the CLI-owned `PlanSession` |
+| Return the agent from `main()` | Rejected: `main()` returns only after the interactive loop ends, too late for first-turn injection |
+| Add a post-build `configure_agent(agent)` callback | Rejected: duplicates the runtime's construction-time contract and makes ordering relative to plan tools/plugins a new API |
+| Global entry point or registry | Rejected: process-global mutation, discovery/ordering concerns, and poor multi-instance isolation |
+| Extend plugin manifests with tools | Rejected: much larger code-loading, trust, permissions, packaging, and namespace surface |
+| Document monkey-patching as supported | Rejected: coupled to import topology, non-local, unsafe for multiple instances, and silently breakable |
+| Use MCP as the workaround | Rejected as an equivalent: valid for remote/process tools, but adds transport and lifecycle costs and does not replace in-process `extra_tools` |
+
+## 8. Scope boundary: `agentao run`
+
+`agentao/cli/run.py:527` also constructs an agent through a fixed
+`build_from_environment(**factory_kwargs)` call. That automation entry point has
+the same abstract extensibility question, but a different public surface:
+`RunSpec`, exit envelopes, signal handling, and non-interactive transport.
+
+Issue #132 is triggered by a thin host embedding the **interactive CLI**. This
+design deliberately does not thread a Python callable through `execute()` or
+`_execute_with_args()`. If a real host needs to embed `agentao run`, add the same
+factory seam in a separate design with automation-specific tests rather than
+quietly expanding this change.
+
+ACP needs no corresponding change: it already exposes `agent_factory`.
+
+## 9. Implementation surface
+
+| Change | Location | Status |
+|---|---|---|
+| `AgentFactory` alias, optional keyword-only `agent_factory`, factory call, and `_check_agent_postconditions` | `agentao/cli/app.py` | landed |
+| Optional keyword-only `agent_factory` forwarded to `AgentaoCLI` | `agentao/cli/entrypoints.py` | landed |
+| Focused factory-seam and post-condition tests | `tests/test_cli_agent_factory.py` | landed (12 tests) |
+| Migrate off the unsupported `build_from_environment` patch seam | `tests/test_clear_resets_confirm.py` | landed (5 tests) |
+| Export `AgentFactory` for typing, or keep it internal | `agentao/cli/__init__.py` | **deferred — Q1** |
+| Document the programmatic interactive-CLI example | `docs/reference/` or the embedding guide | **pending** |
+
+No changes are required in `Agentao`, tool registries, plugin models, MCP, or the
+`agentao.host` exports.
+
+Two incidental cleanups fall out of the change and should land with it rather
+than separately:
+
+- `agentao/cli/app.py:30`'s currently-dead `from ..agent import Agentao` becomes
+  live as the referent of `AgentFactory = Callable[..., Agentao]`.
+- The interactive CLI tests listed in §1 can migrate from
+  `patch('agentao.cli.app.Agentao')` — which intercepts nothing today — to an
+  injected fake factory, making them test what they claim to test.
+
+## 10. Test matrix and acceptance criteria
+
+### Tests
+
+1. A recording factory receives `transport is cli`, the CLI's exact
+   `_plan_session`, and the environment-derived context limit.
+2. A partial factory forwarding `extra_tools` makes the tool visible before the
+   first `cli.run()` turn.
+3. `main(agent_factory=factory)` forwards the identical callable to
+   `AgentaoCLI` and preserves resume behavior.
+4. `AgentaoCLI()` with no factory takes the current default path.
+5. Two CLI instances with different factories expose different *host* tool sets
+   with no leakage. Plugin-contributed tools are out of scope for this
+   assertion (§4).
+6. A factory exception follows the existing direct-constructor and `main()`
+   error paths.
+7. A factory that returns a runtime built without a `permission_engine` fails
+   with a diagnosable error rather than a bare `NoneType` `AttributeError`
+   (§3.1) — or, if no guard is added, the post-conditions are documented and
+   this test is dropped deliberately.
+8. Existing interactive CLI, resume, plan, plugin, and status tests remain green.
+   This is a weak signal on its own: per §1 those tests currently pass while
+   patching a name that intercepts nothing, so "still green" does not establish
+   that the seam is exercised. Criterion 1 and the migrated tests in §9 are what
+   actually cover it.
+
+### Acceptance criteria
+
+- A downstream host can delete all monkey-patching and launch the stock
+  interactive CLI with `extra_tools` through a documented callable.
+- The injected tools are visible on the first model turn and retain the existing
+  capability binding and validation behavior.
+- Default console startup is behaviorally unchanged.
+- The fix adds no global registry, plugin feature, config format, or new tool
+  precedence rule.
+
+## 11. Open review questions
+
+1. **Export the type alias, and under what name?** Two questions, one decision.
+   `AgentFactory` can stay internal with only the callable contract documented,
+   or become a lazy `agentao.cli` export for typing ergonomics. Exporting it
+   *under that name* would put two public `AgentFactory` aliases with
+   incompatible call contracts in the tree (§5.1). Options: keep it internal;
+   export it as `CliAgentFactory`; or export `AgentFactory` from `agentao.cli`
+   and accept that the qualified module path is the disambiguator. Preference:
+   internal, or `CliAgentFactory` if exported.
+2. **Parameter naming:** `agent_factory` matches ACP and is preferred.
+   `runtime_factory` is more explicit but would create two names for the same
+   pattern. (Note this is orthogonal to Q1 — the *parameter* can match ACP even
+   if the *type alias* does not.)
+3. ~~**Guard the transport post-condition?**~~ **Resolved: check added**, as
+   chain reachability over both `agent.transport` and
+   `agent.tool_runner._transport`. Enabling it immediately surfaced five tests
+   in `tests/test_clear_resets_confirm.py` that patched
+   `agentao.cli.app.build_from_environment` and returned a bare `Mock()` —
+   they now build a real runtime through `agent_factory=`. That is §1's
+   argument reproduced in miniature: an unsupported seam that had been passing
+   silently failed loudly the moment a contract check existed.
+4. **Factory errors under `main()`:** should `main()` special-case a factory
+   exception with a traceback or an embedder-oriented message (§6)? Doing so
+   changes `main()`'s error rendering, which §2 lists as out of scope — but the
+   status quo gives embedders a one-line report for their own bug.
+5. **Follow-up for `agentao run`:** only open after a concrete programmatic
+   automation host appears; do not fold it into issue #132 by default.
+6. **Require `isinstance(agent, Agentao)`?** The post-conditions are `hasattr`
+   probes, so a `Mock` or `__getattr__` proxy passes them vacuously (§3.1).
+   An `isinstance` gate would close that and matches non-goal 6 ("the factory
+   returns a real, CLI-compatible `Agentao` runtime") — but it forbids the
+   proxy and wrapper runtimes the seam exists to serve, and forces every test
+   double to be a real runtime. Currently **not** enforced; the attribute list
+   is the compromise.
+7. **`llm_client=` is not sub-agent-safe.** An injected client is used by the
+   main runtime but not inherited by sub-agents: `AgentToolWrapper` re-resolves
+   the LLM from raw `api_key` / `base_url` / `model` scalars and builds a stock
+   client, so `/agent <name> <task>` bypasses a host's proxy, auth, and
+   instrumentation — and a duck-typed client lacking `api_key` raises there.
+   Pre-existing, not caused by this seam, but it makes `llm_client=` an
+   over-claim for CLI hosts. Fixing it means threading the client through
+   sub-agent construction, which is a separate change.
+

--- a/docs/design/cli-host-agent-factory.zh.md
+++ b/docs/design/cli-host-agent-factory.zh.md
@@ -1,0 +1,309 @@
+# 交互式 CLI 宿主注入：`agent_factory`
+
+**状态：** **已实现。** 2026-07-19 为 [issue #132](https://github.com/jin-bo/agentao/issues/132) 落地——接缝（§3）、后置条件校验（§3.1）与 transport guard（§3.2，即 Q3 的结论）均已实现。仍开放：Q1（type alias 是否导出——当前保持模块内部）、Q2（参数命名——当前 `agent_factory`）、Q4（`main()` 错误展示——未改）、Q5（`agentao run`——范围外）。本文提议在 `AgentaoCLI` 与 `cli.main()` 上增加 keyword-only `agent_factory` 接缝；不扩展 plugin，也不引入全局工具注册表。
+**读者：** agentao 维护者，以及复用 agentao 交互式 CLI、同时需要自行配置 `Agentao` runtime 的 Python 宿主。
+**同伴文档：**
+- `docs/design/cli-host-agent-factory.md` — English version
+- `docs/design/host-tool-injection.zh.md` — 已落地的构造期 `extra_tools` / `disable_tools` 契约
+- `docs/design/runtime-tool-injection.zh.md` — 已落地的运行期 `add_tool` / `remove_tool` 契约
+- `docs/reference/host-api.md` — 稳定的进程内宿主 API
+- `agentao/acp/session_new.py` — 已有的 `agent_factory` 依赖注入先例
+
+---
+
+## 1. 问题
+
+agentao 已有可用的宿主工具注入契约，但 Python 宿主若要嵌入**交互式 CLI**，就没有受支持的 API 能触达它。
+
+在 `main@8266de1` 上核实：
+
+| 事实 | 证据 | 结果 |
+|---|---|---|
+| `Agentao` 接受 `extra_tools`、`disable_tools`、`enabled_tools` | `agentao/agent.py:53-104` | 直接嵌入可用 |
+| `build_from_environment(..., **overrides)` 转发构造参数 | `agentao/embedding/factory.py:124-127,253-262` | factory 嵌入可用 |
+| `Agentao.add_tool()` 是运行期对偶 | `agentao/agent.py:853` | 仅在宿主持有实例后可用 |
+| `AgentaoCLI.__init__()` 不接受宿主注入 | `agentao/cli/app.py:43` | 交互式 CLI 封死了构造接缝 |
+| `AgentaoCLI` 以固定参数调用 factory | `agentao/cli/app.py:84-88` | 无法转发 `extra_tools` |
+| `main()` 构造 `AgentaoCLI()` 后立即运行 | `agentao/cli/entrypoints.py:29,74-78` | 既不接 builder，也不在首轮前暴露 agent |
+| CLI 自己的测试套件已经在 patch 一个死名字 | `agentao/cli/app.py:30`、`tests/test_menu_confirmation.py:12` | 下述静默失效并非假设，仓内已实际存在 |
+
+现有绕法是 patch 模块全局属性。它很脆弱，因为 `cli/app.py:33` 按名字导入 factory：
+
+```python
+from ..embedding import build_from_environment
+```
+
+之后替换 `agentao.embedding.build_from_environment`，不会更新已经绑定的
+`agentao.cli.app.build_from_environment`。宿主必须了解 CLI 的内部 import 拓扑、修改进程全局状态，并在未来每增加一个绑定式 import site 时同步补 patch。漏掉时不会报错：CLI 正常启动，但宿主工具悄然缺失。
+
+这种静默失效在本仓库内已可实证。`agentao/cli/app.py:30` 导入了 `Agentao` 却全文再无引用——这是旧构造路径遗留的死 import。而交互式 CLI 的测试（`tests/test_menu_confirmation.py`、`tests/test_status_pause.py`、`tests/test_clear_resets_confirm.py`、`tests/test_readchar_confirmation.py`）恰恰通过 `patch('agentao.cli.app.Agentao')` patch 这个名字；实际构造走的是 `build_from_environment`，而它在函数内从 `..agent` 局部导入 `Agentao`。因此这些 patch 拦截不到任何东西：测试实际在构造真 runtime，却照样通过（`uv run python -m pytest tests/test_menu_confirmation.py` → 7 passed）。一个已经失效的 patch 式接缝，没有产生任何失败信号。本设计要做的，正是让宿主不可能落到这个结局。
+
+这是 API 边界缺口，不是工具校验或注册实现失效。构造期与运行期注入的既有测试都能通过；缺的是一个稳定接口，让宿主控制交互式 CLI 所构造的 runtime。
+
+## 2. 目标与非目标
+
+### 目标
+
+1. 让 Python 宿主复用原生交互式 CLI，同时构造宿主配置过的 `Agentao`。
+2. 保留 CLI 对生命周期对象的所有权：CLI transport、`PlanSession` 与 context limit 仍必须进入 runtime 构造。
+3. 默认 `agentao` console 行为不变。
+4. 注入按 CLI 实例隔离，不增加进程全局 registry 或 patch。
+5. 复用仓库已有模式，不发明第二套依赖注入词汇。
+
+### 非目标
+
+- 不把 Python 工具实现塞进 JSON/settings。
+- 不给 plugin manifest 增加 `tools` 字段，不改变 plugin 信任语义。
+- 不改变 `extra_tools`、`add_tool`、MCP、plan tool 或 plugin 的优先级。
+- 不增加通用 post-construction callback pipeline。
+- 本 issue 不修改 `agentao run`；见 §8。
+- 不保证任意伪装成 `Agentao` 的对象都能配合 CLI。factory 返回真实、与 CLI 兼容的 `Agentao` runtime。
+
+## 3. 决策：注入 agent factory
+
+给两个公开的交互入口增加 keyword-only `agent_factory` 参数：
+
+```python
+# agentao/cli/app.py
+AgentFactory = Callable[..., Agentao]
+
+
+class AgentaoCLI:
+    def __init__(self, *, agent_factory: Optional[AgentFactory] = None):
+        ...
+        factory = (
+            build_from_environment
+            if agent_factory is None
+            else agent_factory
+        )
+        self.agent = factory(
+            transport=self,
+            max_context_tokens=context_limit,
+            plan_session=self._plan_session,
+        )
+```
+
+```python
+# agentao/cli/entrypoints.py
+def main(
+    resume_session: Optional[str] = None,
+    *,
+    agent_factory: Optional[AgentFactory] = None,
+):
+    ...
+    cli = AgentaoCLI(agent_factory=agent_factory)
+```
+
+签名默认值使用 `None`，而不是直接放 factory 函数，以便明确在运行时解析默认 factory，并避免把一个可替换 callable 捕获进默认参数。受支持的扩展机制仍然是参数，不是 patch 这个模块名。这一点刻意偏离了 §5.1 引用的 ACP 先例——后者用的是 `agent_factory: AgentFactory = default_agent_factory`（`agentao/acp/session_new.py:302,475`）。形态相同、默认值不同，属于有意选择而非疏漏。
+
+factory 会收到且仅收到 CLI 所有的构造参数：
+
+| kwarg | 所有者 | 必需行为 |
+|---|---|---|
+| `transport` | `AgentaoCLI` | 转发给 `Agentao`，让交互提示、流式输出、权限请求和事件走 CLI |
+| `max_context_tokens` | CLI 环境策略 | 作为 runtime context limit 转发 |
+| `plan_session` | `AgentaoCLI` | 转发，让 runtime 与 CLI plan 状态共享同一对象 |
+
+宿主通常用 `functools.partial` 组合环境 factory：
+
+```python
+from functools import partial
+
+from agentao.cli import main
+from agentao.embedding import build_from_environment
+
+main(
+    agent_factory=partial(
+        build_from_environment,
+        extra_tools=[NewsSearchTool(), PublishTool()],
+        disable_tools={"web_search"},
+    )
+)
+```
+
+同一接缝也能触达其它既有构造契约，不需要每多一个契约就扩一次 CLI 签名：
+
+```python
+factory = partial(
+    build_from_environment,
+    working_directory=host_project_root,
+    filesystem=host_filesystem,
+    shell=host_shell,
+    extra_tools=host_tools,
+)
+cli = AgentaoCLI(agent_factory=factory)
+cli.run()
+```
+
+示例中刻意不含 `llm_client=`：它对主 runtime 有效，但**不被子 agent 继承**，`/agent` 会绕过它。见 §11 Q7。
+
+宿主 factory 必须接受上述三个关键字参数。它可以接受 `**kwargs`、包装
+`build_from_environment`，也可以直接构造 `Agentao`。忽略或替换 CLI 所有的依赖不属于契约；CLI 不静默修补不合规返回值。
+
+### 3.1 对返回 runtime 的后置条件
+
+上表是契约的**输入**一半。CLI 对**返回值**同样有硬性要求——构造后它会立刻从返回的 agent 上绑定若干属性。包装 `build_from_environment` 的 factory 天然满足；而 §3 明确允许的「直接构造 `Agentao`」路径必须自行保证：
+
+| 返回 agent 上必须具备 | 消费位置 | 缺失后果 |
+|---|---|---|
+| `working_directory` | `app.py:317` | `.agentao/` 读写落到错误的根目录 |
+| `permission_engine`，且**非 `None`** | `app.py:326,374` | CLI 初始化期 `AttributeError: 'NoneType' object has no attribute 'set_mode'` |
+| `tools`（`ToolRegistry`） | `app.py:336-337` | 无法注册 `plan_save` / `plan_finalize`，plan 模式失效 |
+| `tool_runner` | `app.py:340,382` | 无法绑定 session id 与只读模式 |
+| `_plan_session`，且与 CLI 的**同一对象** | `agent.py:503`、`agent.py:1126` | `/plan` 只切换了 CLI 未切换 runtime；模型看不到 `plan_save` / `plan_finalize`，无法收尾 |
+| 可赋值的 `_session_id` | `app.py:339` | 事件携带构造期 UUID，而非 CLI session id |
+| `messages`、`memory_manager`、`context_manager`、`skill_manager`、`clear_history`、`get_current_model` | `input_loop.py`、`commands/sessions.py` | `/clear`、`/new`、`/sessions`、`/replay`、`/model` 在会话中途报错——且发生在 `on_session_end()` 已触发之后 |
+
+`permission_engine` 是最尖锐的一条：`build_from_environment` 总会建一个，所以这条要求在宿主自行 `Agentao(...)` 并保留其 `None` 默认值之前完全不可见。若不加校验，报错发生在 §4 第 3 步之后，且既不指向 factory 也不指向缺失的 kwarg。
+
+**已实现**为 `agentao/cli/app.py::_check_agent_postconditions`，在 factory 返回后立即调用。缺失属性会**合并进同一个 `TypeError`** 一次报全，而不是每跑一次修一条。该校验在默认路径（`agent_factory=None`）同样执行——都是廉价探测，换来的是让原生启动成为宿主契约的活体回归测试。
+
+**这些检查不是什么。** 它们只是 `hasattr` / `is` 探测，并不能证明 runtime 可用。`Mock` 或任何基于 `__getattr__` 的 proxy 都能**空洞地**通过全部属性探测；`_session_id` 的可赋值性则完全没检查（proxy 把写入存到自己身上会静默成功——其故障是上表中的「取值错误」那一行，而非抛异常）。要堵死这些需要 `isinstance(agent, Agentao)`，但那会同时禁掉本接缝正要服务的 wrapper / proxy runtime。故留作 Q6 开放项，不单方面拍板。
+
+### 3.2 覆盖 CLI 所有的 kwarg 会静默失败
+
+本文主推的 `functools.partial` 组合有一个必须明说的 footgun，而且它有**两个相互独立的方向**，需要两种不同的缓解手段。
+
+**方向一：宿主的值被丢弃。** partial 的 keyword 会被**调用时 keyword 覆盖**，因此 `partial(build_from_environment, transport=host_transport)` 不会报错：CLI 的 `transport=self` 胜出，宿主 transport 被丢掉，而 runtime 恰好正确绑定到 CLI。于是所有后置条件**全部通过**。**下游没有任何手段能发现它**——构造后检查在结构上就做不到，因为产出的对象与正确对象无法区分。预绑 `max_context_tokens`（宿主的上限被静默忽略）与 `plan_session` 同理。
+
+缓解：`_reject_prebound_kwargs` 在**调用之前**检查 factory，若某个 `functools.partial` 预绑了 `transport`、`max_context_tokens` 或 `plan_session` 则抛 `TypeError`。只检查 `partial`，因为那是本 API 文档化并推荐的形态。
+
+**方向二：CLI 的值被丢弃。** 在委派前改写 `kwargs["transport"]` 的 wrapper 会返回一个绑到别处的 runtime：流式输出、权限询问与事件全都到不了终端，CLI 表现为「卡住」而非报告违约。
+
+缓解，**已决（Q3）：CLI 加检查。** `_check_agent_postconditions` 要求 CLI 从 runtime 的 transport **可达**——直接相同，或经由一条以 `inner` 暴露被包装 transport 的 wrapper 链。
+
+用**可达性**而非 identity，是因为「包装」本就是 agentao 自己的约定：`ReplayManager.start()` 做的正是这件事——`agent.transport = ReplayAdapter(agent.transport, recorder)`（`agentao/replay/manager.py:104-107`，`ReplayAdapter.inner` 见 `agentao/replay/adapter.py:48-51`）。严格 `is` 检查会拒绝「返回前已开启录制」的 factory，也会拒绝宿主 tee adapter，而换不来任何安全收益：真正会弄坏 CLI 的，是一条**完全回不到 CLI** 的 transport。
+
+该检查覆盖**两个** transport 字段。`ToolRunner` 在构造期捕获 transport，并通过自己那份 `_transport` 转发权限询问；因此两个字段不一致的 runtime 会在第一次确认时卡死——哪怕 `agent.transport` 看着没问题。这也正是 `ReplayManager` 要同时设置两者的原因。
+
+## 4. 生命周期与优先级
+
+改动只替换现有构造点使用的 callable。启动顺序保持：
+
+1. 初始化 CLI 状态及其 `PlanSession`，并从进程 cwd **暂定**读取已保存的权限模式。
+2. 先拒绝预绑了 CLI 所有 kwarg 的 factory（§3.2），再调用
+   `agent_factory(transport=self, max_context_tokens=..., plan_session=...)`。
+3. 校验返回的 runtime（§3.1），随后从中绑定 `_project_root` 与 `permission_engine`。**若 factory 自带 `working_directory`，则重新读取已保存模式**——第 1 步读的是另一个 `.agentao/settings.json`；不重读的话，项目已保存的权限姿态会在启动时被忽略，随后又被下一次 `/mode` 覆盖写回。该顺序陷阱在本接缝之前不存在：那时 CLI 不传 `working_directory`，两个根必然相等。
+4. 注册 CLI 所有的 `plan_save` / `plan_finalize` 工具。
+5. 把 CLI session id 绑定到 agent 与 tool runner。
+6. 加载 CLI plugins。
+7. 创建 prompt session 并进入输入循环。
+
+由此得到：
+
+- 宿主提供的 `extra_tools` 在 `Agentao` 构造时注册，首轮即可见。
+- 既有的 `extra_tools` 校验与 capability binding 仍是唯一权威；CLI 不自行注册工具。
+- 现有 runtime guard 继续保留 plan tool 名，因此宿主 factory 不能通过
+  `extra_tools` 替换绑定 CLI plan 状态机的工具。
+- plugin 加载顺序不变。Plugin agent 使用 namespace-qualified runtime name
+  （`<plugin>:<agent>`）；本文不重定义 plugin collision 或优先级语义。
+- 每个 `AgentaoCLI` 实例调用 factory 一次。两个 CLI 实例可以使用不同 factory 与**宿主工具集合**，不共享可变注册状态。该隔离性断言仅限于经 factory 构造的工具：inline plugin 目录仍是进程全局的（`agentao/cli/entrypoints.py:373` 写入 `_globals._plugin_inline_dirs`），因此同一进程内 plugin 贡献的工具仍被多实例共享。本文不改变这一点。
+
+## 5. 为什么选择这个形态
+
+### 5.1 与 ACP 先例一致
+
+`agentao/acp/session_new.py` 已定义 `AgentFactory = Callable[..., Agentao]`，并在
+`handle_session_new()` / `register()` 中接受它。ACP handler 自己拥有 transport、权限与 session 状态，再把这些对象交给注入 factory。交互式 CLI 面临相同的所有权问题，应采用同一种依赖注入形态。
+
+两处有意偏离：CLI 的参数默认值是 `None` 而非默认 factory（§3）；且两个 `AgentFactory` alias 的**调用契约并不相同**——ACP 的是 `(cwd, client_capabilities, transport, permission_engine, mcp_servers, model)`，CLI 的是 `(transport, max_context_tokens, plan_session)`。用同一个 alias 名字承载不兼容签名是真实的混淆风险，见 §11 Q1。
+
+### 5.2 解开构造循环
+
+直接传预构造 `Agentao` 不是正确接缝。CLI transport 就是 `AgentaoCLI` 实例本身，plan session 也由该实例创建；二者在 CLI 构造前都不存在。factory 把 runtime 构造推迟到 CLI 所有的依赖就绪之后。
+
+### 5.3 不镜像每个 runtime kwarg
+
+只增加 `extra_tools=` 能狭义解决 issue #132，但 `disable_tools`、`enabled_tools`、
+`filesystem`、`shell`、`llm_client` 与未来宿主契约仍不可达。在
+`AgentaoCLI` 上重复 `Agentao` 构造参数，会制造两份不断漂移的公开签名。factory 直接转接已有契约。
+
+### 5.4 保持所有权边界
+
+曾考虑 `agent_overrides: Mapping[str, Any]`，但否决：它需要为 `transport`、
+`plan_session`、`max_context_tokens` 定义合并优先级，还会把构造参数拼写错误变成弱类型 CLI 表面。callable 的责任更明确：消费 CLI 所有的依赖并返回 runtime。
+
+## 6. 兼容性与失败行为
+
+- 两个新参数都是可选、keyword-only；现有 Python 与 console 调用保持源码兼容。
+- `agent_factory=None` 时仍走完全相同的
+  `build_from_environment(transport=..., max_context_tokens=...,
+  plan_session=...)` 路径。
+- `resume_session` 保持既有含义与位置参数兼容性。
+- 直接构造 `AgentaoCLI(...)` 时，factory 异常像今天的构造异常一样向调用者传播。
+- `main(...)` 保持现有顶层异常处理和 fatal error 展示；本文不改 exit code，也不让 `main()` 返回 agent。但要看清这继承了什么：`agentao/cli/entrypoints.py:82-84` 捕获裸 `Exception`，只打印一行 `Fatal error: {e}` 便 `sys.exit(1)`，**没有 traceback**。宿主 factory 签名写错抛出的 `TypeError`，因此只会得到一行文本，没有任何指向宿主自身代码的栈帧——对一个受众全是嵌入方的接口，这个体验很差。见 §11 Q4。
+- factory 按实例持有，不需要锁或全局清理。
+- 该接缝成为有文档的公开 CLI-embedding API，未来若改变调用契约，需要走正常 deprecation。
+
+## 7. 被否决的替代方案
+
+| 方案 | 决定 |
+|---|---|
+| 只给 `AgentaoCLI` / `main()` 增加 `extra_tools=` | 不作为主设计：只修一个构造契约，之后仍会重复扩签名 |
+| 传预构造 `Agentao` | 否决：无法自然接收 `transport=self` 和 CLI 所有的 `PlanSession` |
+| 让 `main()` 返回 agent | 否决：交互循环结束后才返回，赶不上首轮注入 |
+| 增加 `configure_agent(agent)` 构造后 callback | 否决：重复 runtime 构造期契约，并把它相对 plan tools/plugins 的顺序变成新 API |
+| 全局 entry point 或 registry | 否决：进程全局变更、发现/顺序问题、多实例隔离差 |
+| 扩展 plugin manifest 承载 tools | 否决：显著扩大代码加载、信任、权限、打包与命名空间表面 |
+| 把 monkey-patch 写成支持姿势 | 否决：耦合 import 拓扑、非局部、多实例不安全、可静默失效 |
+| 用 MCP 绕过 | 不视为等价：适合远程/进程工具，但增加 transport 与生命周期成本，不能替代进程内 `extra_tools` |
+
+## 8. 范围边界：`agentao run`
+
+`agentao/cli/run.py:527` 同样通过固定的
+`build_from_environment(**factory_kwargs)` 构造 agent。这个自动化入口也有抽象上的扩展性问题，但它的公开表面不同：`RunSpec`、退出 envelope、signal handling 与非交互 transport。
+
+Issue #132 的真实触发方是嵌入**交互式 CLI** 的薄宿主。因此本文不把 Python callable 一路穿过 `execute()` / `_execute_with_args()`。若未来出现真实宿主需要嵌入
+`agentao run`，应另开设计并配自动化专属测试，而不是暗中扩大本次改动。
+
+ACP 无需对应修改：它已经暴露 `agent_factory`。
+
+## 9. 实现改动面
+
+| 改动 | 位置 | 状态 |
+|---|---|---|
+| `AgentFactory` alias、可选 keyword-only `agent_factory`、factory 调用与 `_check_agent_postconditions` | `agentao/cli/app.py` | 已落地 |
+| 可选 keyword-only `agent_factory` 转发给 `AgentaoCLI` | `agentao/cli/entrypoints.py` | 已落地 |
+| 聚焦的 factory 接缝与后置条件测试 | `tests/test_cli_agent_factory.py` | 已落地（12 项） |
+| 从不受支持的 `build_from_environment` patch 接缝迁出 | `tests/test_clear_resets_confirm.py` | 已落地（5 项） |
+| 为 typing 导出 `AgentFactory`，或保持内部 | `agentao/cli/__init__.py` | **暂缓——Q1** |
+| 在 reference 或 embedding guide 增加编程式交互 CLI 示例 | `docs/reference/` 或 embedding guide | **待办** |
+
+`Agentao`、工具 registry、plugin models、MCP 与 `agentao.host` exports 均无需修改。
+
+有两项顺带的清理由本改动自然带出，应随本改动一并落地，而非另起 PR：
+
+- `agentao/cli/app.py:30` 当前的死 import `from ..agent import Agentao` 会因作为 `AgentFactory = Callable[..., Agentao]` 的指代对象而重新变为有效引用。
+- §1 列出的交互式 CLI 测试可以从今天拦截不到任何东西的 `patch('agentao.cli.app.Agentao')` 迁移到注入 fake factory，从而真正测到它们声称在测的东西。
+
+## 10. 测试矩阵与验收标准
+
+### 测试
+
+1. Recording factory 收到 `transport is cli`、CLI 的同一个 `_plan_session`，以及环境解析出的 context limit。
+2. 转发 `extra_tools` 的 partial factory 让工具在第一次 `cli.run()` turn 前可见。
+3. `main(agent_factory=factory)` 把同一个 callable 转给 `AgentaoCLI`，且 resume 行为不变。
+4. 不传 factory 的 `AgentaoCLI()` 仍走当前默认路径。
+5. 两个 CLI 实例用不同 factory，**宿主**工具集合不同且不泄漏。plugin 贡献的工具不在该断言范围内（§4）。
+6. factory 异常分别走既有的直接构造和 `main()` 错误路径。
+7. 返回未带 `permission_engine` 的 runtime 时，报错应可诊断，而不是裸的 `NoneType` `AttributeError`（§3.1）；若最终决定不加 guard，则改为文档化后置条件并有意删除本条。
+8. 既有 interactive CLI、resume、plan、plugin、status 测试继续全绿。单看这条是弱信号：按 §1，这些测试今天就在 patch 一个拦截不到任何东西的名字却照样绿，所以「仍然全绿」并不能证明接缝被覆盖。真正覆盖它的是第 1 条与 §9 中迁移后的测试。
+
+### 验收标准
+
+- 下游宿主能删除全部 monkey-patch，通过有文档的 callable 启动带
+  `extra_tools` 的原生交互式 CLI。
+- 注入工具首轮可见，并保留既有 capability binding 与校验行为。
+- 默认 console 启动行为不变。
+- 修复不增加全局 registry、plugin feature、配置格式或新的工具优先级规则。
+
+## 11. 待评审问题
+
+1. **是否导出 type alias，以及用什么名字？** 这是一个决定里的两个问题。`AgentFactory` 可以保持内部、只文档化 callable 契约，也可以作为 lazy `agentao.cli` export 改善 typing 体验。但**以该名字导出**会让树内出现两个调用契约不兼容的公开 `AgentFactory`（§5.1）。可选项：保持内部；以 `CliAgentFactory` 导出；或坚持从 `agentao.cli` 导出 `AgentFactory`，接受由模块限定路径来消歧。倾向：保持内部；若要导出则用 `CliAgentFactory`。
+2. **参数命名：** `agent_factory` 与 ACP 一致，优先采用。`runtime_factory` 更直白，但会为同一种模式制造两个名字。（注意本问与 Q1 正交——**参数名**可以与 ACP 一致，**type alias** 不必。）
+3. ~~**是否为 transport 后置条件加 guard？**~~ **已决：加检查**，形式为对 `agent.transport` 与 `agent.tool_runner._transport` 两者做**链式可达性**判定。开启该检查后立刻暴露出 `tests/test_clear_resets_confirm.py` 中 5 个测试——它们 patch `agentao.cli.app.build_from_environment` 并返回裸 `Mock()`；现已改为经 `agent_factory=` 构造真实 runtime。这正是 §1 论证的缩微复现：一个不受支持的接缝，在契约检查存在的那一刻才由「静默通过」变为「响亮失败」。
+4. **`main()` 下的 factory 错误：** `main()` 是否应对 factory 异常特殊处理，输出 traceback 或面向嵌入方的提示（§6）？这么做会改变 `main()` 的错误展示，而 §2 已将其列为范围外——但现状是嵌入方为自己的 bug 只拿到一行报告。
+5. **`agentao run` 后续：** 只在真实编程式自动化宿主出现后开启；默认不并入 issue #132。
+6. **是否要求 `isinstance(agent, Agentao)`？** 后置条件是 `hasattr` 探测，`Mock` 或 `__getattr__` proxy 会空洞通过（§3.1）。加 `isinstance` 能堵死这点，也契合非目标 6（「factory 返回真实、与 CLI 兼容的 `Agentao` runtime」）——但它会禁掉本接缝正要服务的 proxy / wrapper runtime，并强制每个 test double 都必须是真 runtime。当前**不**强制；属性清单是折中方案。
+7. **`llm_client=` 对子 agent 不安全。** 注入的 client 对主 runtime 有效，但不被子 agent 继承：`AgentToolWrapper` 会从原始 `api_key` / `base_url` / `model` 标量重新解析并构造一个原生 client，于是 `/agent <name> <task>` 绕过宿主的代理、鉴权与埋点；而缺少 `api_key` 属性的鸭子类型 client 会在那里抛错。此为既存问题、非本接缝引入，但它使 `llm_client=` 对 CLI 宿主构成过度承诺。修复需把 client 贯穿到子 agent 构造，属另一次改动。
+

--- a/tests/test_clear_resets_confirm.py
+++ b/tests/test_clear_resets_confirm.py
@@ -1,159 +1,98 @@
-"""Test that /clear command resets tool confirmation mode."""
+"""Test that /clear command resets tool confirmation mode.
 
-from unittest.mock import Mock, patch
+These tests drive the production reset path rather than simulating it. `/clear`
+(``agentao/cli/input_loop.py``) resets blanket tool auto-approval indirectly, by
+calling ``cli._apply_mode(PermissionMode.WORKSPACE_WRITE)`` — which is where
+``allow_all_tools = False`` actually lives (``agentao/cli/app.py::_apply_mode``).
+Asserting a hand-assigned ``cli.allow_all_tools = False`` would pass even if
+that line were deleted, leaving a user who answered "yes to all" with blanket
+auto-approval across `/clear`.
 
+The runtime is injected via ``AgentaoCLI(agent_factory=...)`` and pinned to a
+``tmp_path``. Patching ``agentao.cli.app.build_from_environment`` was never a
+supported seam (``docs/design/cli-host-agent-factory.md`` §1), and a bare
+``Mock()`` runtime is now rejected by the §3.1 post-conditions.
+"""
 
-def test_clear_resets_confirmation():
-    """Test that clear command resets allow_all_tools to False."""
+from functools import partial
+from unittest.mock import patch
 
-    with patch('agentao.cli.app.safe_load_dotenv'), patch('agentao.cli.subcommands._load_and_register_plugins'):
-        with patch('agentao.cli.app.build_from_environment') as mock_agent_class:
-            # Mock the agent instance
-            mock_agent = Mock()
-            mock_agent_class.return_value = mock_agent
+import pytest
 
-            from agentao.cli import AgentaoCLI
-
-            cli = AgentaoCLI()
-
-            # Enable allow_all mode
-            cli.allow_all_tools = True
-            assert cli.allow_all_tools is True, "Should start as True"
-
-            # Simulate /clear command handling
-            cli.agent.clear_history()
-            cli.allow_all_tools = False  # This is what the clear command does
-
-            # Verify it's reset
-            assert cli.allow_all_tools is False, "Should be reset to False after clear"
-            print("✅ /clear command resets allow_all_tools to False")
+from agentao.embedding import build_from_environment
+from agentao.permissions import PermissionMode
 
 
-def test_clear_command_flow():
-    """Test the full flow of clear command with confirmation reset."""
-
-    with patch('agentao.cli.app.safe_load_dotenv'), patch('agentao.cli.subcommands._load_and_register_plugins'):
-        with patch('agentao.cli.app.build_from_environment') as mock_agent_class:
-            mock_agent = Mock()
-            mock_agent_class.return_value = mock_agent
-
-            from agentao.cli import AgentaoCLI
-
-            cli = AgentaoCLI()
-
-            # Simulate workflow:
-            # 1. User enables allow_all
-            cli.allow_all_tools = True
-
-            # 2. User uses /clear
-            cli.agent.clear_history()
-            cli.allow_all_tools = False
-
-            # 3. Verify both are reset
-            assert cli.allow_all_tools is False, "Confirmation should be reset"
-            mock_agent.clear_history.assert_called_once()
-            print("✅ Full clear command flow works correctly")
+@pytest.fixture
+def cli(tmp_path):
+    """An AgentaoCLI backed by a real runtime rooted in ``tmp_path``."""
+    with patch('agentao.cli.app.safe_load_dotenv'), \
+            patch('agentao.cli.subcommands._load_and_register_plugins'):
+        from agentao.cli import AgentaoCLI
+        return AgentaoCLI(agent_factory=partial(
+            build_from_environment, working_directory=tmp_path))
 
 
-def test_clear_vs_reset_confirm():
-    """Test that both /clear and /reset-confirm reset confirmation."""
-
-    with patch('agentao.cli.app.safe_load_dotenv'), patch('agentao.cli.subcommands._load_and_register_plugins'):
-        with patch('agentao.cli.app.build_from_environment') as mock_agent_class:
-            mock_agent = Mock()
-            mock_agent_class.return_value = mock_agent
-
-            from agentao.cli import AgentaoCLI
-
-            # Test /clear
-            cli1 = AgentaoCLI()
-            cli1.allow_all_tools = True
-            cli1.agent.clear_history()
-            cli1.allow_all_tools = False  # clear does this
-            assert cli1.allow_all_tools is False
-            print("✅ /clear resets confirmation")
-
-            # Test /reset-confirm
-            cli2 = AgentaoCLI()
-            cli2.allow_all_tools = True
-            cli2.allow_all_tools = False  # reset-confirm does this
-            assert cli2.allow_all_tools is False
-            print("✅ /reset-confirm resets confirmation")
-
-            print("✅ Both commands reset confirmation mode")
+def _clear_reset(cli):
+    """The reset `/clear` performs — input_loop.py's `elif command == "clear"`."""
+    cli._apply_mode(PermissionMode.WORKSPACE_WRITE)
 
 
-def test_initial_state():
-    """Test that CLI starts with allow_all_tools = False."""
+def test_clear_resets_confirmation(cli):
+    """/clear turns blanket auto-approval back off."""
+    cli.allow_all_tools = True
 
-    with patch('agentao.cli.app.safe_load_dotenv'), patch('agentao.cli.subcommands._load_and_register_plugins'):
-        with patch('agentao.cli.app.build_from_environment') as mock_agent_class:
-            mock_agent = Mock()
-            mock_agent_class.return_value = mock_agent
+    _clear_reset(cli)
 
-            from agentao.cli import AgentaoCLI
-
-            cli = AgentaoCLI()
-
-            assert cli.allow_all_tools is False, "Should start as False"
-            print("✅ Initial state is correct (allow_all_tools = False)")
+    assert cli.allow_all_tools is False, "Should be reset to False after clear"
 
 
-def test_clear_makes_sense():
-    """Test the logical flow: clear should reset everything to initial state."""
+def test_clear_command_flow(cli):
+    """History clearing and confirmation reset both happen."""
+    cli.allow_all_tools = True
 
-    with patch('agentao.cli.app.safe_load_dotenv'), patch('agentao.cli.subcommands._load_and_register_plugins'):
-        with patch('agentao.cli.app.build_from_environment') as mock_agent_class:
-            mock_agent = Mock()
-            mock_agent_class.return_value = mock_agent
+    with patch.object(cli.agent, 'clear_history') as mock_clear:
+        cli.agent.clear_history()
+        _clear_reset(cli)
 
-            from agentao.cli import AgentaoCLI
-
-            cli = AgentaoCLI()
-
-            # Initial state
-            initial_allow_all = cli.allow_all_tools
-            assert initial_allow_all is False
-
-            # User enables allow_all during conversation
-            cli.allow_all_tools = True
-
-            # User calls /clear to start fresh
-            cli.agent.clear_history()
-            cli.allow_all_tools = False  # Reset to initial state
-
-            # Should be back to initial state
-            assert cli.allow_all_tools == initial_allow_all
-            print("✅ /clear logically resets to initial state")
+    assert cli.allow_all_tools is False, "Confirmation should be reset"
+    mock_clear.assert_called_once()
 
 
-if __name__ == "__main__":
-    print("Testing /clear command resets confirmation mode...")
-    print()
+def test_clear_resets_from_every_mode(cli):
+    """The reset holds regardless of the mode the user was in."""
+    for mode in (PermissionMode.READ_ONLY, PermissionMode.FULL_ACCESS,
+                 PermissionMode.WORKSPACE_WRITE):
+        cli._apply_mode(mode)
+        cli.allow_all_tools = True
 
-    try:
-        test_clear_resets_confirmation()
-        print()
-        test_clear_command_flow()
-        print()
-        test_clear_vs_reset_confirm()
-        print()
-        test_initial_state()
-        print()
-        test_clear_makes_sense()
-        print()
-        print("=" * 50)
-        print("✅ All tests passed!")
-        print("\n[INFO] /clear command now resets:")
-        print("       - Conversation history")
-        print("       - Tool confirmation mode")
-    except AssertionError as e:
-        print(f"❌ Test failed: {e}")
-        import traceback
-        traceback.print_exc()
-        exit(1)
-    except Exception as e:
-        print(f"❌ Unexpected error: {e}")
-        import traceback
-        traceback.print_exc()
-        exit(1)
+        _clear_reset(cli)
+
+        assert cli.allow_all_tools is False, f"not reset when coming from {mode}"
+
+
+def test_clear_restores_workspace_write(cli):
+    """/clear also drops an escalated posture back to workspace-write."""
+    cli._apply_mode(PermissionMode.FULL_ACCESS)
+    assert cli.current_mode == PermissionMode.FULL_ACCESS
+
+    _clear_reset(cli)
+
+    assert cli.current_mode == PermissionMode.WORKSPACE_WRITE
+    assert cli.permission_engine.active_mode == PermissionMode.WORKSPACE_WRITE
+
+
+def test_initial_state(cli):
+    """CLI starts with allow_all_tools = False."""
+    assert cli.allow_all_tools is False, "Should start as False"
+
+
+def test_clear_makes_sense(cli):
+    """The logical flow: clear returns everything to the initial state."""
+    initial_allow_all = cli.allow_all_tools
+    assert initial_allow_all is False
+
+    cli.allow_all_tools = True
+    _clear_reset(cli)
+
+    assert cli.allow_all_tools == initial_allow_all

--- a/tests/test_cli_agent_factory.py
+++ b/tests/test_cli_agent_factory.py
@@ -1,0 +1,347 @@
+"""Host injection seam for the interactive CLI (`agent_factory`).
+
+Covers the contract in ``docs/design/cli-host-agent-factory.md``:
+
+* §3   — the CLI calls the factory with exactly its three owned kwargs
+* §3.1 — post-conditions on the returned runtime
+* §3.2 — pre-bound CLI-owned kwargs and unreachable transports are rejected
+
+These tests inject a factory rather than patching module globals. Note that
+``patch('agentao.cli.app.Agentao')`` — used by several older CLI tests —
+intercepts nothing, because construction goes through
+``build_from_environment``, which imports ``Agentao`` locally.
+
+Every test that reaches the real factory pins ``working_directory`` to a
+``tmp_path``: ``build_from_environment`` otherwise resolves ``Path.cwd()``,
+which under pytest is the repo root, and would create/mutate the developer's
+real ``.agentao/memory.db``, background-task store, and ``agentao.log``.
+"""
+
+from functools import partial
+from unittest.mock import patch
+
+import pytest
+
+from agentao.embedding import build_from_environment
+
+
+def _make_cli(**kwargs):
+    """Build an AgentaoCLI with plugin loading and dotenv reads suppressed."""
+    with patch('agentao.cli.app.safe_load_dotenv'), \
+            patch('agentao.cli.subcommands._load_and_register_plugins'):
+        from agentao.cli import AgentaoCLI
+        return AgentaoCLI(**kwargs)
+
+
+def _isolated(tmp_path, **extra):
+    """A factory that builds a real runtime rooted in ``tmp_path``."""
+    return partial(build_from_environment, working_directory=tmp_path, **extra)
+
+
+class _RecordingFactory:
+    """Wraps the real factory and records the kwargs the CLI passed."""
+
+    def __init__(self, working_directory, **extra):
+        self.calls = []
+        self._extra = {"working_directory": working_directory, **extra}
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return build_from_environment(**{**kwargs, **self._extra})
+
+
+def _host_tool(tool_name):
+    """A minimal host-supplied Tool instance."""
+    from agentao.tools.base import Tool
+
+    return type(
+        "_HostTool", (Tool,),
+        {
+            "name": tool_name,
+            "description": "injected by the host",
+            "parameters": {"type": "object", "properties": {}},
+            "requires_confirmation": False,
+            "execute": lambda self, **kw: "ok",
+        },
+    )()
+
+
+# ── §3: the CLI-owned kwarg set ────────────────────────────────────────────
+
+def test_factory_receives_cli_owned_kwargs(tmp_path):
+    """Transport is the CLI, plan_session is the CLI's own object."""
+    factory = _RecordingFactory(tmp_path)
+    cli = _make_cli(agent_factory=factory)
+
+    assert len(factory.calls) == 1, "factory must be invoked exactly once"
+    call = factory.calls[0]
+    assert set(call) == {"transport", "max_context_tokens", "plan_session"}
+    assert call["transport"] is cli
+    assert call["plan_session"] is cli._plan_session
+    assert isinstance(call["max_context_tokens"], int)
+
+
+def test_context_limit_comes_from_environment(tmp_path, monkeypatch):
+    """The forwarded limit tracks AGENTAO_CONTEXT_TOKENS."""
+    monkeypatch.setenv("AGENTAO_CONTEXT_TOKENS", "12345")
+    factory = _RecordingFactory(tmp_path)
+    _make_cli(agent_factory=factory)
+    assert factory.calls[0]["max_context_tokens"] == 12345
+
+
+def test_extra_tools_visible_before_first_turn(tmp_path):
+    """A host tool is registered by construction, not on the first turn."""
+    cli = _make_cli(agent_factory=_isolated(tmp_path, extra_tools=[_host_tool("host_probe")]))
+
+    assert "host_probe" in cli.agent.tools.tools
+
+
+def test_default_path_unchanged(tmp_path, monkeypatch):
+    """No factory means the current build_from_environment path."""
+    monkeypatch.chdir(tmp_path)
+    cli = _make_cli()
+    assert cli.agent is not None
+    assert cli.agent.transport is cli
+    assert cli.agent.permission_engine is not None
+    assert cli.agent._plan_session is cli._plan_session
+
+
+def test_two_instances_do_not_share_host_tools(tmp_path):
+    """Host tool sets are per-instance (plugins are out of scope)."""
+    cli_a = _make_cli(agent_factory=_isolated(
+        tmp_path / "a", extra_tools=[_host_tool("tool_a")]))
+    cli_b = _make_cli(agent_factory=_isolated(
+        tmp_path / "b", extra_tools=[_host_tool("tool_b")]))
+
+    assert "tool_a" in cli_a.agent.tools.tools
+    assert "tool_a" not in cli_b.agent.tools.tools
+    assert "tool_b" in cli_b.agent.tools.tools
+    assert "tool_b" not in cli_a.agent.tools.tools
+
+
+def test_reused_tool_instance_is_rebound_by_the_second_cli(tmp_path):
+    """Documents a real hazard: one Tool object across two CLIs is shared state.
+
+    ``_bind_and_register`` assigns ``working_directory`` / ``filesystem`` /
+    ``shell`` onto the tool *object*, so a host that reuses one factory (and
+    therefore one ``extra_tools`` list) for two CLI sessions has the second
+    construction silently rebind the first CLI's tool. Asserting the current
+    behavior keeps the hazard visible rather than implying isolation that
+    ``test_two_instances_do_not_share_host_tools`` — which builds distinct Tool
+    objects — cannot detect.
+    """
+    shared = _host_tool("shared_probe")
+    factory_a = _isolated(tmp_path / "a", extra_tools=[shared])
+    factory_b = _isolated(tmp_path / "b", extra_tools=[shared])
+
+    cli_a = _make_cli(agent_factory=factory_a)
+    assert shared.working_directory == cli_a.agent.working_directory
+
+    _make_cli(agent_factory=factory_b)
+    # The *same* object now points at the second CLI's root — the first CLI's
+    # registry still holds it, so its relative paths resolve to the wrong root.
+    assert shared.working_directory != cli_a.agent.working_directory
+    assert cli_a.agent.tools.tools["shared_probe"] is shared
+
+
+def test_factory_exception_propagates_from_constructor():
+    """Direct construction lets the host see its own failure."""
+    def _boom(**kwargs):
+        raise RuntimeError("host factory failed")
+
+    with pytest.raises(RuntimeError, match="host factory failed"):
+        _make_cli(agent_factory=_boom)
+
+
+# ── §3.2: CLI-owned kwargs cannot be pre-bound ─────────────────────────────
+
+@pytest.mark.parametrize("kwarg", ["transport", "max_context_tokens", "plan_session"])
+def test_rejects_partial_prebinding_cli_owned_kwarg(kwarg):
+    """A partial's keyword loses to the call-time keyword, silently.
+
+    Nothing downstream can detect this — the runtime ends up correctly bound to
+    the CLI and every post-condition passes — so it must be caught before the
+    factory runs.
+    """
+    factory = partial(build_from_environment, **{kwarg: object()})
+
+    with pytest.raises(TypeError, match="pre-binds CLI-owned keyword"):
+        _make_cli(agent_factory=factory)
+
+
+def test_allows_partial_with_non_cli_owned_kwargs(tmp_path):
+    """The documented shape — partial carrying extra_tools — still works."""
+    cli = _make_cli(agent_factory=_isolated(
+        tmp_path, extra_tools=[_host_tool("ok_probe")]))
+    assert "ok_probe" in cli.agent.tools.tools
+
+
+# ── §3.1: post-conditions on the returned runtime ──────────────────────────
+
+def test_rejects_none_return():
+    with pytest.raises(TypeError, match="returned None"):
+        _make_cli(agent_factory=lambda **kw: None)
+
+
+def test_rejects_object_missing_required_attrs():
+    """A duck-typed stand-in names every attribute it lacks, at once."""
+    class _NotAnAgent:
+        pass
+
+    with pytest.raises(TypeError) as exc:
+        _make_cli(agent_factory=lambda **kw: _NotAnAgent())
+
+    message = str(exc.value)
+    assert "_NotAnAgent" in message
+    for attr in ("transport", "working_directory", "permission_engine",
+                 "tools", "tool_runner", "memory_manager", "clear_history"):
+        assert attr in message
+
+
+def test_rejects_substituted_transport(tmp_path):
+    """The silent-hang failure mode becomes a loud error."""
+    class _OtherTransport:
+        pass
+
+    def _factory(**kwargs):
+        kwargs["transport"] = _OtherTransport()
+        return build_from_environment(working_directory=tmp_path, **kwargs)
+
+    with pytest.raises(TypeError, match="transport does not reach"):
+        _make_cli(agent_factory=_factory)
+
+
+def test_accepts_wrapped_transport_reaching_the_cli(tmp_path):
+    """Reachability, not identity — agentao's own ReplayAdapter wraps this way."""
+    class _TeeAdapter:
+        def __init__(self, inner):
+            self.inner = inner
+
+        def __getattr__(self, name):
+            return getattr(self.inner, name)
+
+    def _factory(**kwargs):
+        agent = build_from_environment(working_directory=tmp_path, **kwargs)
+        adapter = _TeeAdapter(agent.transport)
+        agent.transport = adapter
+        agent.tool_runner._transport = adapter
+        return agent
+
+    cli = _make_cli(agent_factory=_factory)
+    assert cli.agent.transport.inner is cli
+
+
+def test_rejects_out_of_sync_tool_runner_transport(tmp_path):
+    """agent.transport alone is not enough — ToolRunner holds its own copy."""
+    class _Stale:
+        pass
+
+    def _factory(**kwargs):
+        agent = build_from_environment(working_directory=tmp_path, **kwargs)
+        agent.tool_runner._transport = _Stale()
+        return agent
+
+    with pytest.raises(TypeError, match=r"tool_runner\._transport does not reach"):
+        _make_cli(agent_factory=_factory)
+
+
+def test_rejects_none_permission_engine(tmp_path):
+    """The sharpest post-condition: no bare NoneType AttributeError."""
+    def _factory(**kwargs):
+        agent = build_from_environment(working_directory=tmp_path, **kwargs)
+        agent.permission_engine = None
+        return agent
+
+    with pytest.raises(TypeError, match="permission_engine=None"):
+        _make_cli(agent_factory=_factory)
+
+
+def test_rejects_substituted_plan_session(tmp_path):
+    """Dropping plan_session silently breaks /plan, so it is enforced."""
+    def _factory(*, transport, max_context_tokens, plan_session):
+        # Drops plan_session — the runtime builds its own.
+        return build_from_environment(
+            working_directory=tmp_path,
+            transport=transport,
+            max_context_tokens=max_context_tokens,
+        )
+
+    with pytest.raises(TypeError, match="different PlanSession"):
+        _make_cli(agent_factory=_factory)
+
+
+# ── working_directory / settings interaction ───────────────────────────────
+
+def test_saved_mode_is_read_from_the_factory_working_directory(tmp_path, monkeypatch):
+    """A factory-supplied root must not be shadowed by the process cwd.
+
+    The mode is read once before the factory runs (the root is not yet known)
+    and re-read afterwards if the factory moved it. Without the re-read the
+    project's saved posture is ignored at startup and then overwritten.
+    """
+    import json
+
+    project = tmp_path / "project"
+    (project / ".agentao").mkdir(parents=True)
+    (project / ".agentao" / "settings.json").write_text(
+        json.dumps({"mode": "read-only"}), encoding="utf-8")
+
+    # Process cwd holds a *different*, more permissive posture.
+    cwd = tmp_path / "cwd"
+    (cwd / ".agentao").mkdir(parents=True)
+    (cwd / ".agentao" / "settings.json").write_text(
+        json.dumps({"mode": "full-access"}), encoding="utf-8")
+    monkeypatch.chdir(cwd)
+
+    from agentao.permissions import PermissionMode
+
+    cli = _make_cli(agent_factory=_isolated(project))
+
+    assert cli._project_root == project.resolve()
+    assert cli.current_mode == PermissionMode.READ_ONLY
+    assert cli.permission_engine.active_mode == PermissionMode.READ_ONLY
+
+
+# ── main() forwarding ──────────────────────────────────────────────────────
+
+def _run_main(**kwargs):
+    """Invoke main() without leaking /dev/tty fds or atexit handlers.
+
+    ``main()`` opens ``/dev/tty`` and registers a process-wide terminal-restore
+    handler; neither is cleaned up on the success path, so an unguarded call
+    from a test leaks an fd and leaves a handler that fires at pytest exit.
+    """
+    from agentao.cli import entrypoints
+
+    seen = {}
+
+    class _FakeCLI:
+        def __init__(self, *, agent_factory=None):
+            seen["factory"] = agent_factory
+
+        def run(self):
+            seen["ran"] = True
+
+    with patch('agentao.cli.app.AgentaoCLI', _FakeCLI), \
+            patch('agentao.cli.entrypoints.atexit.register'), \
+            patch.dict('sys.modules', {'termios': None}):
+        entrypoints.main(**kwargs)
+
+    return seen
+
+
+def test_main_forwards_factory_identity(tmp_path):
+    """main() hands the identical callable to AgentaoCLI."""
+    sentinel = _RecordingFactory(tmp_path)
+    seen = _run_main(agent_factory=sentinel)
+
+    assert seen["factory"] is sentinel
+    assert seen.get("ran") is True
+
+
+def test_main_defaults_to_none_factory():
+    """Console startup is unchanged: no factory reaches AgentaoCLI."""
+    seen = _run_main()
+
+    assert seen["factory"] is None
+    assert seen.get("ran") is True


### PR DESCRIPTION
Closes #132.

## Problem

A Python host embedding the **interactive CLI** had no supported way to reach agentao's existing host tool-injection contract. `Agentao` accepts `extra_tools` / `disable_tools` / `enabled_tools` and `build_from_environment(**overrides)` forwards them, but `AgentaoCLI` called the factory with a fixed kwarg set and `main()` constructed the CLI and ran it immediately. The only workaround was patching module globals — fragile, since `cli/app.py` imports the factory by name, and silent when it breaks.

That silent-failure mode was already live in-tree: `cli/app.py` imported `Agentao` without using it, and four CLI test modules patched that dead name. The patches intercepted nothing; the tests passed anyway.

## Change

Keyword-only `agent_factory` on `AgentaoCLI.__init__` and `cli.main()`, called as `factory(transport=self, max_context_tokens=..., plan_session=...)` — mirroring the ACP precedent in `acp/session_new.py`. Default `None` takes the exact existing path, so console startup is unchanged.

```python
main(agent_factory=partial(
    build_from_environment,
    extra_tools=[NewsSearchTool(), PublishTool()],
    disable_tools={"web_search"},
))
```

### Validation of the returned runtime

The CLI binds several attributes off the agent, so `_check_agent_postconditions` names the violated post-condition instead of failing far from the cause:

- required attributes, reported together in one `TypeError`;
- `permission_engine` non-`None` — otherwise a bare `AttributeError: 'NoneType' has no attribute 'set_mode'`;
- `_plan_session` identical to the CLI's — dropping it leaves `/plan` switching the CLI but not the runtime, hiding `plan_save`/`plan_finalize` from the model with no way to finish the plan;
- the CLI **reachable** from both `agent.transport` and `tool_runner._transport`. Reachability rather than identity because wrapping is agentao's own convention — `ReplayManager.start()` splices a `ReplayAdapter` exposing `inner`. `ToolRunner` keeps its own transport copy and routes permission prompts through it, so the two fields must agree or the CLI hangs at the first confirmation.

### Two ordering hazards the seam introduced

- **`functools.partial` pre-binding.** Python resolves `partial(f, k=v)(k=w)` to `w`, so a host's `transport=` is silently discarded while the runtime ends up correctly bound and every post-condition passes. Undetectable after construction — rejected before the call.
- **Permission mode read from the wrong root.** The mode is read before the factory runs, from a cwd-derived root later rebound to `agent.working_directory`. Without a re-read, a project's saved posture is ignored at startup and overwritten by the next `/mode`. The old code was correct only because the CLI passed no `working_directory`.

## Tests

21 new seam/post-condition tests. Each is pinned to `tmp_path` — previously the suite wrote to the developer's real `.agentao/memory.db`, background-task store, and `agentao.log`. `main()` invocations no longer leak `/dev/tty` fds or atexit handlers.

`test_clear_resets_confirm.py` migrates off the unsupported patch seam and drives the real reset path. The previous version hand-assigned `allow_all_tools = False` and asserted it — it would have passed with the production reset deleted. Each new guard was mutation-tested: disabling it fails exactly its own test.

Full suite: **3551 passed, 2 skipped**. Interactive startup and a programmatic host embed both verified end to end.

## Known limits (recorded in the design doc, not fixed here)

- The checks are `hasattr`/`is` probes; a `Mock` or `__getattr__` proxy satisfies them vacuously. Closing that needs `isinstance(agent, Agentao)`, which would forbid the proxy/wrapper runtimes this seam serves — left as open Q6 rather than decided unilaterally.
- `llm_client=` is used by the main runtime but **not** inherited by sub-agents: `AgentToolWrapper` rebuilds a stock client from raw scalars, so `/agent` bypasses a host's proxy/auth/instrumentation. Pre-existing, outside this diff; removed from the documented example and recorded as Q7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)