### PR TITLE
feat(mcp): send a default User-Agent on URL-transport requests

### DIFF
--- a/agentao/mcp/client.py
+++ b/agentao/mcp/client.py
@@ -18,6 +18,7 @@ from mcp.client.streamable_http import (
 )
 from mcp.types import Tool as McpToolDef
 
+from .. import __version__
 from ..capabilities.process import build_child_env
 from .config import (
     McpServerConfig,
@@ -138,6 +139,28 @@ _PREFLIGHT_TIMEOUT_SECONDS = 5.0
 # can actually run to completion over SSE, while small per-request budgets
 # don't shorten the idle tolerance of the long-lived stream between calls.
 _DEFAULT_SSE_READ_TIMEOUT = 300.0
+
+# Default ``User-Agent`` for URL-transport MCP requests. Without it every SSE /
+# Streamable HTTP request (and the content-type preflight) goes out as the bare
+# ``python-httpx`` UA, leaving agentao anonymous in server logs and tripping
+# servers that filter or rate-limit unknown clients. The UA is informational
+# only — not an auth/trust signal — and a user-configured ``User-Agent`` header
+# still wins (see :func:`_with_default_user_agent`).
+_MCP_USER_AGENT = f"agentao-mcp/{__version__}"
+
+
+def _with_default_user_agent(headers: Optional[Dict[str, str]]) -> Dict[str, str]:
+    """Return *headers* with :data:`_MCP_USER_AGENT` added when none is set.
+
+    A user-supplied ``User-Agent`` — in *any* casing, since HTTP header names
+    are case-insensitive — is preserved, so an explicit override wins. The input
+    is copied, never mutated: it aliases ``self.config['headers']``, which is
+    re-read on every (re)connect.
+    """
+    result = dict(headers or {})
+    if not any(key.lower() == "user-agent" for key in result):
+        result["User-Agent"] = _MCP_USER_AGENT
+    return result
 
 
 class ServerStatus(str, Enum):
@@ -381,7 +404,10 @@ class McpClient:
         itself is applied in ``call_tool`` via ``read_timeout_seconds``.
         """
         url = self.config["url"]
-        headers = self.config.get("headers", {})
+        # Add a default User-Agent (preserving a user-configured one) before the
+        # preflight so every agentao MCP request on this URL — probe, handshake,
+        # and tool calls — identifies itself consistently.
+        headers = _with_default_user_agent(self.config.get("headers"))
         sse_read_timeout = (
             request_timeout
             if request_timeout is not None and request_timeout > _DEFAULT_SSE_READ_TIMEOUT
@@ -451,7 +477,9 @@ class McpClient:
             startup_timeout, request_timeout
         )
         http_client = create_mcp_http_client(
-            headers=headers or None,
+            # ``headers`` always carries at least the default User-Agent (see
+            # _prepare_url_connect), so it is never empty — pass it directly.
+            headers=headers,
             timeout=httpx.Timeout(startup_timeout, read=sse_read_timeout),
         )
         # Caller-managed lifecycle: enter the client first so the LIFO unwind

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -206,6 +206,8 @@ Full rule taxonomy, examples, and runtime semantics → [TOOL_CONFIRMATION_FEATU
 
 > **`env` and the base environment.** A stdio server's `env` entries are applied on top of a **scrubbed** copy of agentao's environment: `mcp/client.py` builds the child env via `build_child_env()`, which drops agentao's own provider credentials (`HARNESS_ENV_KEYS`). An MCP server that previously relied on *inheriting* `GEMINI_API_KEY`, `OPENAI_API_KEY`, etc. now gets a 401 — pass the key explicitly in `env` (`{"GEMINI_API_KEY": "$GEMINI_API_KEY"}`, applied after the scrub) or set `AGENTAO_SCRUB_CHILD_ENV=0` (§2) to restore full inheritance. Everything else in the environment is inherited unchanged.
 
+> **Default `User-Agent` (URL transports).** Streamable HTTP and SSE requests — including the content-type preflight — send `User-Agent: agentao-mcp/<version>` so agentao is identifiable in server logs and isn't filtered as an unknown client. Override it by setting a `User-Agent` entry in `headers` (any casing wins); stdio servers are unaffected.
+
 **Transport selection (`mcp/config.py :: resolve_transport`).** The optional
 `type` field selects the transport: `"stdio"` / `"sse"` / `"http"` (aliases
 `"streamable-http"` / `"streamable_http"` fold to `"http"`). When `type` is

--- a/tests/test_mcp_streamable_http.py
+++ b/tests/test_mcp_streamable_http.py
@@ -20,6 +20,8 @@ import pytest
 
 from agentao.mcp.client import (
     _DEFAULT_SSE_READ_TIMEOUT,
+    _MCP_USER_AGENT,
+    _with_default_user_agent,
     McpClient,
     NonMcpEndpointError,
     ServerStatus,
@@ -356,3 +358,74 @@ def test_cli_add_stdio_unaffected(tmp_path):
     servers = _cli_add(tmp_path, "add fs npx -y server")
     assert servers["fs"]["command"] == "npx"
     assert servers["fs"]["args"] == ["-y", "server"]
+
+
+# ---------------------------------------------------------------------------
+# Default User-Agent for URL-transport MCP requests (#34883 borrow)
+# ---------------------------------------------------------------------------
+
+def test_user_agent_constant_is_named_and_versioned():
+    # Server operators identify agentao by this string; keep the name/version
+    # shape so it stays greppable in their logs.
+    assert _MCP_USER_AGENT.startswith("agentao-mcp/")
+    assert _MCP_USER_AGENT != "agentao-mcp/"  # a real version is appended
+
+
+def test_with_default_user_agent_adds_when_absent():
+    assert _with_default_user_agent(None) == {"User-Agent": _MCP_USER_AGENT}
+    assert _with_default_user_agent({}) == {"User-Agent": _MCP_USER_AGENT}
+
+
+def test_with_default_user_agent_added_alongside_other_headers():
+    result = _with_default_user_agent({"Authorization": "Bearer x"})
+    assert result["Authorization"] == "Bearer x"
+    assert result["User-Agent"] == _MCP_USER_AGENT
+
+
+@pytest.mark.parametrize("name", ["User-Agent", "user-agent", "USER-AGENT", "User-agent"])
+def test_with_default_user_agent_preserves_configured_value_any_casing(name):
+    # HTTP header names are case-insensitive: a configured UA under any casing
+    # wins, and no duplicate canonical-cased default is added beside it.
+    result = _with_default_user_agent({name: "my-client/9"})
+    assert result[name] == "my-client/9"
+    ua_keys = [k for k in result if k.lower() == "user-agent"]
+    assert ua_keys == [name]
+
+
+def test_with_default_user_agent_does_not_mutate_input():
+    original = {"Authorization": "Bearer x"}
+    _with_default_user_agent(original)
+    assert original == {"Authorization": "Bearer x"}  # UA did not leak back in
+
+
+def test_streamable_http_sends_default_user_agent():
+    _, captured = _drive_connect({"url": "https://h/mcp"})
+    assert captured["client"]["headers"]["User-Agent"] == _MCP_USER_AGENT
+
+
+def test_sse_sends_default_user_agent():
+    _, captured = _drive_connect({"type": "sse", "url": "https://h/sse"})
+    assert captured["sse"]["headers"]["User-Agent"] == _MCP_USER_AGENT
+
+
+def test_preflight_probe_receives_default_user_agent():
+    # The UA is injected before the preflight call, so the probe identifies
+    # agentao too — not only the handshake and tool calls.
+    seen = {}
+
+    async def capture_preflight(self, url, headers):
+        seen["headers"] = headers
+
+    client = McpClient("svr", {"url": "https://h/mcp"})
+    with patch.object(McpClient, "_preflight_content_type", capture_preflight):
+        _url, headers, _timeout = run_async(client._prepare_url_connect(60.0, None))
+    assert seen["headers"]["User-Agent"] == _MCP_USER_AGENT
+    assert headers["User-Agent"] == _MCP_USER_AGENT  # same headers reach the transport
+
+
+def test_connect_does_not_mutate_configured_headers():
+    # The default UA must not leak back into the caller-owned config, which is
+    # re-read on every reconnect.
+    config = {"url": "https://h/mcp", "headers": {"Authorization": "Bearer x"}}
+    _drive_connect(config)
+    assert config["headers"] == {"Authorization": "Bearer x"}


### PR DESCRIPTION
## What

MCP SSE / Streamable HTTP requests (and the content-type preflight) previously went out with httpx's bare `python-httpx/x.y.z` User-Agent, leaving agentao anonymous in server logs and filterable as an unknown client. `web_fetch` already sets a UA; MCP did not.

This injects a default `User-Agent: agentao-mcp/<version>` in the shared `_prepare_url_connect` preamble, so the **preflight probe, handshake, and tool calls** all identify consistently.

- A user-configured `User-Agent` header wins — checked **case-insensitively** (HTTP header names are case-insensitive).
- The config dict is **copied, never mutated** (`self.config['headers']` is re-read on every reconnect).
- **stdio** servers are unaffected (no HTTP).

Borrowed from openai/codex #34883 (2026-07-23 pull review). The UA is informational only — not an auth/trust signal.

## Why not the other candidates from that review
- **Omit `mcp_` tool prefix per server** (codex #34991) — rejected: agentao's `mcp_` prefix is a load-bearing `enabled_tools` allowlist boundary (`tooling/registry.py`), not cosmetic namespacing.
- **Skill-catalog budget warning** (codex #34997) — N/A: agentao doesn't cap the catalog; demand-gated.

## Tests
- 11 new cases in `tests/test_mcp_streamable_http.py`: helper unit tests (absent → injected, any-casing preserve, no mutation), SSE + Streamable HTTP integration, and preflight-probe-carries-UA end-to-end.
- Full suite green (3568 passed) before the xhigh review cleanups; MCP subsuite 307 passed after.

## Review
xhigh workflow review applied 2 cleanups (dead `headers or None` branch removed; corrected a false `web_fetch`-consistency comment). One PLAUSIBLE finding (forced UA may trip allow-list WAFs) intentionally left as designed — the documented `headers` override covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)