### PR TITLE
feat(acp-client): land the June-grade acp_client audit (AC1–AC8)

### DIFF
--- a/agentao/acp_client/manager/connection.py
+++ b/agentao/acp_client/manager/connection.py
@@ -162,15 +162,10 @@ class ConnectionMixin:
                         details={"server": name},
                     )
                 _server_lock.release()
-                try:
+                with self._handshake_guarded(name):
                     existing.create_session(
                         cwd=eff_cwd, mcp_servers=eff_mcp, timeout=timeout,
                     )
-                except BaseException as exc:
-                    if self._reclassify_as_handshake_fail(exc, name):
-                        self._note_handshake_failure_and_maybe_fatal(name)
-                    raise
-                self._note_handshake_success(name)
                 return existing
 
         # Refuse to attach a new ACPClient while a concurrent prompt_once
@@ -225,21 +220,7 @@ class ConnectionMixin:
             notification_callback=_on_notification,
             server_request_callback=_on_server_request,
         )
-        # Re-label initialize()/create_session() failures as HANDSHAKE_FAIL
-        # so callers can separate protocol-level setup from ordinary RPC
-        # errors on an established session. AcpRpcError keeps its numeric
-        # ``code`` contract; we only tag the structured classification.
-        # The sticky-fatal accounting lives here (not just in the
-        # ``ensure_connected``/``prompt_once`` wrappers) so hosts that
-        # call ``connect_server`` directly get the same "2 consecutive
-        # handshakes ⇒ fatal" contract as every other entry point.
-        try:
-            client.start_reader()
-            client.initialize(timeout=timeout)
-            client.create_session(
-                cwd=cwd, mcp_servers=mcp_servers, timeout=timeout,
-            )
-        except BaseException as exc:
+        def _teardown_partial_handshake() -> None:
             # client.close() calls unsubscribe_stdout(), which detaches our
             # subscriber from the feeder thread — no stale reader remains.
             # Only stop the subprocess if we started it; a pre-warmed server
@@ -260,15 +241,18 @@ class ConnectionMixin:
                         "acp[%s]: error stopping handle after handshake failure",
                         name, exc_info=True,
                     )
-            if self._reclassify_as_handshake_fail(exc, name):
-                self._note_handshake_failure_and_maybe_fatal(name)
-            raise
 
-        # A successful connect/handshake clears the handshake-failure
-        # streak — otherwise an earlier single failure would linger and
-        # combine with a later unrelated failure to trip the sticky-fatal
-        # "consecutive handshake failures" rule across prewarmed hosts.
-        self._note_handshake_success(name)
+        # ``_handshake_guarded`` re-labels initialize()/create_session()
+        # failures as HANDSHAKE_FAIL and owns the sticky-fatal accounting, so
+        # hosts that call ``connect_server`` directly get the same "2
+        # consecutive handshakes ⇒ fatal" contract (and streak-clear on
+        # success) as every other entry point.
+        with self._handshake_guarded(name, on_failure=_teardown_partial_handshake):
+            client.start_reader()
+            client.initialize(timeout=timeout)
+            client.create_session(
+                cwd=cwd, mcp_servers=mcp_servers, timeout=timeout,
+            )
         self._clients[name] = client
         return client
 
@@ -390,20 +374,15 @@ class ConnectionMixin:
                         details={"server": name},
                     )
                 _server_lock.release()
-            try:
+            # Successful re-session clears the streak the same as a greenfield
+            # handshake (so a prior isolated failure cannot combine with a
+            # future one); a failure feeds the same sticky-fatal accounting.
+            with self._handshake_guarded(name):
                 client.create_session(
                     cwd=effective_cwd,
                     mcp_servers=effective_mcp,
                     timeout=timeout,
                 )
-            except BaseException as exc:
-                if self._reclassify_as_handshake_fail(exc, name):
-                    self._note_handshake_failure_and_maybe_fatal(name)
-                raise
-            # Successful re-session — treat the same as a successful
-            # greenfield handshake and clear the streak so a prior
-            # isolated failure cannot combine with a future one.
-            self._note_handshake_success(name)
             return client
         # No cached long-lived client.  Before spawning a brand-new ACPClient
         # (which starts a competing reader thread on the handle's stdout),

--- a/agentao/acp_client/manager/helpers.py
+++ b/agentao/acp_client/manager/helpers.py
@@ -8,12 +8,40 @@ the manager class graph.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..interaction import PendingInteraction
 
 logger = logging.getLogger("agentao.acp_client")
+
+# Upper bound on a single server-supplied display string we will surface.
+# agent_message_chunk / agent_thought_chunk (and the permission title / ask_user
+# question) carry server text verbatim and are intentionally NOT summarized like
+# tool lines. This cap bounds the **display string** — what lands in
+# ``InboxMessage.text`` and, downstream, the Markdown accumulation in render.py —
+# so a compromised/buggy server can't stream one multi-GB chunk and force a
+# giant string through the render path. It is far larger than any real streaming
+# delta or whole reply, so it never touches legitimate content. Note it does NOT
+# bound the *raw* payload (`InboxMessage.raw = params` still retains the full
+# object) nor the process-level stdin read; those are the job of the deferred
+# readline-frame cap. See docs/design/acp-client-audit.md AC5.
+_MAX_CHUNK_DISPLAY_CHARS = 256 * 1024
+
+
+def _cap_chunk(text: Any) -> Any:
+    """Bound a server-supplied display string to ``_MAX_CHUNK_DISPLAY_CHARS``.
+
+    Non-``str`` values (a hostile server may send a JSON number/bool for a
+    ``text`` field) are returned unchanged — matching the pre-cap behavior and
+    avoiding a ``TypeError`` on ``len()`` that would silently drop the message.
+    The truncation marker is pure ASCII so it can never raise
+    ``UnicodeEncodeError`` on a non-UTF-8 stdout in the plain render fallback.
+    """
+    if not isinstance(text, str) or len(text) <= _MAX_CHUNK_DISPLAY_CHARS:
+        return text
+    dropped = len(text) - _MAX_CHUNK_DISPLAY_CHARS
+    return text[:_MAX_CHUNK_DISPLAY_CHARS] + f"...[truncated {dropped} chars]"
 
 
 def _extract_display_text(method: str, params: Any) -> str:
@@ -34,7 +62,9 @@ def _extract_display_text(method: str, params: Any) -> str:
 
     # -- _agentao.cn/ask_user ----------------------------------------------
     if method == "_agentao.cn/ask_user":
-        return params.get("question") or params.get("message") or "(input requested)"
+        return _cap_chunk(
+            params.get("question") or params.get("message") or "(input requested)"
+        )
 
     # -- session/update (most common) --------------------------------------
     if method == "session/update":
@@ -52,8 +82,8 @@ def _format_permission_text(params: dict) -> str:
     """Format a ``session/request_permission`` payload."""
     tool_call = params.get("toolCall")
     if not isinstance(tool_call, dict):
-        return params.get("message") or "(permission requested)"
-    title = tool_call.get("title") or "unknown tool"
+        return _cap_chunk(params.get("message") or "(permission requested)")
+    title = _cap_chunk(tool_call.get("title") or "unknown tool")
     kind = tool_call.get("kind", "")
     raw_input = tool_call.get("rawInput")
     parts = [f"Allow {title}"]
@@ -102,7 +132,7 @@ def _format_session_update(params: dict) -> str:
         content = update.get("content")
         if isinstance(content, dict):
             text = content.get("text", "")
-            return text if text else ""
+            return _cap_chunk(text) if text else ""
         return ""
 
     # agent_thought_chunk: show reasoning (dimmed in render)
@@ -110,7 +140,7 @@ def _format_session_update(params: dict) -> str:
         content = update.get("content")
         if isinstance(content, dict):
             text = content.get("text", "")
-            return text if text else ""
+            return _cap_chunk(text) if text else ""
         return ""
 
     # user_message_chunk
@@ -126,6 +156,73 @@ def _format_session_update(params: dict) -> str:
 
 def _truncate(s: str, n: int) -> str:
     return s if len(s) <= n else s[: n - 3] + "..."
+
+
+def _opt_id(opt: Dict[str, Any]) -> Optional[str]:
+    """Return the first non-empty ``optionId`` / ``id`` string on *opt*."""
+    for key in ("optionId", "id"):
+        val = opt.get(key)
+        if isinstance(val, str) and val:
+            return val
+    return None
+
+
+def _first_id_by_kind(
+    options: List[Dict[str, Any]], kind: str,
+) -> Optional[str]:
+    """First valid option id whose ``kind`` exactly equals *kind*.
+
+    The exact-canonical-kind lookup shared by :func:`_select_option`'s pass 1
+    and :func:`_select_option_by_kind`, so canonical-kind matching lives in one
+    place.
+    """
+    for opt in options:
+        if opt.get("kind") == kind:
+            oid = _opt_id(opt)
+            if oid:
+                return oid
+    return None
+
+
+def _select_option(
+    options: List[Dict[str, Any]],
+    *,
+    canonical_kind: str,
+    kind_prefix: str,
+    hints: Tuple[str, ...],
+) -> Optional[str]:
+    """Three-pass option-id picker shared by the approve / reject selectors.
+
+    1. First option whose ``kind`` equals *canonical_kind* (with a valid id).
+    2. First option whose ``kind`` starts with *kind_prefix*.
+    3. First option whose ``optionId`` / ``id`` / ``name`` / ``label`` contains
+       any of *hints* (case-insensitive).
+
+    Returns ``None`` when nothing matches.
+    """
+    if not options:
+        return None
+    # Pass 1: canonical kind.
+    oid = _first_id_by_kind(options, canonical_kind)
+    if oid:
+        return oid
+    # Pass 2: any kind with the family prefix.
+    for opt in options:
+        kind = opt.get("kind")
+        if isinstance(kind, str) and kind.startswith(kind_prefix):
+            oid = _opt_id(opt)
+            if oid:
+                return oid
+    # Pass 3: text hint in id / name / label.
+    for opt in options:
+        haystack = " ".join(
+            str(opt.get(k, "")) for k in ("optionId", "id", "name", "label")
+        ).lower()
+        if any(h in haystack for h in hints):
+            oid = _opt_id(opt)
+            if oid:
+                return oid
+    return None
 
 
 def _select_reject_option(options: List[Dict[str, Any]]) -> Optional[str]:
@@ -144,40 +241,12 @@ def _select_reject_option(options: List[Dict[str, Any]]) -> Optional[str]:
     fall back to an explicit ``cancelled`` outcome so the server does not
     hang waiting for a valid selection.
     """
-    if not options:
-        return None
-
-    def _opt_id(opt: Dict[str, Any]) -> Optional[str]:
-        for key in ("optionId", "id"):
-            val = opt.get(key)
-            if isinstance(val, str) and val:
-                return val
-        return None
-
-    # Pass 1: kind == "reject_once" (canonical).
-    for opt in options:
-        if opt.get("kind") == "reject_once":
-            oid = _opt_id(opt)
-            if oid:
-                return oid
-    # Pass 2: any reject_* kind.
-    for opt in options:
-        kind = opt.get("kind")
-        if isinstance(kind, str) and kind.startswith("reject"):
-            oid = _opt_id(opt)
-            if oid:
-                return oid
-    # Pass 3: reject/deny/cancel hint in id or name.
-    hints = ("reject", "deny", "cancel")
-    for opt in options:
-        haystack = " ".join(
-            str(opt.get(k, "")) for k in ("optionId", "id", "name", "label")
-        ).lower()
-        if any(h in haystack for h in hints):
-            oid = _opt_id(opt)
-            if oid:
-                return oid
-    return None
+    return _select_option(
+        options,
+        canonical_kind="reject_once",
+        kind_prefix="reject",
+        hints=("reject", "deny", "cancel"),
+    )
 
 
 def _extract_options(interaction: "PendingInteraction") -> List[Dict[str, Any]]:
@@ -206,13 +275,7 @@ def _select_option_by_kind(
     for reject) without duplicating the broader fallback logic in
     :func:`_select_approve_option` / :func:`_select_reject_option`.
     """
-    for opt in options:
-        if opt.get("kind") == preferred_kind:
-            for key in ("optionId", "id"):
-                val = opt.get(key)
-                if isinstance(val, str) and val:
-                    return val
-    return None
+    return _first_id_by_kind(options, preferred_kind)
 
 
 def _select_approve_option(options: List[Dict[str, Any]]) -> Optional[str]:
@@ -222,37 +285,9 @@ def _select_approve_option(options: List[Dict[str, Any]]) -> Optional[str]:
     flavored entries. Returns ``None`` when no such option exists; callers
     should fall back to the reject path rather than send an invalid id.
     """
-    if not options:
-        return None
-
-    def _opt_id(opt: Dict[str, Any]) -> Optional[str]:
-        for key in ("optionId", "id"):
-            val = opt.get(key)
-            if isinstance(val, str) and val:
-                return val
-        return None
-
-    # Pass 1: kind == "allow_once" (canonical).
-    for opt in options:
-        if opt.get("kind") == "allow_once":
-            oid = _opt_id(opt)
-            if oid:
-                return oid
-    # Pass 2: any allow_* kind.
-    for opt in options:
-        kind = opt.get("kind")
-        if isinstance(kind, str) and kind.startswith("allow"):
-            oid = _opt_id(opt)
-            if oid:
-                return oid
-    # Pass 3: allow/accept/approve hint in id or name.
-    hints = ("allow", "accept", "approve")
-    for opt in options:
-        haystack = " ".join(
-            str(opt.get(k, "")) for k in ("optionId", "id", "name", "label")
-        ).lower()
-        if any(h in haystack for h in hints):
-            oid = _opt_id(opt)
-            if oid:
-                return oid
-    return None
+    return _select_option(
+        options,
+        canonical_kind="allow_once",
+        kind_prefix="allow",
+        hints=("allow", "accept", "approve"),
+    )

--- a/agentao/acp_client/manager/interactions.py
+++ b/agentao/acp_client/manager/interactions.py
@@ -31,6 +31,11 @@ from .helpers import (
 from .turns import _TurnContext
 
 
+def _selected_outcome(option_id: str) -> Dict[str, Any]:
+    """Build the ACP ``selected`` permission-response envelope for *option_id*."""
+    return {"outcome": {"outcome": "selected", "optionId": option_id}}
+
+
 class InteractionsMixin:
     """Inbox / interaction routing for :class:`ACPManager`."""
 
@@ -273,13 +278,7 @@ class InteractionsMixin:
                     approve_option = _select_approve_option(options)
                     if approve_option is not None:
                         client.send_response(
-                            request_id,
-                            {
-                                "outcome": {
-                                    "outcome": "selected",
-                                    "optionId": approve_option,
-                                }
-                            },
+                            request_id, _selected_outcome(approve_option)
                         )
                         approved = True
                     else:
@@ -293,13 +292,7 @@ class InteractionsMixin:
                         reject_option = _select_reject_option(options)
                         if reject_option is not None:
                             client.send_response(
-                                request_id,
-                                {
-                                    "outcome": {
-                                        "outcome": "selected",
-                                        "optionId": reject_option,
-                                    }
-                                },
+                                request_id, _selected_outcome(reject_option)
                             )
                         else:
                             client.send_response(
@@ -310,13 +303,7 @@ class InteractionsMixin:
                     reject_option = _select_reject_option(options)
                     if reject_option is not None:
                         client.send_response(
-                            request_id,
-                            {
-                                "outcome": {
-                                    "outcome": "selected",
-                                    "optionId": reject_option,
-                                }
-                            },
+                            request_id, _selected_outcome(reject_option)
                         )
                     else:
                         # No reject-flavored option in the server's list, and
@@ -409,6 +396,29 @@ class InteractionsMixin:
                 exc,
             )
 
+    def _resolve_and_respond(
+        self,
+        name: str,
+        request_id: str,
+        resolve_result: Dict[str, Any],
+        response_result: Dict[str, Any],
+    ) -> bool:
+        """Shared tail of approve / reject / reply.
+
+        Marks the interaction resolved in the registry with *resolve_result*,
+        forwards *response_result* to the server, and moves the handle off
+        ``WAITING_FOR_USER``. Returns ``True`` iff the interaction was found
+        and resolved.
+        """
+        resolved = self.interactions.resolve(request_id, resolve_result)
+        if resolved is None:
+            return False
+        self._send_interaction_response(resolved, response_result)
+        handle = self._handles.get(name)
+        if handle is not None and handle.state == ServerState.WAITING_FOR_USER:
+            handle._set_state(self._post_interaction_state(name))
+        return True
+
     def approve_interaction(
         self,
         name: str,
@@ -436,21 +446,12 @@ class InteractionsMixin:
             or _select_approve_option(options)
             or preferred_kind
         )
-        resolved = self.interactions.resolve(
-            request_id, {"outcome": "approved", "optionId": option_id}
+        return self._resolve_and_respond(
+            name,
+            request_id,
+            {"outcome": "approved", "optionId": option_id},
+            _selected_outcome(option_id),
         )
-        if resolved is not None:
-            self._send_interaction_response(resolved, {
-                "outcome": {
-                    "outcome": "selected",
-                    "optionId": option_id,
-                },
-            })
-            handle = self._handles.get(name)
-            if handle is not None and handle.state == ServerState.WAITING_FOR_USER:
-                handle._set_state(self._post_interaction_state(name))
-            return True
-        return False
 
     def reject_interaction(
         self,
@@ -481,21 +482,12 @@ class InteractionsMixin:
             or _select_reject_option(options)
             or preferred_kind
         )
-        resolved = self.interactions.resolve(
-            request_id, {"outcome": "rejected", "optionId": option_id}
+        return self._resolve_and_respond(
+            name,
+            request_id,
+            {"outcome": "rejected", "optionId": option_id},
+            _selected_outcome(option_id),
         )
-        if resolved is not None:
-            self._send_interaction_response(resolved, {
-                "outcome": {
-                    "outcome": "selected",
-                    "optionId": option_id,
-                },
-            })
-            handle = self._handles.get(name)
-            if handle is not None and handle.state == ServerState.WAITING_FOR_USER:
-                handle._set_state(self._post_interaction_state(name))
-            return True
-        return False
 
     def reply_interaction(
         self, name: str, request_id: str, text: str
@@ -509,16 +501,9 @@ class InteractionsMixin:
         interaction = self.interactions.get(request_id)
         if interaction is None or interaction.server != name:
             return False
-        resolved = self.interactions.resolve(
-            request_id, {"outcome": "answered", "text": text}
+        return self._resolve_and_respond(
+            name,
+            request_id,
+            {"outcome": "answered", "text": text},
+            {"outcome": "answered", "text": text},
         )
-        if resolved is not None:
-            self._send_interaction_response(resolved, {
-                "outcome": "answered",
-                "text": text,
-            })
-            handle = self._handles.get(name)
-            if handle is not None and handle.state == ServerState.WAITING_FOR_USER:
-                handle._set_state(self._post_interaction_state(name))
-            return True
-        return False

--- a/agentao/acp_client/manager/lifecycle.py
+++ b/agentao/acp_client/manager/lifecycle.py
@@ -72,7 +72,12 @@ class LifecycleMixin:
 
     def stop_all(self) -> None:
         """Stop all clients and server subprocesses."""
-        for name, client in self._clients.items():
+        # Snapshot before iterating: ``client.close()`` and any concurrent
+        # lock-free liveness poll (``get_status``/``readiness`` →
+        # ``_check_cached_client_alive`` → ``_clients.pop``) can mutate
+        # ``_clients`` mid-loop, which would raise "dictionary changed size
+        # during iteration". Mirrors the ``_ephemeral_clients`` block below.
+        for name, client in list(self._clients.items()):
             try:
                 client.close()
             except Exception as exc:

--- a/agentao/acp_client/manager/recovery.py
+++ b/agentao/acp_client/manager/recovery.py
@@ -8,8 +8,9 @@ entry point leans on before reusing a cached client.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Callable, Iterator, Optional
 
 from ..client import (
     AcpClientError,
@@ -201,6 +202,55 @@ class RecoveryMixin:
         if streak > 1:
             self._mark_fatal(name)
 
+    @contextmanager
+    def _handshake_guarded(
+        self,
+        name: str,
+        *,
+        on_failure: Optional[Callable[[], None]] = None,
+        cleanup_before_accounting: bool = True,
+    ) -> Iterator[None]:
+        """Run a handshake / session-setup body under the sticky-fatal contract.
+
+        Every entry point that runs ``initialize`` / ``create_session`` — the
+        greenfield ``connect_server``, the cached-client re-session in
+        ``ensure_connected``, and both ``prompt_once`` paths (cached re-session
+        and the ephemeral greenfield) — must, on failure, reclassify the error
+        as ``HANDSHAKE_FAIL`` and flip sticky-fatal on the *second* consecutive
+        one, and on success clear the streak. That dance used to be copy-pasted
+        at each site, so a new entry point could silently opt out of the
+        documented recovery contract. Route every site through here instead —
+        the pairing of failure-accounting and success-clear is then structural,
+        not a discipline each caller has to remember.
+
+        ``on_failure`` runs the caller's own teardown on the failure path (close
+        the half-built client, stop a proc this call started, drop an ephemeral
+        registration). ``cleanup_before_accounting`` controls its order relative
+        to the accounting — and it matters, because BOTH the accounting
+        (``_mark_fatal`` → handle state ``FAILED``) and a typical teardown
+        (``handle.stop()`` → handle state ``STOPPED``) write ``handle.info.state``,
+        so whichever runs last is the terminal state a host observes via
+        ``get_status()``. The two original greenfield sites disagreed:
+        ``connect_server`` cleaned up *then* accounted (terminal ``FAILED``),
+        while ``_open_ephemeral_client_locked`` accounted *then* cleaned up
+        (terminal ``STOPPED``). Each passes the flag that reproduces its own
+        prior order, so this consolidation stays behaviour-preserving.
+        ``on_failure`` must not raise (guard its own sub-steps), or it would
+        mask the original error and skip the accounting.
+        """
+        try:
+            yield
+        except BaseException as exc:
+            if on_failure is not None and cleanup_before_accounting:
+                on_failure()
+            if self._reclassify_as_handshake_fail(exc, name):
+                self._note_handshake_failure_and_maybe_fatal(name)
+            if on_failure is not None and not cleanup_before_accounting:
+                on_failure()
+            raise
+        else:
+            self._note_handshake_success(name)
+
     def _reclassify_as_handshake_fail(
         self, exc: BaseException, name: str,
     ) -> bool:
@@ -386,7 +436,12 @@ class RecoveryMixin:
             # combine with a future one across an unrelated subprocess death.
             # Without this, "handshake failure → recoverable death → handshake
             # failure" incorrectly trips sticky-fatal after only one new failure.
-            self._handshake_fail_streak[name] = 0
+            # Hold ``_recovery_lock`` like every other streak mutation
+            # (_clear_fatal / _note_handshake_success / _and_maybe_fatal): this
+            # method runs lock-free from the get_status/readiness poll path, so a
+            # bare write could interleave with a racing locked read-modify-write.
+            with self._recovery_lock:
+                self._handshake_fail_streak[name] = 0
         if classification == "fatal":
             self._mark_fatal(name)
             raise AcpClientError(

--- a/agentao/acp_client/manager/turns.py
+++ b/agentao/acp_client/manager/turns.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ..client import (
     ACPClient,
@@ -531,61 +531,14 @@ class TurnsMixin:
             name, cwd=cwd, mcp_servers=mcp_servers,
         )
 
-        # Ephemeral setup is safe to do OUTSIDE the turn lock — an
-        # ephemeral client is specific to this call and not visible to
-        # any concurrent turn. Re-sessioning a CACHED client is *not*
-        # safe outside the lock (it would overwrite shared session
-        # state under another running turn), so we defer the
-        # cached-client branch to inside the lock.
-        #
-        # The check-and-create runs under the handshake lock so a
-        # concurrent ``send_prompt`` pre-warm or another ``prompt_once``
-        # on another thread cannot race our check and cause two
-        # ``ACPClient`` readers to attach to the same handle's stdout.
-        #
-        # If another thread's ``prompt_once`` already has an ephemeral
-        # in flight, we cannot safely spawn a second one (duplicate
-        # reader) and cannot borrow theirs (single-use per call). Fail
-        # fast with ``SERVER_BUSY`` — ``_record_last_error`` filters it
-        # so this doesn't clobber any real failure in the store.
-        #
-        # process_was_running is sampled inside the handshake lock so
-        # that a concurrent start_server() / start_all() cannot start the
-        # subprocess in the window between sampling and the lock, which
-        # would leave process_was_running=False for a process we did not
-        # start and cause the cleanup paths to stop a shared daemon.
-        client: Optional[ACPClient] = None
-        ephemeral_created = False
-        process_was_running = True  # safe default: don't stop anything
-        try:
-            with self._get_handshake_lock(name):
-                process_was_running = (
-                    handle._proc is not None and handle._proc.poll() is None
-                )
-                with self._ephemeral_lock:
-                    has_ephemeral = name in self._ephemeral_clients
-                if has_ephemeral:
-                    raise AcpClientError(
-                        f"server '{name}' has an active turn; "
-                        f"prompt_once is fail-fast",
-                        code=AcpErrorCode.SERVER_BUSY,
-                        details={"server": name},
-                    )
-                if self._clients.get(name) is None:
-                    client = self._open_ephemeral_client_locked(
-                        name,
-                        cwd=effective_cwd,
-                        mcp_servers=effective_mcp,
-                        timeout=timeout,
-                    )
-                    ephemeral_created = True
-                # Else: a long-lived client already exists (possibly
-                # installed by a concurrent pre-warm). Leave ``client``
-                # as None; the cached-client branch below (inside the
-                # turn lock) handles fast-path reuse / re-session.
-        except Exception as exc:
-            self._record_last_error(name, exc)
-            raise
+        # Ephemeral setup / defer runs under the handshake lock; the
+        # concurrency rationale lives on ``_setup_ephemeral_or_defer``.
+        client, ephemeral_created, process_was_running = (
+            self._setup_ephemeral_or_defer(
+                name, handle,
+                cwd=effective_cwd, mcp_servers=effective_mcp, timeout=timeout,
+            )
+        )
 
         lock = self._get_server_lock(name)
         if not lock.acquire(blocking=False):
@@ -611,59 +564,14 @@ class TurnsMixin:
         try:
             try:
                 if not ephemeral_created:
-                    # Cached-client path. We hold the turn lock now, so
-                    # a re-session on ``existing`` cannot corrupt any
-                    # concurrent turn.
-                    existing = self._clients.get(name)
-                    if existing is None:
-                        # Rare: cache was evicted (restart_server etc.)
-                        # between the pre-check and here. Fall through
-                        # to a full ``ensure_connected`` inside the
-                        # turn lock.
-                        client = self.ensure_connected(
-                            name,
-                            cwd=effective_cwd,
-                            mcp_servers=effective_mcp,
-                            timeout=timeout,
-                            _inside_turn=True,
-                        )
-                    else:
-                        # Re-check liveness now that we hold the turn lock:
-                        # the process may have died in the window between the
-                        # early pre-check and here.
-                        self._check_cached_client_alive(name)
-                        existing = self._clients.get(name)
-                        if existing is None:
-                            # Died since the pre-check; rebuild.
-                            client = self.ensure_connected(
-                                name,
-                                cwd=effective_cwd,
-                                mcp_servers=effective_mcp,
-                                timeout=timeout,
-                                _inside_turn=True,
-                            )
-                        elif existing.connection_info.session_id and self._session_matches(
-                            existing, cwd=effective_cwd, mcp_servers=effective_mcp,
-                        ):
-                            client = existing
-                        else:
-                            # Re-session the cached client — handshake lock
-                            # still serializes against concurrent
-                            # connect_server / ephemeral setup on other
-                            # threads.
-                            with self._get_handshake_lock(name):
-                                try:
-                                    existing.create_session(
-                                        cwd=effective_cwd,
-                                        mcp_servers=effective_mcp,
-                                        timeout=timeout,
-                                    )
-                                except BaseException as exc:
-                                    if self._reclassify_as_handshake_fail(exc, name):
-                                        self._note_handshake_failure_and_maybe_fatal(name)
-                                    raise
-                                self._note_handshake_success(name)
-                            client = existing
+                    # Cached-client path — we hold the turn lock, so a
+                    # re-session cannot corrupt a concurrent turn.
+                    client = self._reuse_cached_client_for_prompt_once(
+                        name,
+                        cwd=effective_cwd,
+                        mcp_servers=effective_mcp,
+                        timeout=timeout,
+                    )
                 raw = self._run_turn_on_client(
                     name, client, prompt,
                     timeout=timeout,
@@ -682,34 +590,161 @@ class TurnsMixin:
                 raise
         finally:
             if ephemeral_created and client is not None:
-                # prompt_once is always one-shot — never promote the
-                # ephemeral client to the long-lived cache, regardless of
-                # stop_process or process_was_running.  Close the client to
-                # stop its reader thread cleanly; a subsequent connect or
-                # prompt_once call on the same server will start a fresh
-                # reader.  Only stop the subprocess when stop_process=True
-                # AND this call was the one that started it.
-                keep_process_alive = not stop_process or process_was_running
-                with self._get_handshake_lock(name):
-                    with self._ephemeral_lock:
-                        if self._ephemeral_clients.get(name) is client:
-                            self._ephemeral_clients.pop(name, None)
-                    try:
-                        client.close()
-                    except Exception:
-                        logger.debug(
-                            "acp[%s]: error closing ephemeral client",
-                            name, exc_info=True,
-                        )
-                    if not keep_process_alive and name not in self._clients:
-                        try:
-                            handle.stop()
-                        except Exception:
-                            logger.debug(
-                                "acp[%s]: error stopping handle",
-                                name, exc_info=True,
-                                )
+                self._teardown_ephemeral_after_prompt(
+                    name, client, handle,
+                    stop_process=stop_process,
+                    process_was_running=process_was_running,
+                )
             lock.release()
+
+    def _setup_ephemeral_or_defer(
+        self,
+        name: str,
+        handle: ACPProcessHandle,
+        *,
+        cwd: Optional[str],
+        mcp_servers: Optional[List[dict]],
+        timeout: Optional[float],
+    ) -> Tuple[Optional[ACPClient], bool, bool]:
+        """Open a one-shot ephemeral client, or defer to the cached branch.
+
+        Runs under the handshake lock and returns
+        ``(client, ephemeral_created, process_was_running)``:
+
+        * Ephemeral setup is safe OUTSIDE the turn lock — the client is
+          specific to this call and invisible to any concurrent turn.
+          Re-sessioning a CACHED client is *not* safe outside the turn lock
+          (it would overwrite shared session state under another running
+          turn), so when a long-lived client already exists we return
+          ``client=None`` and let ``prompt_once``'s in-turn-lock branch
+          reuse / re-session it.
+        * The check-and-create is under the handshake lock so a concurrent
+          ``send_prompt`` pre-warm or another ``prompt_once`` cannot race the
+          check and attach two ``ACPClient`` readers to one handle's stdout.
+        * If another thread's ``prompt_once`` already has an ephemeral in
+          flight we can neither spawn a second (duplicate reader) nor borrow
+          theirs (single-use) — fail fast with ``SERVER_BUSY`` (which
+          ``_record_last_error`` filters, so it won't clobber a real failure).
+        * ``process_was_running`` is sampled inside the handshake lock so a
+          concurrent ``start_server`` / ``start_all`` can't start the proc in
+          the window between sampling and the lock and trick the cleanup paths
+          into stopping a shared daemon.
+        """
+        client: Optional[ACPClient] = None
+        ephemeral_created = False
+        process_was_running = True  # safe default: don't stop anything
+        try:
+            with self._get_handshake_lock(name):
+                process_was_running = (
+                    handle._proc is not None and handle._proc.poll() is None
+                )
+                with self._ephemeral_lock:
+                    has_ephemeral = name in self._ephemeral_clients
+                if has_ephemeral:
+                    raise AcpClientError(
+                        f"server '{name}' has an active turn; "
+                        f"prompt_once is fail-fast",
+                        code=AcpErrorCode.SERVER_BUSY,
+                        details={"server": name},
+                    )
+                if self._clients.get(name) is None:
+                    client = self._open_ephemeral_client_locked(
+                        name,
+                        cwd=cwd,
+                        mcp_servers=mcp_servers,
+                        timeout=timeout,
+                    )
+                    ephemeral_created = True
+        except Exception as exc:
+            self._record_last_error(name, exc)
+            raise
+        return client, ephemeral_created, process_was_running
+
+    def _reuse_cached_client_for_prompt_once(
+        self,
+        name: str,
+        *,
+        cwd: Optional[str],
+        mcp_servers: Optional[List[dict]],
+        timeout: Optional[float],
+    ) -> ACPClient:
+        """Resolve the client for the cached (non-ephemeral) ``prompt_once``
+        path. The caller holds the per-server turn lock, so re-sessioning the
+        cached client here cannot corrupt a concurrent turn.
+
+        Rebuilds via ``ensure_connected`` when the cache was evicted
+        (``restart_server`` etc.) or the subprocess died since the pre-check;
+        reuses the cached client directly when its session still matches;
+        otherwise re-sessions it under the handshake lock (which serializes
+        against concurrent ``connect_server`` / ephemeral setup), with
+        ``_handshake_guarded`` owning the sticky-fatal accounting.
+        """
+        existing = self._clients.get(name)
+        if existing is None:
+            # Cache evicted between the pre-check and here — rebuild.
+            return self.ensure_connected(
+                name, cwd=cwd, mcp_servers=mcp_servers, timeout=timeout,
+                _inside_turn=True,
+            )
+        # Re-check liveness now that we hold the turn lock: the proc may have
+        # died in the window between the early pre-check and here.
+        self._check_cached_client_alive(name)
+        existing = self._clients.get(name)
+        if existing is None:
+            # Died since the pre-check; rebuild.
+            return self.ensure_connected(
+                name, cwd=cwd, mcp_servers=mcp_servers, timeout=timeout,
+                _inside_turn=True,
+            )
+        if existing.connection_info.session_id and self._session_matches(
+            existing, cwd=cwd, mcp_servers=mcp_servers,
+        ):
+            return existing
+        with self._get_handshake_lock(name), self._handshake_guarded(name):
+            existing.create_session(
+                cwd=cwd, mcp_servers=mcp_servers, timeout=timeout,
+            )
+        return existing
+
+    def _teardown_ephemeral_after_prompt(
+        self,
+        name: str,
+        client: ACPClient,
+        handle: ACPProcessHandle,
+        *,
+        stop_process: bool,
+        process_was_running: bool,
+    ) -> None:
+        """Tear down a ``prompt_once`` ephemeral client in the ``finally``.
+
+        ``prompt_once`` is always one-shot — never promote the ephemeral
+        client to the long-lived cache, regardless of ``stop_process`` or
+        ``process_was_running``. Close the client to stop its reader thread
+        cleanly (a later connect / prompt_once starts a fresh reader); only
+        stop the subprocess when ``stop_process=True`` AND this call was the
+        one that started it. Runs under the handshake lock so no concurrent
+        caller observes the popped-but-still-running window.
+        """
+        keep_process_alive = not stop_process or process_was_running
+        with self._get_handshake_lock(name):
+            with self._ephemeral_lock:
+                if self._ephemeral_clients.get(name) is client:
+                    self._ephemeral_clients.pop(name, None)
+            try:
+                client.close()
+            except Exception:
+                logger.debug(
+                    "acp[%s]: error closing ephemeral client",
+                    name, exc_info=True,
+                )
+            if not keep_process_alive and name not in self._clients:
+                try:
+                    handle.stop()
+                except Exception:
+                    logger.debug(
+                        "acp[%s]: error stopping handle",
+                        name, exc_info=True,
+                    )
 
     def _rollback_ephemeral_on_busy(
         self,
@@ -825,20 +860,7 @@ class TurnsMixin:
         )
         with self._ephemeral_lock:
             self._ephemeral_clients[name] = client
-        try:
-            client.start_reader()
-            client.initialize(timeout=timeout)
-            client.create_session(
-                cwd=cwd, mcp_servers=mcp_servers, timeout=timeout,
-            )
-        except BaseException as exc:
-            # Shared classification + sticky-fatal accounting — same
-            # behaviour as the long-lived ``connect_server`` and
-            # cached-client ``ensure_connected`` paths so the
-            # "2 consecutive handshakes ⇒ fatal" contract holds
-            # whichever API the embedder chose.
-            if self._reclassify_as_handshake_fail(exc, name):
-                self._note_handshake_failure_and_maybe_fatal(name)
+        def _teardown_partial_ephemeral() -> None:
             with self._ephemeral_lock:
                 if self._ephemeral_clients.get(name) is client:
                     self._ephemeral_clients.pop(name, None)
@@ -859,14 +881,25 @@ class TurnsMixin:
                         "acp[%s]: stop handle after ephemeral setup failure raised",
                         name, exc_info=True,
                     )
-            raise
-        # Successful greenfield handshake in the ephemeral/``prompt_once``
-        # path — clear the streak for the same reason the long-lived
-        # ``connect_server`` and cached-client re-session paths do.
-        # Without this, a prior isolated handshake failure would linger
-        # at streak=1 and combine with a future unrelated handshake
-        # failure into an incorrect sticky-fatal flip.
-        self._note_handshake_success(name)
+
+        # Shared classification + sticky-fatal accounting via
+        # ``_handshake_guarded`` — same behaviour as the long-lived
+        # ``connect_server`` and cached-client ``ensure_connected`` paths so the
+        # "2 consecutive handshakes ⇒ fatal" contract (and the streak-clear on
+        # success) holds whichever API the embedder chose. This site historically
+        # ran the accounting BEFORE its teardown (so a 2nd-failure sticky-fatal
+        # left the handle FAILED, then ``handle.stop()`` set it STOPPED — the
+        # terminal state); ``cleanup_before_accounting=False`` preserves that.
+        with self._handshake_guarded(
+            name,
+            on_failure=_teardown_partial_ephemeral,
+            cleanup_before_accounting=False,
+        ):
+            client.start_reader()
+            client.initialize(timeout=timeout)
+            client.create_session(
+                cwd=cwd, mcp_servers=mcp_servers, timeout=timeout,
+            )
         return client
 
     # ------------------------------------------------------------------

--- a/agentao/acp_client/process.py
+++ b/agentao/acp_client/process.py
@@ -14,10 +14,11 @@ import collections
 import logging
 import queue
 import subprocess
+import sys
 import threading
 from typing import List, Optional
 
-from ..capabilities.process import build_child_env
+from ..capabilities.process import build_child_env, kill_process_tree
 from .models import AcpProcessInfo, AcpServerConfig, ServerState
 
 # Default capacity for the stderr ring buffer (number of lines).
@@ -28,6 +29,11 @@ _STDERR_RING_CAPACITY = 200
 # its shutdown ``finally`` (persist each session, disconnect MCP) on that path,
 # so we give it this long before escalating to SIGTERM/SIGKILL.
 _GRACEFUL_STOP_TIMEOUT = 5.0
+# After the graceful window, SIGTERM the server (child-scoped) and wait this
+# long before escalating to a whole-tree SIGKILL.
+_TERMINATE_STOP_TIMEOUT = 5.0
+# Final reap window after force-killing the process tree.
+_KILL_STOP_TIMEOUT = 2.0
 
 logger = logging.getLogger("agentao.acp_client")
 
@@ -123,14 +129,29 @@ class ACPProcessHandle:
             # key can still be given one explicitly.
             env = build_child_env(self.config.env)
 
+            popen_kwargs = dict(
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=self.config.cwd,
+                env=env,
+            )
+            # Lead our own process group / session so a force-stop can reap the
+            # *whole* tree (see ``kill_process_tree``): an ACP server that spawns
+            # its own MCP/shell grandchildren must not orphan them when we
+            # SIGKILL an unresponsive parent. This is also REQUIRED for the
+            # whole-tree kill in ``_stop_unlocked`` (``kill_process_tree`` ->
+            # ``killpg``) to target the child's group rather than agentao's own.
+            # Mirrors ``run_captured``.
+            if sys.platform == "win32":
+                popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+            else:
+                popen_kwargs["start_new_session"] = True
+
             try:
                 self._proc = subprocess.Popen(
                     [self.config.command, *self.config.args],
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    cwd=self.config.cwd,
-                    env=env,
+                    **popen_kwargs,
                 )
             except Exception as exc:
                 self._set_state(ServerState.FAILED, str(exc))
@@ -186,8 +207,10 @@ class ACPProcessHandle:
         """Gracefully stop the subprocess.
 
         Closes stdin first so an ACP server can persist its sessions and exit
-        on EOF, waits up to ``_GRACEFUL_STOP_TIMEOUT`` s, then escalates to
-        SIGTERM (5 s) and finally SIGKILL.  Idempotent.
+        on EOF, waits up to ``_GRACEFUL_STOP_TIMEOUT`` s, then escalates to a
+        child-scoped SIGTERM and finally a whole-process-tree SIGKILL (so an
+        unresponsive server can't orphan its MCP/shell grandchildren).
+        Idempotent.
         """
         with self._lock:
             self._stop_unlocked()
@@ -224,25 +247,46 @@ class ACPProcessHandle:
         try:
             self._proc.wait(timeout=_GRACEFUL_STOP_TIMEOUT)
         except subprocess.TimeoutExpired:
-            # 2. Graceful EOF exit didn't take — escalate.
+            # 2. Graceful EOF exit didn't take — escalate. SIGTERM the server
+            #    itself first (child-scoped) so a server that traps SIGTERM can
+            #    still run its own shutdown and reap its grandchildren cleanly.
             logger.warning(
                 "acp server '%s' did not exit %.0f s after stdin close — terminating",
                 self.name,
                 _GRACEFUL_STOP_TIMEOUT,
             )
+            survived_sigterm = False
             try:
                 self._proc.terminate()
-                self._proc.wait(timeout=5)
+                self._proc.wait(timeout=_TERMINATE_STOP_TIMEOUT)
             except subprocess.TimeoutExpired:
-                logger.warning(
-                    "acp server '%s' did not stop within 5 s — killing", self.name
-                )
-                self._proc.kill()
-                self._proc.wait(timeout=2)
+                survived_sigterm = True
             except Exception as exc:
                 logger.error(
                     "acp server '%s': error during stop: %s", self.name, exc
                 )
+            if survived_sigterm:
+                logger.warning(
+                    "acp server '%s' did not stop within %.0f s — "
+                    "killing process tree",
+                    self.name, _TERMINATE_STOP_TIMEOUT,
+                )
+            # 3. Force-reap the WHOLE tree — not just the direct child — on
+            #    every escalation path. A server that SURVIVES SIGTERM is killed
+            #    outright; one that DIES on SIGTERM may have exited without
+            #    reaping its own MCP/shell grandchildren (the default SIGTERM
+            #    disposition just terminates), and ``terminate()`` is
+            #    child-scoped, so those grandchildren would otherwise orphan.
+            #    ``kill_process_tree`` signals the process group
+            #    (``start_new_session`` at spawn made the child its leader): a
+            #    surviving grandchild keeps the group id reserved so the kill
+            #    reaches it, and if the server already cleaned up the group is
+            #    empty and this is a harmless no-op.
+            kill_process_tree(self._proc)
+            try:
+                self._proc.wait(timeout=_KILL_STOP_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                pass
         except Exception as exc:
             logger.error(
                 "acp server '%s': error during stop: %s", self.name, exc

--- a/agentao/acp_client/render.py
+++ b/agentao/acp_client/render.py
@@ -44,6 +44,13 @@ _MARKDOWN_KINDS = {
     "agent_message_chunk",
 }
 
+# Upper bound on the *aggregate* agent text rendered in one flush. Each chunk is
+# already capped (helpers._cap_chunk, 256 KiB), but flush_to_console accumulates
+# every same-server agent_message_chunk in a batch before one RichMarkdown parse;
+# a burst of near-cap chunks could concatenate into tens of MB and stall the UI.
+# This bounds the string handed to RichMarkdown — far above any real reply.
+_MAX_AGENT_RENDER_CHARS = 1024 * 1024
+
 
 # ---------------------------------------------------------------------------
 # Style mapping
@@ -59,6 +66,61 @@ _KIND_PREFIXES = {
 
 
 # ---------------------------------------------------------------------------
+# Terminal-escape sanitization (server-controlled display text)
+# ---------------------------------------------------------------------------
+
+# An ACP server is a third-party subprocess; its notification / agent text is
+# echoed to the user's terminal. Strip the control bytes that drive ANSI/CSI/OSC
+# escape sequences (cursor, screen-clear, set-title, clipboard) before display,
+# keeping only the whitespace we intend to render. This is defense-in-depth on
+# the OUTPUT channel — the server already runs env-scrubbed (see process.py) —
+# but the plain path writes verbatim to stdout, so it is the unambiguous
+# injection vector. See docs/design/acp-client-audit.md AC5.
+_ALLOWED_CONTROL = frozenset({"\n", "\t"})
+
+# Unicode bidirectional / directional-formatting controls. These reorder
+# rendered text with NO ESC/CSI/OSC byte (Trojan-Source, CVE-2021-42574): e.g. a
+# RIGHT-TO-LEFT OVERRIDE (U+202E) can make "denied" visually read "approved". We
+# strip the embedding / override / isolate controls and the standalone direction
+# marks — they only affect visual ordering, so removing them shows logical order.
+# We deliberately do NOT strip ZWJ/ZWNJ/BOM: those are legitimate in emoji
+# sequences and Arabic/Indic scripts, and stripping them would corrupt real text.
+_BIDI_CONTROLS = frozenset(
+    # LRE RLE PDF LRO RLO         LRI RLI FSI PDI       LRM RLM ALM
+    [chr(cp) for cp in (
+        0x202A, 0x202B, 0x202C, 0x202D, 0x202E,  # embeddings / overrides
+        0x2066, 0x2067, 0x2068, 0x2069,          # isolates
+        0x200E, 0x200F, 0x061C,                  # standalone direction marks
+    )]
+)
+
+
+def _is_disallowed_control(ch: str) -> bool:
+    """True if *ch* is a terminal control char we must not echo verbatim."""
+    if ch in _ALLOWED_CONTROL:
+        return False
+    # C0 (incl. ESC/U+001B, which begins every CSI/OSC), DEL, and C1.
+    if ch < "\x20" or "\x7f" <= ch <= "\x9f":
+        return True
+    # Unicode bidi/direction overrides (visual spoofing with no escape byte).
+    return ch in _BIDI_CONTROLS
+
+
+def _sanitize_terminal_text(text: str) -> str:
+    """Drop terminal control chars from server-controlled text before display.
+
+    Removes C0 controls (U+0000–U+001F, including ESC), DEL (U+007F), C1
+    controls (U+0080–U+009F), and the Unicode bidirectional-override / direction
+    controls (Trojan-Source), preserving ``\\n`` / ``\\t``. Printable text and
+    other higher Unicode pass through untouched, so Markdown / prose renders
+    unchanged.
+    """
+    if not text or not any(_is_disallowed_control(ch) for ch in text):
+        return text
+    return "".join(ch for ch in text if not _is_disallowed_control(ch))
+
+
+# ---------------------------------------------------------------------------
 # Plain-text fallback
 # ---------------------------------------------------------------------------
 
@@ -71,7 +133,7 @@ def render_plain(msg: InboxMessage) -> str:
         if msg.kind not in (MessageKind.RESPONSE, MessageKind.NOTIFICATION)
         else ""
     )
-    text = msg.text.replace("\n", "\n  ")
+    text = _sanitize_terminal_text(msg.text).replace("\n", "\n  ")
     return f"[{msg.server}]{kind_label} {text}  ({ts})"
 
 
@@ -135,6 +197,12 @@ def flush_to_console(
         agent_text_parts = []
         if not full_text.strip():
             return 0
+        if len(full_text) > _MAX_AGENT_RENDER_CHARS:
+            dropped = len(full_text) - _MAX_AGENT_RENDER_CHARS
+            full_text = (
+                full_text[:_MAX_AGENT_RENDER_CHARS]
+                + f"...[truncated {dropped} chars]"
+            )
         console.print()
         if markdown_mode:
             console.print(RichMarkdown(full_text))
@@ -150,7 +218,9 @@ def flush_to_console(
                 "acp[%s] %s: %s",
                 msg.server,
                 msg.update_kind,
-                msg.text[:200] if msg.text else "(empty)",
+                # Sanitize before logging: a DEBUG stream handler can echo this
+                # to the terminal, so server escapes must not bypass AC5 here.
+                _sanitize_terminal_text(msg.text[:200]) if msg.text else "(empty)",
             )
             continue
 
@@ -166,7 +236,7 @@ def flush_to_console(
                 rendered += _flush_agent_text()
             current_server = msg.server
             if msg.text:
-                agent_text_parts.append(msg.text)
+                agent_text_parts.append(_sanitize_terminal_text(msg.text))
             continue
 
         # Flush any accumulated agent text before showing other messages.
@@ -187,7 +257,7 @@ def flush_to_console(
         if label:
             prefix += f" [{color}]{label}:[/{color}]"
 
-        text = msg.text or ""
+        text = _sanitize_terminal_text(msg.text or "")
         lines = text.split("\n")
         first = lines[0]
         rest = lines[1:]

--- a/agentao/cli/commands_ext/acp.py
+++ b/agentao/cli/commands_ext/acp.py
@@ -191,6 +191,7 @@ def _handle_inline_interaction(cli, mgr, server_name: str, interaction) -> None:
     free-form text input.  Runs on the main thread.
     """
     from ...acp_client.interaction import InteractionKind
+    from ...acp_client.render import _sanitize_terminal_text as _san
 
     if interaction.kind == InteractionKind.PERMISSION:
         console.print(
@@ -202,17 +203,21 @@ def _handle_inline_interaction(cli, mgr, server_name: str, interaction) -> None:
             tool_call = interaction.details.get("toolCall")
 
         if isinstance(tool_call, dict):
-            title = tool_call.get("title") or "unknown tool"
+            # All of title / rawInput / content / prompt below are
+            # server-controlled; sanitize terminal escapes before printing so a
+            # hostile server can't drive ANSI/OSC sequences into the terminal
+            # via the inline permission prompt (this path bypasses render.py).
+            title = _san(tool_call.get("title") or "unknown tool")
             kind = tool_call.get("kind", "")
             kind_str = f" [dim]({kind})[/dim]" if kind else ""
             console.print(f"  [cyan]{title}[/cyan]{kind_str}")
             raw_input = tool_call.get("rawInput")
             if isinstance(raw_input, dict) and raw_input:
                 for k, v in list(raw_input.items())[:6]:
-                    val = str(v)
+                    val = _san(str(v))
                     if len(val) > 80:
                         val = val[:77] + "..."
-                    console.print(f"    {k}: [dim]{val}[/dim]")
+                    console.print(f"    {_san(str(k))}: [dim]{val}[/dim]")
                 if len(raw_input) > 6:
                     console.print(f"    [dim]... +{len(raw_input) - 6} more[/dim]")
             content = tool_call.get("content")
@@ -221,9 +226,13 @@ def _handle_inline_interaction(cli, mgr, server_name: str, interaction) -> None:
                     if isinstance(entry, dict):
                         c = entry.get("content")
                         if isinstance(c, dict) and c.get("text"):
-                            console.print(f"    [dim]{c['text'][:100]}[/dim]")
+                            console.print(f"    [dim]{_san(str(c['text']))[:100]}[/dim]")
         else:
-            prompt_text = interaction.prompt[:120] if interaction.prompt else "(no description)"
+            prompt_text = (
+                _san(interaction.prompt)[:120]
+                if interaction.prompt
+                else "(no description)"
+            )
             console.print(f"  {prompt_text}")
         console.print(
             "\n [green]1[/green]. Approve once  "
@@ -263,7 +272,9 @@ def _handle_inline_interaction(cli, mgr, server_name: str, interaction) -> None:
                 return
 
     elif interaction.kind == InteractionKind.INPUT:
-        prompt_text = interaction.prompt if interaction.prompt else "(input requested)"
+        prompt_text = (
+            _san(interaction.prompt) if interaction.prompt else "(input requested)"
+        )
         console.print(
             f"\n[bold magenta]Input request from '{server_name}':[/bold magenta]"
         )

--- a/docs/design/acp-client-audit.md
+++ b/docs/design/acp-client-audit.md
@@ -1,0 +1,571 @@
+# Agentao — `acp_client/` Subpackage Audit
+
+**Status:** Review record. Drafted 2026-07-23 from a June-grade four-dimension
+audit of the `agentao/acp_client/` subpackage — the ACP *client* (Agentao talking
+**out** to project-local ACP servers it spawns as child processes over stdio).
+**This is an evidence-backed findings list + prioritized proposal, not an approved
+plan.** The subpackage was **not in scope** of the 2026-06-19
+`optimization-opportunities-review.md` (that pass covered the runtime, packaging,
+CLI, and the ACP *server*); this closes that gap.
+**Audience:** Agentao maintainers.
+**Companion:** `acp-client-audit.zh.md`.
+**Related:**
+- `optimization-opportunities-review.md` — the June audit whose method and
+  tiering this doc mirrors; several conventions here (do-now bug vs opportunistic
+  consolidation, `gap ≠ need`, verified non-findings) are inherited from it.
+- `acp-server-conformance-review.md` — the ACP *server* side; this is its client mirror.
+- `core-boundary-review.md` — the render/display-in-core question (AC5) respects
+  the boundary it documents.
+
+**Method:** four parallel evidence-gathering passes — **complexity/structure**,
+**correctness/concurrency/resource-safety**, **duplication/reuse**, and
+**contract/boundary/security** — each required to cite `file:line` and back every
+claim with `grep`/read rather than intuition, consistent with this repo's
+*evidence-before-recommendation, gap ≠ need* discipline. The highest-impact and
+least-reversible claims (the two concurrency bugs, the process-kill limitation,
+the dead-code removals, and the render/injection surface) were **independently
+re-read against source** before this doc landed. Code references anchored to
+`main`@`278e92a` (2026-07-23). Line numbers will drift — re-grep before acting.
+
+---
+
+## TL;DR
+
+`acp_client/` is a **well-built, defensively-coded subpackage** — 19 files /
+~5.8k LOC with 11 test files exercising it, a deliberate mixin decomposition of
+the manager, correct provider-credential scrubbing on spawned children, and a
+genuinely hard concurrency contract (single-active-turn lock + handshake lock +
+sticky-fatal recovery) that is *mostly* right. There is **no security hole and no
+architectural emergency.** The auditors' strongest signal was **convergence on a
+few real items**, not a long defect list.
+
+The findings split into three bounded classes:
+
+1. **Do-now, low-risk (AC1, AC4).** One trivial concurrency bug (`stop_all`
+   iterates a live dict — a one-line `list()` fix) and three dead / test-only
+   code surfaces that read as live behavior. Both are safe, small, and reduce
+   real confusion.
+2. **Do-now-ish, small (AC2) + recorded limitation (AC3).** A lock-asymmetry in
+   the recovery counter (AC2) is a small correctness fix; the process-tree kill
+   gap (AC3) is a **documented** limitation whose fix is not drop-in (needs a
+   spawn-side change) — recorded, opt-in.
+3. **Opportunistic / larger (AC5–AC8).** Terminal-escape + size hardening of
+   server-controlled display text (AC5), and two maintainability items: the
+   handshake "sticky-fatal dance" copy-pasted across 5 entry points (AC6, the
+   *dangerous* kind of duplication) and the 261-line `prompt_once` (AC7). These
+   carry the real ongoing cost but also the most behavioral risk — Tier-3, opt-in.
+
+> **The priority ranking is the maintainer's call.** This doc supplies
+> grep-verified evidence and a *suggested* ordering; it does not declare what is
+> or isn't worth the maintainer's time.
+
+> **Scope honesty — the concurrency findings (AC1/AC2) bite only the documented
+> multi-threaded embedding surface.** Inside the interactive CLI,
+> `get_status`/`stop_all`/`send_prompt` run on one thread and never race. But the
+> module is explicitly documented for concurrent daemon/workflow embedding
+> (`turns.py` docstrings on monitoring + worker threads), and **per-client reader
+> threads already run callbacks concurrently with the main thread**, so the races
+> are real for that surface — not hypothetical.
+
+---
+
+## Baseline metrics
+
+| Metric | Value | Reading |
+|---|---|---|
+| Source files / LOC | 19 / ~5,785 | largest never-audited subpackage |
+| Test files referencing it | 11 (`test_acp_client_*` ×7 + 4) | well-covered |
+| Largest file | `manager/turns.py` (892) | turn orchestration + ephemerals |
+| Largest method | `manager/turns.py::prompt_once` (261, `452–712`) | **fattest method in the whole repo** |
+| Child-env credential scrub | present (`process.py:124 build_child_env`) | security-positive (see N1) |
+| Remote/URL transport | none (stdio-only) | voids SSRF surface (see N2) |
+
+---
+
+## Tier 1 — Do now, low risk
+
+### AC1 — `stop_all()` iterates the live `_clients` dict → `RuntimeError` + leaked subprocesses under concurrent embedding · MEDIUM (bug — do now, trivial)
+`lifecycle.py:75`: `for name, client in self._clients.items():` iterates the
+**live** dict — while the very next block (`:82`) defensively copies
+`list(self._ephemeral_clients.items())`. The asymmetry is the tell. `_clients` is
+`pop`-ed from **lock-free** call sites reachable concurrently:
+`_check_cached_client_alive` (`recovery.py:376`) is invoked *without* the
+handshake lock from the doc-stated "read-only" accessors `get_status`
+(`status.py`), `readiness` (`status.py`), and the `prompt_once` pre-check
+(`turns.py:525`); `stop_server` (`lifecycle.py:171`) and `_evict_cached_client`
+(`lifecycle.py:114`) also `pop` off that path.
+
+- **Failure scenario:** a monitor thread polls `readiness()`/`get_status()` on a
+  server whose subprocess died while still `READY`; its
+  `_check_cached_client_alive` runs `self._clients.pop(name)` (`recovery.py:376`)
+  *while* another thread is inside `stop_all()`'s `for … in self._clients.items()`
+  → `RuntimeError: dictionary changed size during iteration`. `stop_all` aborts
+  partway; every handle after the crash point never gets `handle.stop()` →
+  **leaked ACP subprocesses.**
+- **Fix (single-point, trivial):** iterate a snapshot —
+  `for name, client in list(self._clients.items()):` — matching the ephemeral
+  block one line below. Scope the PR to this method.
+
+### AC4 — Three dead / test-only surfaces read as live behavior · LOW (quick win)
+Each is grep-verified to have **zero production callers/writers**; all three are
+kept alive only by tests, so a reader treats inert machinery as real:
+
+- **`interaction.py:56` `deadline_at` + `:122` `expire_overdue`** — `deadline_at`
+  is **never assigned** anywhere outside its `None` default (grep: only the
+  docstring `:43`, the field default `:56`, and the two *reads* at `:134–135`).
+  The `deadline_at is not None` guard is therefore **always False in production**,
+  so `expire_overdue()` is a guaranteed no-op — the entire deadline/expiry
+  mechanism is inert, wired only by tests that set the field by hand.
+- **`turns.py:760` `_open_ephemeral_client`** (the lock-acquiring wrapper) — zero
+  production callers; `prompt_once` calls `_open_ephemeral_client_locked` (`:789`)
+  directly (`turns.py:575`). Every other mention is a comment. Only a test
+  monkeypatches it as a spy — which can't even intercept the real `_locked` path.
+- **`recovery.py:166` `_note_handshake_failure`** (bare, non-`_and_maybe_fatal`)
+  — zero production callers (grep across `agentao/`); only tests use it to
+  simulate a streak.
+- **Fix:** delete the two dead helpers and either wire `deadline_at` or remove the
+  expiry machinery. Removal touches the tests that reference them — do it as one
+  small, clearly-scoped cleanup, not bundled with a behavior change.
+
+---
+
+## Tier 2 — Small correctness fix + a recorded limitation
+
+### AC2 — Recovery counter written without `_recovery_lock`; "read-only" status accessors mutate recovery state off the lock path · LOW–MEDIUM (bug — do now, small)
+Same root as AC1 (lock-free mutation from poll paths), distinct defect.
+`recovery.py:389` writes `self._handshake_fail_streak[name] = 0` **without**
+`_recovery_lock` — while **every other** write to that map holds it
+(`recovery.py:164,168,184,200,300`; e.g. `_clear_fatal:296–300` wraps the
+identical `= 0` write in `with self._recovery_lock`). The enclosing
+`_check_cached_client_alive` also `pop`s `_clients`, closes clients, calls
+`_mark_fatal`, and mutates handle state — all reachable lock-free from the
+doc-stated "read-only" `status.py` accessors.
+
+- **Failure scenario:** thread A in `_note_handshake_failure_and_maybe_fatal`
+  does a locked read-modify-write on the streak (read `1` → write `2` → trip
+  fatal at `>1`); thread B (a lock-free `get_status` poll on a died-in-`READY`
+  server) executes the bare `= 0` at `:389` **between A's read and write**,
+  because B never contends for the lock A holds. The reset is lost or clobbers
+  A's increment → the "2 consecutive handshake failures ⇒ sticky-fatal"
+  accounting desyncs, flipping a server fatal one crash early, or failing to trip
+  when it should. Impact is bounded (off-by-one on a recovery counter), but a
+  method documented "read-only" (`status.py`) silently closing clients and
+  evicting `_clients` is its own surprise.
+- **Fix (small):** take `_recovery_lock` around the `:389` write (and audit the
+  other mutations in `_check_cached_client_alive` for the same). Alternatively —
+  and this is a maintainer judgment, not a forced choice — give the status
+  accessors a lock-free *read-only* liveness probe that defers the eviction/mark
+  to the next real recovery call, so "read-only" is true again. The narrow lock
+  fix is the smaller change; the probe split is the cleaner contract.
+
+### AC3 — Process teardown reaps only the direct child; grandchildren orphaned on SIGKILL · LOW–MEDIUM (documented limitation — recorded, opt-in)
+`process.py:127` spawns the server with **no** `start_new_session=True` / process
+group; `_stop_unlocked` escalates `terminate()` (`:234`) → `kill()` (`:240`),
+both signalling only the immediate child. `acp_client/` never uses the repo's
+`capabilities/process.py::kill_process_tree` (killpg / `taskkill /T`).
+
+- This is **explicitly documented** in-code (`process.py:209–216`): the design
+  prefers the graceful stdin-EOF path precisely so the server reaps its own
+  MCP/shell grandchildren, "which `terminate()` here cannot." So it is a
+  *known* limitation, not an oversight.
+- **Failure scenario:** a server that ignores both stdin-EOF **and** SIGTERM is
+  SIGKILLed; its grandchildren (its own MCP-stdio / shell children) are orphaned
+  and survive. Repeated `restart_server`/`stop_all` cycles accumulate them.
+- **Fix is NOT drop-in.** `kill_process_tree` uses `killpg(proc.pid)`, which only
+  isolates descendants when the child is a session/group leader — so a correct
+  fix must **both** spawn with `start_new_session=True` **and** switch the kill
+  path to the tree reaper. Two options, maintainer's call: (a) make that
+  spawn+kill change and route through `kill_process_tree`, or (b) leave the
+  documented graceful-first design and accept the SIGKILL-tail leak as a rare,
+  recorded edge. Recorded, not scheduled.
+
+---
+
+## Tier 3 — Opportunistic hardening + larger refactors (opt-in)
+
+### AC5 — Server-controlled display text is not sanitized for terminal escapes; agent chunks are size-unbounded · LOW–MEDIUM (opportunistic hardening)
+The renderer prints a **third-party** ACP server's output to the user's terminal
+(`render.py`). Two gaps:
+
+- **Terminal-escape injection.** The plain fallback (`render.py:117`,
+  `sys.stdout.write(render_all_plain(...))`) writes server text **verbatim** —
+  `render_plain:74` only does `\n`→`\n  `, no escape-sequence stripping. The Rich
+  path escapes Rich *markup* (`rich.markup.escape`, `:185,195,197`) but that
+  handles `[bold]`-style tags, **not** raw ANSI/terminal control sequences
+  (`\x1b[…`, OSC set-title, clipboard). Source text is fully server-controlled
+  (`agent_message_chunk` → `helpers.py`). A malicious/compromised server can emit
+  cursor/screen/title manipulation into the terminal; the plain path is the
+  unambiguous vector.
+- **Unbounded size (DoS).** No length cap on the stdout read (`process.py` line
+  iteration) or on `agent_message_chunk`/`agent_thought_chunk` text
+  (`helpers.py` returns them **untruncated**, unlike every other kind, which caps
+  at 40–120 chars). A server emitting one multi-GB line forces unbounded
+  in-memory buffering.
+- **Fix (opportunistic):** strip/replace C0/C1 control bytes (keep `\n`/`\t`)
+  before display on **both** paths, and cap per-line / per-chunk length on read.
+  Fold in next time `render.py` / `helpers.py` is touched. (Trust posture: the
+  same server already runs as a spawned child with scrubbed env — this is
+  defense-in-depth on the *output* channel, not a headline hole.)
+- **Status: IMPLEMENTED** (escape sanitization on both paths + per-chunk cap);
+  the readline-level cap is **deferred** (framing rewrite). See the Implementation
+  status section below.
+
+### AC6 — The re-session + sticky-fatal handshake "dance" is copy-pasted across 5 entry points · MEDIUM (dangerous duplication — consolidate)
+The classification *primitives* were already extracted (`_reclassify_as_handshake_fail`
+/ `_note_handshake_failure_and_maybe_fatal` / `_note_handshake_success`), but the
+**sequence that wraps `create_session`/`initialize`** in
+`try … except BaseException: if reclassify: note-fatal; raise` + trailing
+`note-success` is hand-inlined at **5 sites** (grep-confirmed):
+`connection.py:170–173`, `:263–271`, `:400–406`, `turns.py:662–665`, `:840–869`.
+
+- **Why this is the dangerous kind:** the code itself repeatedly comments that
+  *every* handshake entry point "must also flip sticky-fatal … otherwise a host
+  choosing one API silently opts out of the recovery contract." The invariant is
+  fragile **because** it is copied — a 6th entry point that forgets the dance
+  silently breaks recovery, with no test forcing the wrapper's presence.
+- **Fix:** one `_handshake_guarded(fn, name)` wrapper/context-manager that runs
+  the setup call, does reclassify+maybe-fatal on failure and `note-success` on
+  success; all 5 sites call it. This is real consolidation against a
+  correctness-adjacent invariant — worth doing on its own, not merely
+  opportunistically. Two related closures (the client-callback builders in
+  `connection.py` ≈ `turns.py:_open_ephemeral_client_locked`) can fold in with it.
+
+### AC7 — `prompt_once` is a 261-line, depth-~8 method mixing 7 concerns · HIGH maintenance cost (refactor, opt-in)
+`turns.py:452–712` — the single fattest method in the repo (confirmed span; next
+method `_rollback_ephemeral_on_busy` begins at `:714`). It interleaves: policy
+resolution + handle lookup, recovery pre-check, ephemeral setup under the
+handshake lock, fail-fast turn-lock acquire + rollback, a **cached-client
+reuse/re-session branch that re-implements `_ensure_connected_locked`** (this is
+one of AC6's 5 copies), turn run + `PromptResult` build, and a deeply-nested
+`finally` ephemeral teardown. The depth-8 re-session-inside-`finally` region is
+exactly where a concurrency regression is most likely to hide.
+
+- **Extractable blocks (with the AC6 helper doing the heavy lifting):**
+  `_setup_ephemeral_or_defer(...)`, `_reuse_cached_client_for_prompt_once(...)`
+  (→ the shared `_handshake_guarded`), `_teardown_ephemeral_after_prompt(...)`.
+  Splitting drops the core path to ~120 lines.
+- **Constraint:** the handshake-lock/turn-lock ordering, the fail-fast
+  `_rollback_ephemeral_on_busy` gate, and the `finally` teardown's
+  "don't stop a proc a live winner is using" guard (`turns.py:751`) are
+  load-bearing. Mechanical refactor, must keep the concurrency tests green.
+
+### AC8 — Cluster of LOW, no-drift internal duplication · LOW (opportunistic only)
+Recorded so a future pass doesn't re-discover them; **none has dangerous drift**,
+so fold in only when the file is open:
+
+- `manager/interactions.py`: `approve_interaction` (`:412–453`) ≈
+  `reject_interaction` (`:455–498`) are mirror images; the `{"outcome":{"outcome":
+  "selected","optionId":…}}` envelope is hand-built 5× (`:277,297,314,443,488`).
+- `manager/helpers.py`: `_select_approve_option` (`:218`) ≈ `_select_reject_option`
+  (`:131`) — same 3-pass scanner, differing only in target literals; the `_opt_id`
+  closure is defined 3×.
+- `client.py`: `send_prompt` (`:519`) re-implements the send half of
+  `send_prompt_nonblocking` (`:622`) + `finish_prompt` (`:679`).
+- `models.py`: `InteractionPolicy.mode` validated 3× (`:206`, `:367`, `_parse…:274`);
+  `max_recoverable_restarts` bound checked 2× (`:347`, `from_dict:466`).
+- **Fix:** parameterized helpers (`_select_option(...)`, `_selected(option_id)`,
+  route `from_dict` through `__post_init__`). Opportunistic; do **not** manufacture
+  shared API solely to delete these.
+- **Status: PARTIALLY IMPLEMENTED** — the no-drift wins landed (`_select_option` +
+  `_opt_id` in `helpers.py`; `_selected_outcome` + `_resolve_and_respond` in
+  `interactions.py`). The `models.py` validation dedup and the `client.py`
+  `send_prompt` overlap are **skipped with cause** (context-specific error messages;
+  concurrency-sensitive path). See the Implementation status section below.
+
+---
+
+## Verified non-findings (checked and cleared — do not "fix")
+
+- **N1 — child env IS scrubbed (security-positive).** `process.py:124`
+  `build_child_env(self.config.env)` drops `HARNESS_ENV_KEYS` (provider creds)
+  before spawning; the sole `Popen` (`:127`) uses it. A third-party ACP server
+  does **not** inherit `OPENAI_API_KEY` etc. Explicitly documented (`:119–124`,
+  "same trust position as an MCP server").
+- **N2 — no SSRF surface.** `AcpServerConfig` accepts only `command/args/env/cwd`;
+  grep for `url|https?|headers|authorization|bearer|sse|streamable|websocket`
+  across `acp_client/` → **no transport match.** stdio-only; `url_policy.py` is
+  inapplicable (watch-item only if a URL transport is ever added).
+- **N3 — secrets are redacted in `agentao.log`.** The `agentao.acp_client` logger
+  is a child of `agentao`, whose file handler carries `_RedactingFormatter`; debug
+  param dumps and child stderr are redacted. Config never logs env *values*
+  (errors use `type(...).__name__`). No hand-rolled redaction (correctly — grep
+  `secret_scan|redact` → no match; it isn't needed here).
+- **N4 — the ephemeral open/rollback/busy race is well-defended.** Traced the
+  two-prompt interleavings: the handshake lock serializes open/connect/rollback;
+  `has_ephemeral` fail-fasts a competing `prompt_once`; `_rollback_ephemeral_on_busy`
+  guards teardown with `name not in self._clients and not process_was_running`
+  (`turns.py:751`) so a proc a live winner uses is never torn down. No TOCTOU.
+- **N5 — concurrent `_send` cannot corrupt NDJSON framing.** Each frame is a single
+  `stdin.write(line + "\n")` on a `BufferedWriter` whose `write()` is atomic under
+  its internal lock; concurrent cancel/response/notify interleave whole lines,
+  never bytes.
+- **N6 — no turn-slot / proc leak on the normal error paths.** `_active_turns` is
+  cleared in `finally` on every path; failed connect / bad handshake calls
+  `handle.stop()` only when *this* call started the proc (`_we_started` gate),
+  so a pre-warmed server survives a bad handshake. `prompt_once`'s ephemeral is
+  popped+closed in `finally` (`turns.py:683–712`).
+- **N7 — boundary is clean.** No core module eagerly imports `acp_client`; the only
+  non-package references are two docstring mentions and **lazy, function-local**
+  imports in CLI entrypoints (`cli/acp_inbox.py`, `cli/commands_ext/acp.py`).
+  Render/display lives inside `acp_client/` (mild layering smell) but is
+  self-contained — `client.py`/`process.py`/`manager/*` never import `render`, so
+  core doesn't pull display in.
+- **N8 — `config.py` does NOT copy the lossy read-json-swallow idiom** the June
+  review flagged repo-wide; it **raises** `AcpConfigError` with precise messages on
+  both `OSError` and `JSONDecodeError`. Stricter by design.
+- **N9 — the manager mixin split is deliberate, not a god-class.** The
+  lifecycle/connection/turns/interactions/status/recovery split is documented in
+  the module + `__init__` docstrings; shared `self.*` state is the documented
+  contract.
+
+---
+
+## Recommended sequence
+
+> **This is the original proposal.** For what actually landed (and where AC4
+> deviated), see **Implementation status** below — it supersedes this ordering.
+
+1. **PR 1 — do-now, low risk.** AC1 (`stop_all` snapshot — one line) + AC4 (delete
+   the three dead surfaces). No behavior change beyond removing a crash and dead
+   code.
+2. **PR 2 — small correctness.** AC2 (lock the recovery-counter write, or split the
+   read-only probe — maintainer's call). Single, tightly-scoped.
+3. **Recorded, opt-in.** AC3 (spawn+kill-tree change *or* accept the documented
+   limitation) — a deliberate decision, not scheduled work.
+4. **Tier 3 — opt-in, higher value/risk.** AC6 (the sticky-fatal dance is the one
+   consolidation worth doing on its own — a correctness-adjacent invariant), then
+   AC7 (`prompt_once`, which the AC6 helper de-risks). AC5 hardening and the AC8
+   cluster fold in opportunistically when those files are next touched.
+
+The AC3 spawn-model change and the AC5 output-hardening posture are
+harness-vs-product judgment calls that belong to the maintainer.
+
+---
+
+## Appendix — how each finding was verified
+
+| Finding | Verification |
+|---|---|
+| AC1 | read `lifecycle.py:73–97` (live `.items()` at `:75` vs `list(...)` at `:82`); traced `_clients.pop` sites — `recovery.py:376`, `lifecycle.py:114/171` — reachable lock-free from `status.py` |
+| AC2 | read `recovery.py:296–407`; `_clear_fatal:300` holds `_recovery_lock` for the identical `= 0` write, `:389` does not; grep of all `_handshake_fail_streak` writes confirmed the asymmetry |
+| AC3 | read `process.py:100–260`: `Popen` at `:127` has no `start_new_session`; escalation `terminate:234`/`kill:240`; documented limitation comment `:209–216`; compared to `capabilities/process.py::kill_process_tree` |
+| AC4 | grep `deadline_at` (no assignment outside `:56` default), `_open_ephemeral_client\b` (only comments + the def), `_note_handshake_failure\b` (no production caller) |
+| AC5 | read `render.py` end-to-end: plain `sys.stdout.write` `:117`, `escape` handles markup not ANSI `:185/195/197`; `helpers.py` agent chunks untruncated |
+| AC6 | grep `_reclassify_as_handshake_fail`/`_note_handshake_success` → 5 call-site clusters (`connection.py:170/263/400`, `turns.py:662/840`); matching `create_session`/`initialize` sites |
+| AC7 | `awk` method-span → `prompt_once` `452–712` (261 lines), next def `_rollback_ephemeral_on_busy` at `:714` |
+| N1–N9 | `build_child_env` read; grep for url/SSRF transport (none); logger parentage + `_RedactingFormatter`; traced ephemeral race interleavings; NDJSON atomic-write reasoning; `_we_started` gate; `import.*acp_client` across `agentao/` |
+
+---
+
+## Implementation status (2026-07-23 → 2026-07-24)
+
+**Landed: AC1 (crash fix), AC2 (lock fix), AC3 (process-tree kill), AC4′
+(test-correctness fix), AC6 (handshake-dance consolidation), AC7 (`prompt_once`
+decomposition).** AC4's "dead code" was re-scoped and deliberately NOT deleted —
+the direct read contradicted the "dead code, delete it" framing, so the honest
+call was to keep the code and record why (same conservative reflex as the June
+review's T1.4 revert — don't end a contract early just because a surface looks
+dead). AC5 and AC8 remain recorded (opportunistic).
+
+- **AC1 — implemented.** `lifecycle.py::stop_all` now iterates
+  `list(self._clients.items())` (a snapshot), matching the `_ephemeral_clients`
+  block directly below it. Regression test added:
+  `tests/test_acp_client_process.py::TestACPManager::test_stop_all_survives_client_removed_mid_iteration`
+  — a fake client whose `close()` pops a sibling deterministically reproduces the
+  mid-iteration mutation. **Proven to have teeth:** reverting the one-line fix
+  makes the test fail with exactly `RuntimeError: dictionary changed size during
+  iteration` at `lifecycle.py:80`; with the fix, the full acp_client + headless
+  suites are green (194 passed). An `xhigh` workflow code review then flagged that
+  the test's explicit `mgr._clients == {}` assertion is guaranteed by `stop_all`'s
+  unconditional `clear()` — so a `client_a.closed and client_b.closed` assertion
+  was added to prove each snapshotted client is actually drained (not merely
+  dropped). (The reviewer's other candidate — that the two close-loops are now
+  copy-paste — was refuted by the verify pass: they clear different dicts.)
+
+- **AC2 — implemented.** `recovery.py::_check_cached_client_alive` now wraps the
+  streak-reset write (`self._handshake_fail_streak[name] = 0`) in
+  `with self._recovery_lock:`, matching every other streak mutation
+  (`_clear_fatal` / `_note_handshake_success` / `_note_handshake_failure_and_maybe_fatal`).
+  `_mark_fatal` and `_note_recovery_attempt` were confirmed already locked, so
+  `:389` was the sole unlocked recovery-dict write. The narrow-lock option was
+  chosen over the read-only-probe split (the smaller change). Green: embedding +
+  headless suites (117 passed).
+
+- **AC3 — implemented.** `process.py::ACPProcessHandle.start` now spawns with
+  `start_new_session=True` (POSIX) / `CREATE_NEW_PROCESS_GROUP` (Windows), and the
+  force-stop escalation's final SIGKILL routes through
+  `capabilities/process.py::kill_process_tree` instead of `self._proc.kill()`, so an
+  unresponsive server's MCP/shell grandchildren are reaped rather than orphaned. The
+  graceful stdin-EOF path and the child-scoped SIGTERM middle stage are unchanged
+  (the server still reaps its own grandchildren on a clean shutdown); only the last
+  resort became tree-scoped. Both halves shipped together because `killpg(proc.pid)`
+  is only safe once the child leads its own group. The two escalation waits are now
+  module constants (`_TERMINATE_STOP_TIMEOUT` / `_KILL_STOP_TIMEOUT`) so tests can
+  speed them up. Two new tests: a fast POSIX check that the child is its own
+  process-group leader, and an integration test that a signal-ignoring server's
+  grandchild is reaped — **proven to have teeth** (reverting to `self._proc.kill()`
+  makes the grandchild survive and the test fail). A follow-up review pass found the
+  first cut only reaped the tree when the server *survived* SIGTERM; a server that
+  *dies* on SIGTERM without reaping its own children would still orphan them. Fixed
+  by making the whole-tree sweep unconditional after the SIGTERM stage (a no-op when
+  the group is already empty), with a second teeth test for the die-on-SIGTERM path.
+  Two **accepted trade-offs** the review surfaced, both requiring changes outside
+  this subpackage so left as recorded follow-ups: (1) `start_new_session` detaches
+  the server from agentao's controlling terminal, so a terminal-close `SIGHUP` no
+  longer reaps it — robust cleanup on agentao's *own* abnormal termination needs a
+  CLI-layer `SIGHUP`/`SIGTERM` handler calling `stop_all()` (the interactive CLI only
+  cleans up via a `finally`); (2) on Windows the force-kill now shells out to
+  `taskkill /F /T` (≤5 s) instead of an instant `proc.kill()`, so the handle lock is
+  held marginally longer on the already-degenerate force path. Both are inherent to
+  correct process-group tree-reaping.
+
+- **AC4′ — implemented.** `test_acp_client_embedding.py` (the sessionless-cached
+  re-session test) now spies on `_open_ephemeral_client_locked` — the method
+  `prompt_once` actually calls — instead of the never-called `_open_ephemeral_client`
+  wrapper, so `called["ephemeral"] == 0` now genuinely asserts "no ephemeral was
+  created on the cached-reuse path" rather than being vacuously true. Still green.
+
+- **AC4 — re-scoped, not deleted.** Reading each of the three surfaces against its
+  callers showed none is pure rot:
+  - `interaction.py deadline_at` / `expire_overdue` — a **designed-but-unwired
+    feature** (interaction deadline → default action), with a full docstring and an
+    isolation test (`test_acp_client_cli.py::test_expire_overdue`). Wiring-vs-remove
+    is a **product decision for the maintainer**, not a cleanup — left in place.
+  - `recovery.py:166 _note_handshake_failure` — functions as a clean **test seam**:
+    `test_headless_runtime.py:1207,1247` use it to simulate "streak = 1" without
+    reaching into the private `_handshake_fail_streak` dict. Deleting it would push
+    those tests to poke internal state directly — a downgrade. Left in place.
+  - `turns.py:760 _open_ephemeral_client` (redundant lock-acquiring wrapper) — the
+    real defect here is **not** the dead wrapper but a **vacuous test assertion**:
+    `test_acp_client_embedding.py:945–953` spies on `_open_ephemeral_client` and
+    asserts it "MUST NOT fire", but production takes the `_locked` path, so the
+    assertion is trivially true and guards nothing. **New sub-finding (AC4′):**
+    retarget that spy to `_open_ephemeral_client_locked` so the test actually
+    asserts "no ephemeral client is created on the cached path." That is a
+    test-correctness fix (behavior-meaningful), separate from any code deletion.
+    **Implemented** (see the AC4′ bullet above).
+
+- **AC6 — implemented.** A `RecoveryMixin._handshake_guarded(name, *, on_failure=None)`
+  context manager now owns the sticky-fatal dance (reclassify → maybe-fatal → raise
+  on failure; note-success on success). All **5** copies route through it:
+  `connection.py` ×3 (`_connect_server_locked` cached-reuse + greenfield,
+  `ensure_connected` re-session) and `turns.py` ×2 (`prompt_once` cached re-session,
+  `_open_ephemeral_client_locked` greenfield). Sites 2 and 5 keep their site-specific
+  teardown via the `on_failure` hook (close the half-built client, stop a
+  self-started proc). **Order subtlety (caught by the xhigh code review):** the two
+  greenfield sites ran accounting and teardown in *opposite* orders, and both
+  `_mark_fatal` (→ handle state `FAILED`) and `handle.stop()` (→ `STOPPED`) write
+  `handle.info.state`, so the order decides the terminal state a host sees via
+  `get_status()`. The CM therefore takes a `cleanup_before_accounting` flag; each
+  site passes the value that reproduces its own prior order (site 2 → `FAILED`, site
+  5 → `STOPPED`), keeping the consolidation truly behaviour-preserving. A 6th entry
+  point can no longer forget the accounting. Green: full acp_client + headless suites.
+
+- **AC7 — implemented.** `prompt_once` dropped from **261 → 148 lines** (the code
+  body ~95; the rest is its docstring) by extracting three cohesive helpers:
+  `_setup_ephemeral_or_defer` (handshake-locked ephemeral setup / defer →
+  `(client, ephemeral_created, process_was_running)`),
+  `_reuse_cached_client_for_prompt_once` (the cached-reuse/re-session branch,
+  flattened from depth-8 nesting to early returns), and
+  `_teardown_ephemeral_after_prompt` (the `finally` teardown). The load-bearing
+  invariants held: the turn lock's unconditional `lock.release()` stays in
+  `prompt_once`'s `finally`; the handshake-lock/turn-lock ordering, the fail-fast
+  `_rollback_ephemeral_on_busy` gate, and the "don't stop a proc a live winner is
+  using" guard are all preserved (moved verbatim into the helpers). Green: 252
+  acp_client + headless tests.
+
+- **AC5 — implemented (output hardening), one sub-part deferred.** Added
+  `render._sanitize_terminal_text` (drops C0 incl. ESC, DEL, and C1 controls;
+  keeps `\n`/`\t`) and wired it into **both** display paths: the plain
+  `render_plain` fallback (the verbatim-`sys.stdout.write` vector) and the Rich
+  path (agent-Markdown accumulation + the prefixed-line branch). Stripping the ESC
+  byte alone neutralizes every CSI/OSC sequence — the standard, robust approach —
+  so the residual `[2J`-style text is inert; we do **not** fragile-parse whole
+  sequences. Added a per-chunk cap `helpers._cap_chunk` (`_MAX_CHUNK_DISPLAY_CHARS
+  = 256 KiB`) on `agent_message_chunk` / `agent_thought_chunk` — the only kinds
+  that were returned untruncated — so a compromised server can't force multi-GB
+  buffering in the inbox + Markdown accumulator. The cap is far above any real
+  streaming delta, so it never touches legitimate content. +9 teeth tests
+  (`test_acp_client_inbox.py::TestTerminalSanitization`/`TestChunkCap`), incl.
+  Rich-path OSC-set-title/BEL removal. **Deferred (documented):** the
+  readline-level hard cap in `process.py` — the multi-GB buffering happens inside
+  the C-level `for raw_line in stdout` before any Python check can see the line, so
+  a real cap there needs a bounded-frame NDJSON reader with a *drop-oversized-frame*
+  policy (a mid-line truncation would corrupt a legitimately-large valid JSON-RPC
+  frame). That is a framing rewrite on the hottest client path; given the child is
+  already env-scrubbed and the display buffer is now bounded by `_cap_chunk`, it is
+  left as a recorded follow-up rather than shipped under the "opportunistic" label.
+
+- **AC8 — partially implemented (the no-drift wins), two items skipped with cause.**
+  Done: (a) `helpers.py` — extracted a module-level `_opt_id` and a parameterized
+  `_select_option(options, *, canonical_kind, kind_prefix, hints)`; the three
+  copies (`_select_reject_option`, `_select_approve_option`, and the inlined
+  `_opt_id` in `_select_option_by_kind`) now route through it. The public
+  `_select_approve_option` / `_select_reject_option` / `_select_option_by_kind`
+  names (exported in `manager/__init__.__all__`, imported by
+  `test_acp_client_embedding.py`) are kept as thin wrappers — behavior-preserving.
+  (b) `interactions.py` — the `{"outcome":{"outcome":"selected","optionId":…}}`
+  envelope (hand-built 5×) is now `_selected_outcome(option_id)`, and the identical
+  resolve → send-response → transition-off-`WAITING_FOR_USER` tail of
+  `approve`/`reject`/`reply_interaction` is now `_resolve_and_respond(...)`.
+  **Skipped, with cause:** (c) `models.py`'s 3× mode / 2× restart-bound validation
+  is intentional context-specific messaging — `from_dict` / `_parse_non_interactive_policy`
+  emit *JSON field-name* errors (`'maxRecoverableRestarts'`, migration hints) at
+  config-load, while `__post_init__` emits *Python attribute* errors at dataclass
+  construction; these strings are user-facing UX (and some are asserted in tests),
+  so collapsing them would degrade the message, not just dedup. This is exactly the
+  "no dangerous drift → leave it" case. (d) `client.py`'s `send_prompt` vs
+  `send_prompt_nonblocking` + `finish_prompt` overlap sits on the JSON-RPC
+  send/response-correlation path that the concurrency tests guard; it is the
+  riskiest of the four for the lowest (LOW) payoff, so per the audit's own
+  "do not manufacture shared API solely to delete these" guidance it is left
+  recorded. Existing coverage (`TestSelectRejectOption`, the
+  `result["outcome"]["optionId"]` envelope assertions in `test_acp_client_cli.py`,
+  and the `accept_all` auto-reject tests in `test_headless_runtime.py`) validates
+  the consolidations as behavior-preserving.
+
+- **AC5/AC8 xhigh code-review round (post-implementation)** — a second workflow
+  review of the AC5/AC8 diff found **9 distinct defects, all fixed** (the AC1/2/3/6/7
+  diff was separately reviewed clean). The material ones were mine:
+  1. **Sanitizer missed the interaction display path** (highest severity). `flush_to_console`
+     skips PERMISSION/INPUT and delegates to `_handle_inline_interaction`
+     (`cli/commands_ext/acp.py`), which `console.print`s the server's `toolCall.title`
+     / `rawInput` / `content` / `interaction.prompt` **unsanitized** — the exact
+     interaction channel AC5 targets. Fixed by sanitizing every server-controlled
+     field at that second display boundary (+3 tests driving ESC/OSC through a fake
+     console).
+  2. **`_cap_chunk` TypeError regression** — `len()`/slice assumed `str`; a JSON-number
+     `content.text` from a hostile server raised `TypeError` (swallowed by the client's
+     notification try/except → the message *and* the host callback silently dropped),
+     where the pre-diff code returned the value. Fixed with an `isinstance(text, str)`
+     passthrough guard.
+  3. **Sanitizer left Unicode bidi-override controls** (Trojan-Source / CVE-2021-42574):
+     U+202A–202E / U+2066–2069 / U+200E/200F/061C reorder text with no ESC byte. Added
+     `_BIDI_CONTROLS` to the strip set; deliberately keeps ZWJ/ZWNJ/BOM (legit in
+     emoji / Arabic-Indic).
+  4. **Cap over-claimed memory bounding** — `_cap_chunk` bounds only the *display*
+     string; `InboxMessage.raw = params` still retains the full payload. Corrected the
+     comment to scope the claim (display path only) and point the true payload / process-
+     read bound at the deferred readline-frame cap.
+  5. **Cap skipped sibling server text** — permission `toolCall.title` and `ask_user`
+     `question`/`message` reached `InboxMessage.text` uncapped. Now routed through
+     `_cap_chunk`.
+  6. **Cross-chunk accumulation unbounded** — per-chunk cap didn't bound the
+     `agent_text_parts` join handed to RichMarkdown (~256×256 KiB per flush). Added
+     `render._MAX_AGENT_RENDER_CHARS = 1 MiB` on the aggregate.
+  7. **Non-ASCII ellipsis** in the truncation marker (`…`) could `UnicodeEncodeError`
+     under a non-UTF-8 stdout in the plain path. Switched to ASCII `...`.
+  8. **Debug log-only branch** logged server `msg.text[:200]` unsanitized (a DEBUG
+     stream handler would echo escapes). Now sanitized before logging.
+  9. **`_select_option_by_kind` duplicated pass 1** of `_select_option`. Extracted
+     `_first_id_by_kind` shared by both. Full suite green after fixes.
+
+**Net:** three real defects addressed (AC1 crash, AC2 lock, AC3 orphaned
+grandchildren) with teeth-proven / behavior-preserving coverage; two Tier-3
+refactors landed behind their concurrency tests (AC6 handshake-dance consolidation,
+AC7 `prompt_once` decomposition); AC5 output-hardening shipped (escape sanitization
++ chunk cap; the readline-level cap deferred as a framing rewrite); AC8's no-drift
+consolidations landed (`_select_option`, `_selected_outcome`, `_resolve_and_respond`)
+with the two message-/concurrency-sensitive items left recorded. The AC4 "dead code"
+bucket stays downgraded to one implemented test-correctness item (AC4′) plus one
+maintainer product decision.

--- a/docs/design/acp-client-audit.zh.md
+++ b/docs/design/acp-client-audit.zh.md
@@ -1,0 +1,420 @@
+# Agentao — `acp_client/` 子包审计
+
+**状态:** 评审记录。2026-07-23 以"六月同等标准"对 `agentao/acp_client/` 子包做的
+四维审计——这是 ACP **客户端**(Agentao **向外**连接它以子进程 stdio 方式拉起的
+项目本地 ACP server)。**本文是有证据支撑的发现清单 + 优先级建议,不是已批准的
+计划。** 该子包**不在** 2026-06-19 `optimization-opportunities-review.md` 的审计
+范围内(那一轮覆盖 runtime、打包、CLI 和 ACP **服务端**);本文补上这个缺口。
+**读者:** Agentao 维护者。
+**配套:** `acp-client-audit.md`(权威英文版)。
+**相关:**
+- `optimization-opportunities-review.md` —— 六月审计,本文沿用其方法与分层
+  (立即修的 bug vs 顺手合并、`gap ≠ need`、已核实的非问题)。
+- `acp-server-conformance-review.md` —— ACP **服务端**,本文是其客户端镜像。
+- `core-boundary-review.md` —— 渲染/展示是否该住在 core(AC5)遵循它记录的边界。
+
+**方法:** 四路并行取证——**复杂度/结构**、**正确性/并发/资源安全**、**重复/复用**、
+**契约/边界/安全**,每条发现必须引用 `file:line`,以 `grep`/阅读佐证,而非凭直觉,
+符合本仓"先证据后建议、gap ≠ need"的纪律。最高影响、最不可逆的论断(两个并发 bug、
+进程 kill 局限、死代码删除、渲染/注入面)在落文档前**已逐一对源码独立复读**。代码
+引用锚定 `main`@`278e92a`(2026-07-23)。行号会漂移——动手前重新 grep。
+
+---
+
+## 摘要(TL;DR)
+
+`acp_client/` 是一个**构建良好、防御式编码**的子包——19 文件 / ~5.8k LOC,11 个测试
+文件覆盖,manager 有意的 mixin 分解,对拉起的子进程正确剥离了 provider 凭据,并且有一
+套确实很难的并发契约(单活跃 turn 锁 + handshake 锁 + sticky-fatal 恢复)——**大体是
+对的**。**没有安全漏洞,也没有架构性紧急问题。** 四个审计员最强的信号是**在少数几项上
+收敛**,而不是一长串缺陷。
+
+发现分为三类有边界的工作:
+
+1. **立即做、低风险(AC1、AC4)。** 一个平凡的并发 bug(`stop_all` 迭代活字典——
+   一行 `list()` 修复)+ 三处会被误读为"活行为"的死/仅测试代码。都安全、微小、能真正
+   减少困惑。
+2. **尽快做、小改动(AC2)+ 记录性局限(AC3)。** 恢复计数器的锁不对称(AC2)是个小的
+   正确性修复;进程树 kill 缺口(AC3)是**已文档化**的局限,其修复非即插即用(需要
+   改 spawn 侧)——记录、可选。
+3. **顺手/较大(AC5–AC8)。** 对服务器可控展示文本做终端转义 + 尺寸加固(AC5),以及两个
+   可维护性项:复制在 5 处入口的 handshake"sticky-fatal 舞蹈"(AC6,**危险的那种**
+   重复)和 261 行的 `prompt_once`(AC7)。这些承载真正的长期成本,但行为风险也最大——
+   Tier-3、可选。
+
+> **优先级排序是维护者的判断。** 本文提供 grep 核实的证据和*建议*次序;不替维护者裁定
+> 什么值不值得花时间。
+
+> **范围诚实——并发发现(AC1/AC2)只在已文档化的多线程嵌入面上触发。** 交互式 CLI 里
+> `get_status`/`stop_all`/`send_prompt` 单线程运行,永不竞争。但该模块被明确文档化为
+> 支持并发 daemon/workflow 嵌入(`turns.py` 关于监控线程 + 工作线程的 docstring),而且
+> **每个客户端的 reader 线程已经在与主线程并发地跑回调**,所以对那个面而言竞争是真实的,
+> 不是假想。
+
+---
+
+## 基线指标
+
+| 指标 | 值 | 解读 |
+|---|---|---|
+| 源文件 / LOC | 19 / ~5,785 | 最大的从未被审计的子包 |
+| 引用它的测试文件 | 11(`test_acp_client_*` ×7 + 4) | 覆盖良好 |
+| 最大文件 | `manager/turns.py`(892) | turn 编排 + ephemeral |
+| 最大方法 | `manager/turns.py::prompt_once`(261,`452–712`) | **全仓最长方法** |
+| 子进程 env 凭据剥离 | 有(`process.py:124 build_child_env`) | 安全正向(见 N1) |
+| 远程/URL 传输 | 无(纯 stdio) | 消除 SSRF 面(见 N2) |
+
+---
+
+## Tier 1 —— 立即做,低风险
+
+### AC1 —— `stop_all()` 迭代活 `_clients` 字典 → 并发嵌入下 `RuntimeError` + 子进程泄漏 · MEDIUM(bug——立即修,平凡)
+`lifecycle.py:75`:`for name, client in self._clients.items():` 迭代**活**字典——而紧邻
+的下一块(`:82`)却防御式拷贝了 `list(self._ephemeral_clients.items())`。这个不对称就是
+线索。`_clients` 会从**无锁**且可并发到达的调用点被 `pop`:`_check_cached_client_alive`
+(`recovery.py:376`)在**不持** handshake 锁的情况下被文档自称"只读"的访问器 `get_status`
+(`status.py`)、`readiness`(`status.py`)和 `prompt_once` 前置检查(`turns.py:525`)调用;
+`stop_server`(`lifecycle.py:171`)和 `_evict_cached_client`(`lifecycle.py:114`)也在该路径
+上 `pop`。
+
+- **失败场景:** 监控线程对一个子进程在 `READY` 状态下已死的 server 轮询
+  `readiness()`/`get_status()`;其 `_check_cached_client_alive` 执行
+  `self._clients.pop(name)`(`recovery.py:376`),**恰在**另一线程处于 `stop_all()` 的
+  `for … in self._clients.items()` 之中 → `RuntimeError: dictionary changed size during
+  iteration`。`stop_all` 中途中止;崩溃点之后的每个 handle 都拿不到 `handle.stop()` →
+  **ACP 子进程泄漏。**
+- **修复(单点、平凡):** 迭代快照——`for name, client in list(self._clients.items()):`——
+  与下一行的 ephemeral 块一致。PR 只改这一个方法。
+
+### AC4 —— 三处死/仅测试代码被误读为活行为 · LOW(快赢)
+每一处都经 grep 核实**零生产调用/写入**;三者都仅由测试维持存活,读者会把惰性机制当真:
+
+- **`interaction.py:56` `deadline_at` + `:122` `expire_overdue`** —— `deadline_at` 除
+  `None` 默认外**从未被赋值**(grep:只有 docstring `:43`、字段默认 `:56`、以及 `:134–135`
+  两处*读取*)。故 `deadline_at is not None` 守卫在生产中**恒为 False**,`expire_overdue()`
+  是保证的空操作——整套 deadline/过期机制是惰性的,只被手动设字段的测试接线。
+- **`turns.py:760` `_open_ephemeral_client`**(取锁包装)—— 零生产调用;`prompt_once` 直接
+  调 `_open_ephemeral_client_locked`(`:789`)于 `turns.py:575`。其余提及都是注释。只有一个
+  测试把它 monkeypatch 成 spy——而它连真实的 `_locked` 路径都拦不到。
+- **`recovery.py:166` `_note_handshake_failure`**(裸版,非 `_and_maybe_fatal`)—— 零生产
+  调用(grep 遍 `agentao/`);只有测试用它模拟 streak。
+- **修复:** 删掉两个死 helper,并对 `deadline_at` 要么接线要么删除过期机制。删除会触及引用
+  它们的测试——作为一次小而边界清晰的清理,不要和行为改动捆绑。
+
+---
+
+## Tier 2 —— 小的正确性修复 + 一个记录性局限
+
+### AC2 —— 恢复计数器写入未持 `_recovery_lock`;"只读"status 访问器在锁外改动恢复状态 · LOW–MEDIUM(bug——立即修,小)
+与 AC1 同根(轮询路径上的无锁改动),但是独立缺陷。`recovery.py:389` 写
+`self._handshake_fail_streak[name] = 0` **未持** `_recovery_lock`——而对该 map 的**其余每一处**
+写入都持锁(`recovery.py:164,168,184,200,300`;例如 `_clear_fatal:296–300` 把同样的 `= 0`
+写入包在 `with self._recovery_lock` 里)。外层 `_check_cached_client_alive` 还会 `pop`
+`_clients`、关闭 client、调 `_mark_fatal`、改 handle 状态——全都从文档自称"只读"的
+`status.py` 访问器无锁可达。
+
+- **失败场景:** 线程 A 在 `_note_handshake_failure_and_maybe_fatal` 里对 streak 做持锁的
+  读-改-写(读 `1` → 写 `2` → 在 `>1` 触发 fatal);线程 B(对一个 `READY` 中已死 server 的
+  无锁 `get_status` 轮询)在 A 的读与写**之间**执行 `:389` 的裸 `= 0`,因为 B 从不去争 A 持有
+  的锁。这次重置丢失或覆盖 A 的自增 → "连续 2 次 handshake 失败 ⇒ sticky-fatal"的账目错位,
+  使 server 提前一次崩溃就 fatal,或该 trip 时不 trip。影响有界(恢复计数器差一),但一个被
+  文档化为"只读"的方法(`status.py`)悄悄关 client、逐出 `_clients`,本身就是意外。
+- **修复(小):** 对 `:389` 写入加 `_recovery_lock`(并顺带审计 `_check_cached_client_alive`
+  里其他改动是否同样需要)。或者——这是维护者判断,不是被迫的唯一路径——给 status 访问器一个
+  无锁**只读**存活探针,把逐出/标记推迟到下一次真正的恢复调用,让"只读"名副其实。窄锁修复改动更
+  小;探针拆分契约更干净。
+
+### AC3 —— 进程 teardown 只回收直接子进程;SIGKILL 时孙进程被孤立 · LOW–MEDIUM(已文档化局限——记录、可选)
+`process.py:127` 拉起 server 时**没有** `start_new_session=True` / 进程组;`_stop_unlocked`
+逐级升级 `terminate()`(`:234`)→ `kill()`(`:240`),都只对直接子进程发信号。`acp_client/`
+从不使用本仓的 `capabilities/process.py::kill_process_tree`(killpg / `taskkill /T`)。
+
+- 这在代码里**有明确文档**(`process.py:209–216`):设计**刻意**偏好优雅的 stdin-EOF 路径,
+  正是为了让 server 自己回收它的 MCP/shell 孙进程——"这里的 `terminate()` 做不到"。所以是
+  *已知*局限,不是疏漏。
+- **失败场景:** 一个既忽略 stdin-EOF **又**忽略 SIGTERM 的 server 被 SIGKILL;它的孙进程
+  (它自己的 MCP-stdio / shell 子进程)被孤立并存活。反复 `restart_server`/`stop_all` 会累积。
+- **修复非即插即用。** `kill_process_tree` 用 `killpg(proc.pid)`,只有子进程是会话/组 leader 时
+  才能隔离后代——所以正确修复必须**既**以 `start_new_session=True` spawn,**又**把 kill 路径切到
+  树回收器。两个选项,维护者定:(a) 做这个 spawn+kill 改动并走 `kill_process_tree`,或
+  (b) 保留已文档化的"优雅优先"设计,接受 SIGKILL 尾部泄漏这个罕见、已记录的边界。记录,不排期。
+
+---
+
+## Tier 3 —— 顺手加固 + 较大重构(可选)
+
+### AC5 —— 服务器可控展示文本未做终端转义清理;agent 分片尺寸无界 · LOW–MEDIUM(顺手加固)
+渲染器把**第三方** ACP server 的输出打到用户终端(`render.py`)。两个缺口:
+
+- **终端转义注入。** plain 回退路径(`render.py:117`,`sys.stdout.write(render_all_plain(...))`)
+  **原样**写服务器文本——`render_plain:74` 只做 `\n`→`\n  `,不剥离转义序列。Rich 路径转义的是
+  Rich *markup*(`rich.markup.escape`,`:185,195,197`),那处理的是 `[bold]` 之类标记,**不是**
+  裸 ANSI/终端控制序列(`\x1b[…`、OSC 设标题、剪贴板)。源文本完全服务器可控
+  (`agent_message_chunk` → `helpers.py`)。恶意/被攻陷的 server 可向终端注入光标/屏幕/标题操纵;
+  plain 路径是最明确的载体。
+- **尺寸无界(DoS)。** stdout 读取(`process.py` 行迭代)与 `agent_message_chunk`/
+  `agent_thought_chunk` 文本(`helpers.py` **不截断**返回,而其他每种 kind 都截到 40–120 字符)
+  都无长度上限。server 发一条多 GB 的单行会强制无界内存缓冲。
+- **修复(顺手):** 在**两条**路径展示前剥离/替换 C0/C1 控制字节(保留 `\n`/`\t`),并对读取的
+  每行/每片长度设上限。下次动 `render.py`/`helpers.py` 时并入。(信任姿态:同一 server 已作为
+  env 被剥离的子进程运行——这是对*输出*通道的纵深防御,不是头号漏洞。)
+- **状态:已实现**(两条路径都做转义清理 + 每片尺寸上限);readline 级上限**延期**(需重写
+  帧解析)。详见下方"实现状态"。
+
+### AC6 —— re-session + sticky-fatal 的 handshake"舞蹈"复制在 5 处入口 · MEDIUM(危险重复——合并)
+分类*原语*已被提取(`_reclassify_as_handshake_fail` / `_note_handshake_failure_and_maybe_fatal`
+/ `_note_handshake_success`),但**包裹 `create_session`/`initialize` 的那套序列**——
+`try … except BaseException: if reclassify: note-fatal; raise` + 末尾 `note-success`——被手工内联在
+**5 处**(grep 确认):`connection.py:170–173`、`:263–271`、`:400–406`、`turns.py:662–665`、`:840–869`。
+
+- **为何是危险的那种:** 代码自己反复注释,*每个* handshake 入口"都必须翻转 sticky-fatal……
+  否则选了某个 API 的 host 会悄悄退出恢复契约"。这个不变量**正因为被复制而脆弱**——第 6 个入口
+  忘了这套舞蹈就会悄悄破坏恢复,而没有测试强制包装存在。
+- **修复:** 一个 `_handshake_guarded(fn, name)` 包装/上下文管理器,跑 setup 调用、失败时
+  reclassify+maybe-fatal、成功时 `note-success`;5 处都调它。这是针对一个正确性相邻不变量的真正
+  合并——值得单独做,而非仅顺手。两个相关闭包(`connection.py` 里 ≈ `turns.py:_open_ephemeral_client_locked`
+  的 client-callback 构造)可随之并入。
+
+### AC7 —— `prompt_once` 是 261 行、深度约 8、混 7 个关注点的方法 · HIGH 维护成本(重构,可选)
+`turns.py:452–712` —— 全仓最长方法(span 已确认;下一方法 `_rollback_ephemeral_on_busy` 起于
+`:714`)。它交织:policy 解析 + handle 查找、恢复前置检查、handshake 锁下的 ephemeral 建立、
+fail-fast 取 turn 锁 + 回滚、一个**重实现 `_ensure_connected_locked` 的 cached-client 复用/re-session
+分支**(这是 AC6 那 5 份复制之一)、turn 运行 + `PromptResult` 构建、以及深度嵌套的 `finally`
+ephemeral 拆除。深度 8 的"re-session-在-`finally`-内"区域,正是并发回归最可能藏身处。
+
+- **可提取块(由 AC6 的 helper 挑重担):** `_setup_ephemeral_or_defer(...)`、
+  `_reuse_cached_client_for_prompt_once(...)`(→ 共享的 `_handshake_guarded`)、
+  `_teardown_ephemeral_after_prompt(...)`。拆分后核心路径降到约 120 行。
+- **约束:** handshake 锁/turn 锁的次序、fail-fast 的 `_rollback_ephemeral_on_busy` 门,以及
+  `finally` 拆除里"别停一个活赢家正用的 proc"守卫(`turns.py:751`)是承重的。机械重构,须保并发
+  测试全绿。
+
+### AC8 —— 一簇 LOW、无漂移的内部重复 · LOW(仅顺手)
+记录下来免得下一轮重新发现;**没有一处有危险漂移**,故只在文件已打开时并入:
+
+- `manager/interactions.py`:`approve_interaction`(`:412–453`)≈ `reject_interaction`(`:455–498`)
+  互为镜像;`{"outcome":{"outcome":"selected","optionId":…}}` 信封手搭 5 次(`:277,297,314,443,488`)。
+- `manager/helpers.py`:`_select_approve_option`(`:218`)≈ `_select_reject_option`(`:131`)——
+  同 3 遍扫描,只差目标字面量;`_opt_id` 闭包定义 3 次。
+- `client.py`:`send_prompt`(`:519`)重实现 `send_prompt_nonblocking`(`:622`)的发送半段 +
+  `finish_prompt`(`:679`)。
+- `models.py`:`InteractionPolicy.mode` 校验 3 次(`:206`、`:367`、`_parse…:274`);
+  `max_recoverable_restarts` 边界查 2 次(`:347`、`from_dict:466`)。
+- **修复:** 参数化 helper(`_select_option(...)`、`_selected(option_id)`,让 `from_dict` 走
+  `__post_init__`)。顺手;**不要**为删这些而制造共享 API。
+- **状态:部分实现**——无漂移的净收益已落地(`helpers.py` 的 `_select_option` + `_opt_id`;
+  `interactions.py` 的 `_selected_outcome` + `_resolve_and_respond`)。`models.py` 的校验去重与
+  `client.py` 的 `send_prompt` 重叠**有据跳过**(前者是随上下文变化的错误消息 UX;后者在并发敏感
+  路径上)。详见下方"实现状态"。
+
+---
+
+## 已核实的非问题(查过、清白——不要"修")
+
+- **N1 —— 子进程 env 确实被剥离(安全正向)。** `process.py:124`
+  `build_child_env(self.config.env)` 在 spawn 前丢弃 `HARNESS_ENV_KEYS`(provider 凭据);唯一的
+  `Popen`(`:127`)用它。第三方 ACP server **不会**继承 `OPENAI_API_KEY` 等。有明确文档
+  (`:119–124`,"与 MCP server 相同的信任位置")。
+- **N2 —— 无 SSRF 面。** `AcpServerConfig` 只接受 `command/args/env/cwd`;在 `acp_client/` grep
+  `url|https?|headers|authorization|bearer|sse|streamable|websocket` → **无传输匹配**。纯 stdio;
+  `url_policy.py` 不适用(仅在将来加 URL 传输时作为观察项)。
+- **N3 —— `agentao.log` 中密钥已脱敏。** `agentao.acp_client` logger 是 `agentao` 的子 logger,
+  其文件 handler 带 `_RedactingFormatter`;debug 参数转储与子进程 stderr 都被脱敏。config 从不记录
+  env *值*(错误用 `type(...).__name__`)。无手搓脱敏(正确——grep `secret_scan|redact` → 无匹配;
+  这里不需要)。
+- **N4 —— ephemeral open/rollback/busy 竞争防御良好。** 追踪了双 prompt 交错:handshake 锁序列化
+  open/connect/rollback;`has_ephemeral` fail-fast 竞争的 `prompt_once`;`_rollback_ephemeral_on_busy`
+  以 `name not in self._clients and not process_was_running`(`turns.py:751`)守拆除,故活赢家在用的
+  proc 绝不被拆。无 TOCTOU。
+- **N5 —— 并发 `_send` 不会破坏 NDJSON 帧。** 每帧是单次 `stdin.write(line + "\n")`,`BufferedWriter`
+  的 `write()` 在其内部锁下原子;并发 cancel/response/notify 以整行交错,绝不逐字节。
+- **N6 —— 正常错误路径无 turn-slot / proc 泄漏。** `_active_turns` 在每条路径 `finally` 清理;失败
+  connect / 坏 handshake 仅在*本次*调用启动了该 proc 时(`_we_started` 门)才调 `handle.stop()`,故
+  预热 server 能挺过坏 handshake。`prompt_once` 的 ephemeral 在 `finally` 被 pop+close(`turns.py:683–712`)。
+- **N7 —— 边界干净。** 无 core 模块 eager import `acp_client`;包外唯一引用是两处 docstring 提及,以及
+  CLI 入口里**惰性、函数内** import(`cli/acp_inbox.py`、`cli/commands_ext/acp.py`)。渲染/展示住在
+  `acp_client/` 内(轻微分层气味)但自足——`client.py`/`process.py`/`manager/*` 从不 import `render`,
+  故 core 不会把展示拉进来。
+- **N8 —— `config.py` 未复制**六月审计标记的全仓"读-json-吞异常"惰性惯用法;它在 `OSError` 与
+  `JSONDecodeError` 两处都**抛** `AcpConfigError` 并带精确消息。设计上更严。
+- **N9 —— manager 的 mixin 拆分是有意的,不是 god-class。** lifecycle/connection/turns/interactions/
+  status/recovery 的拆分在模块 + `__init__` docstring 有文档;共享 `self.*` 状态是有文档的契约。
+
+---
+
+## 建议次序
+
+> **这是最初的提案。** 实际落地情况(以及 AC4 的偏离)见下方**实现状态**——它取代本排序。
+
+1. **PR 1 —— 立即做、低风险。** AC1(`stop_all` 快照——一行)+ AC4(删三处死代码)。除消除一个崩溃
+   和死代码外无行为改变。
+2. **PR 2 —— 小的正确性。** AC2(给恢复计数器写入加锁,或拆只读探针——维护者定)。单一、边界收紧。
+3. **记录、可选。** AC3(做 spawn+kill-tree 改动 *或* 接受已文档化局限)——一个刻意决定,不是排期工作。
+4. **Tier 3 —— 可选、更高价值/风险。** AC6(sticky-fatal 舞蹈是唯一值得单独做的合并——一个正确性相邻
+   不变量),然后 AC7(`prompt_once`,由 AC6 的 helper 降险)。AC5 加固与 AC8 簇在这些文件下次被动时
+   顺手并入。
+
+AC3 的 spawn 模型改动与 AC5 的输出加固姿态是 harness-vs-product 判断题,归维护者。
+
+---
+
+## 附录 —— 每条发现如何核实
+
+| 发现 | 核实 |
+|---|---|
+| AC1 | 读 `lifecycle.py:73–97`(`:75` 活 `.items()` vs `:82` `list(...)`);追踪 `_clients.pop` 点——`recovery.py:376`、`lifecycle.py:114/171`——从 `status.py` 无锁可达 |
+| AC2 | 读 `recovery.py:296–407`;`_clear_fatal:300` 对同样的 `= 0` 写入持 `_recovery_lock`,`:389` 不持;grep 所有 `_handshake_fail_streak` 写入确认不对称 |
+| AC3 | 读 `process.py:100–260`:`:127` `Popen` 无 `start_new_session`;升级 `terminate:234`/`kill:240`;局限注释 `:209–216`;对比 `capabilities/process.py::kill_process_tree` |
+| AC4 | grep `deadline_at`(除 `:56` 默认外无赋值)、`_open_ephemeral_client\b`(只有注释 + def)、`_note_handshake_failure\b`(无生产调用) |
+| AC5 | 通读 `render.py`:plain `sys.stdout.write` `:117`,`escape` 处理 markup 而非 ANSI `:185/195/197`;`helpers.py` agent 分片不截断 |
+| AC6 | grep `_reclassify_as_handshake_fail`/`_note_handshake_success` → 5 处调用簇(`connection.py:170/263/400`、`turns.py:662/840`);对应 `create_session`/`initialize` 点 |
+| AC7 | `awk` 方法 span → `prompt_once` `452–712`(261 行),下一 def `_rollback_ephemeral_on_busy` 在 `:714` |
+| N1–N9 | 读 `build_child_env`;grep url/SSRF 传输(无);logger 父子关系 + `_RedactingFormatter`;追踪 ephemeral 竞争交错;NDJSON 原子写推理;`_we_started` 门;`agentao/` 全局 `import.*acp_client` |
+
+---
+
+## 实现状态(2026-07-23 → 2026-07-24)
+
+**已落地:AC1(崩溃修复)、AC2(加锁修复)、AC3(进程树 kill)、AC4′(测试正确性修复)、
+AC6(handshake 舞蹈合并)、AC7(`prompt_once` 拆分)。AC4 的"死代码"经直接核查被重新界定,
+并刻意未删除**——直接阅读与"死代码,删掉"的框定相矛盾,于是诚实的选择是保留代码并记录原因
+(与六月审计 T1.4 回滚同样的保守反射——不要因为某表面看似死就提前终结一个契约)。AC5 与
+AC8 仍记录待办(顺手项)。
+
+- **AC1 —— 已实现。** `lifecycle.py::stop_all` 现在迭代 `list(self._clients.items())`
+  (快照),与其正下方的 `_ephemeral_clients` 块一致。新增回归测试:
+  `tests/test_acp_client_process.py::TestACPManager::test_stop_all_survives_client_removed_mid_iteration`
+  —— 一个 `close()` 会 pop 兄弟条目的假 client 确定性复现迭代中改动。**已证明有牙:**
+  回退这一行修复会让测试精确抛出 `RuntimeError: dictionary changed size during iteration`
+  于 `lifecycle.py:80`;带修复时,acp_client + headless 全套绿(194 passed)。随后一次 `xhigh`
+  workflow 代码评审指出该测试的显式断言 `mgr._clients == {}` 由 `stop_all` 无条件的 `clear()`
+  保证,故补上 `client_a.closed and client_b.closed` 断言,证明每个快照 client 确实被 close(而
+  非仅被丢弃)。(评审的另一候选——两个 close 循环现在是复制粘贴——被 verify 阶段驳回:它们清的
+  是不同的 dict。)
+
+- **AC2 —— 已实现。** `recovery.py::_check_cached_client_alive` 现在把 streak 重置写入
+  (`self._handshake_fail_streak[name] = 0`)包在 `with self._recovery_lock:` 里,与其余每处
+  streak 改动一致(`_clear_fatal` / `_note_handshake_success` /
+  `_note_handshake_failure_and_maybe_fatal`)。已确认 `_mark_fatal` 与 `_note_recovery_attempt`
+  本就持锁,故 `:389` 是唯一无锁的恢复字典写入。选了窄锁方案而非只读探针拆分(改动更小)。绿:
+  embedding + headless 套件(117 passed)。
+
+- **AC3 —— 已实现。** `process.py::ACPProcessHandle.start` 现在以 `start_new_session=True`
+  (POSIX)/ `CREATE_NEW_PROCESS_GROUP`(Windows)spawn,强制停止升级链的最终 SIGKILL 改走
+  `capabilities/process.py::kill_process_tree` 而非 `self._proc.kill()`,使无响应 server 的
+  MCP/shell 孙进程被回收而非孤立。优雅 stdin-EOF 路径与子进程作用域的 SIGTERM 中间阶段不变
+  (server 在干净关停时仍自己回收孙进程),只有最后手段变为整树作用域。两半必须一起改,因为
+  `killpg(proc.pid)` 只有在子进程是组 leader 时才安全。两个升级超时提为模块常量
+  (`_TERMINATE_STOP_TIMEOUT` / `_KILL_STOP_TIMEOUT`)以便测试提速。两个新测试:快速验证子进程是
+  自己进程组 leader,以及一个集成测试验证忽略信号的 server 的孙进程被回收——**已证明有牙**
+  (改回 `self._proc.kill()` 会让孙进程存活、测试失败)。后续评审发现首版只在 server **挺过**
+  SIGTERM 时才回收整树;而**死于** SIGTERM 且不回收自己子进程的 server 仍会孤立它们。已修:让整树
+  回收在 SIGTERM 阶段后**无条件**执行(组已空时为 no-op),并为"死于 SIGTERM"路径加了第二个有牙
+  测试。评审还指出两个**接受的权衡**,因需改动本子包之外、留作记录性后续:(1)`start_new_session`
+  使 server 脱离 agentao 的控制终端,终端关闭的 `SIGHUP` 不再回收它——agentao **自身**异常终止时的
+  健壮清理需要 CLI 层的 `SIGHUP`/`SIGTERM` handler 调 `stop_all()`(交互式 CLI 目前只靠 `finally`
+  清理);(2)Windows 上强制 kill 现走 `taskkill /F /T`(≤5 秒)而非瞬时 `proc.kill()`,故在已然退化
+  的强制路径上 handle 锁多持有一小会儿。两者都是正确的进程组整树回收所固有的。
+
+- **AC4′ —— 已实现。** `test_acp_client_embedding.py`(无 session 的 cached 复用 re-session 测试)
+  现在 spy 于 `_open_ephemeral_client_locked`——`prompt_once` 真正调用的方法——而非从不被调用的
+  `_open_ephemeral_client` 包装,故 `called["ephemeral"] == 0` 现在真正断言"cached 复用路径上未
+  创建 ephemeral",而非恒真。仍绿。
+
+- **AC4 —— 重新界定,未删除。** 逐一对着调用方阅读三处表面,发现没有一处是纯 rot:
+  - `interaction.py deadline_at` / `expire_overdue` —— 一个**设计了但未接线的功能**
+    (交互 deadline → 默认动作),带完整 docstring 和独立测试
+    (`test_acp_client_cli.py::test_expire_overdue`)。接线 vs 删除是**维护者的产品决定**,
+    不是清理——保留。
+  - `recovery.py:166 _note_handshake_failure` —— 作为干净的**测试接缝**:
+    `test_headless_runtime.py:1207,1247` 用它模拟"streak = 1",不必去戳私有
+    `_handshake_fail_streak` dict。删了会逼那些测试直接改内部状态——降级。保留。
+  - `turns.py:760 _open_ephemeral_client`(冗余取锁包装)—— 这里真正的缺陷**不是**死包装,
+    而是一个**空断言**:`test_acp_client_embedding.py:945–953` 对 `_open_ephemeral_client`
+    做 spy 并断言它"MUST NOT fire",但生产走 `_locked` 路径,故该断言恒真、什么也没守。
+    **子发现(AC4′,已实现,见上):** 把 spy 改指向 `_open_ephemeral_client_locked`,让测试
+    真正断言"cached 路径上不会创建 ephemeral client"。这是测试正确性修复(行为有意义),与任何
+    代码删除无关。
+
+- **AC6 —— 已实现。** 新增 `RecoveryMixin._handshake_guarded(name, *, on_failure=None)`
+  上下文管理器,统管 sticky-fatal 舞蹈(失败:reclassify → maybe-fatal → raise;成功:
+  note-success)。全部 **5** 处复制均改走它:`connection.py` ×3(`_connect_server_locked`
+  cached 复用 + greenfield、`ensure_connected` re-session)与 `turns.py` ×2(`prompt_once`
+  cached re-session、`_open_ephemeral_client_locked` greenfield)。站点2、5 通过 `on_failure`
+  钩子保留各自清理(关半建 client、停自启 proc)。**顺序细节(被 xhigh 代码评审抓到):** 两个
+  greenfield 站点的"记账 vs 清理"顺序**相反**,而 `_mark_fatal`(→ handle 状态 `FAILED`)与
+  `handle.stop()`(→ `STOPPED`)都写 `handle.info.state`,故顺序决定 host 经 `get_status()` 看到的
+  终态。因此 CM 加了 `cleanup_before_accounting` 标志;每个站点传入复现其原有顺序的值(站点2 →
+  `FAILED`,站点5 → `STOPPED`),使合并真正行为保持。第 6 个入口再也无法漏掉记账。绿:acp_client +
+  headless 全套。
+
+- **AC7 —— 已实现。** `prompt_once` 从 **261 → 148 行**(代码体约 95,其余是 docstring),提取三个
+  内聚 helper:`_setup_ephemeral_or_defer`(handshake 锁下的 ephemeral 设置/延迟 →
+  `(client, ephemeral_created, process_was_running)`)、`_reuse_cached_client_for_prompt_once`
+  (cached 复用/re-session 分支,从深度 8 嵌套扁平化为早返回)、`_teardown_ephemeral_after_prompt`
+  (`finally` 拆除)。承重不变量都保住了:turn 锁无条件的 `lock.release()` 仍在 `prompt_once` 的
+  `finally`;handshake 锁/turn 锁次序、fail-fast 的 `_rollback_ephemeral_on_busy` 门、"别停活赢家
+  在用的 proc"守卫均原样保留(逐字搬进 helper)。绿:252 个 acp_client + headless 测试。
+
+- **AC5 —— 已实现(输出加固),一个子项延期。** 新增 `render._sanitize_terminal_text`(剥离 C0
+  含 ESC、DEL、C1 控制字符;保留 `\n`/`\t`),接入**两条**展示路径:plain 的 `render_plain` 回退
+  (那条原样 `sys.stdout.write` 的载体)与 Rich 路径(agent-Markdown 累积 + 前缀行分支)。只剥 ESC
+  字节即可让每个 CSI/OSC 序列失效——这是标准、稳健的做法——残留的 `[2J` 之类是惰性文本;我们
+  **不**去 fragile-parse 整段序列。新增每片上限 `helpers._cap_chunk`(`_MAX_CHUNK_DISPLAY_CHARS
+  = 256 KiB`)于 `agent_message_chunk` / `agent_thought_chunk`(唯二不截断返回的 kind),使被攻陷
+  server 无法在 inbox + Markdown 累积器里强制多 GB 缓冲;上限远高于任何真实流式增量,故绝不触碰
+  合法内容。+9 个有牙测试(`TestTerminalSanitization`/`TestChunkCap`,含 Rich 路径 OSC-设标题/BEL
+  剥离)。**延期(已记录):** `process.py` 的 readline 级硬上限——多 GB 缓冲发生在 C 层
+  `for raw_line in stdout` 内、任何 Python 检查看到该行之前,故真正的上限需要一个带*丢弃超大帧*
+  策略的定长帧 NDJSON 读取器(行内截断会破坏一个合法的超大 JSON-RPC 帧)。那是客户端最热路径上的
+  帧解析重写;鉴于子进程已 env 被剥离、展示缓冲现已被 `_cap_chunk` 限住,留作记录性后续,而不在
+  "顺手"名义下仓促发布。
+
+- **AC8 —— 部分实现(无漂移的净收益),两项有据跳过。** 已做:(a)`helpers.py`——提取模块级
+  `_opt_id` 与参数化的 `_select_option(options, *, canonical_kind, kind_prefix, hints)`;三份复制
+  (`_select_reject_option`、`_select_approve_option`,以及 `_select_option_by_kind` 里内联的
+  `_opt_id`)都改走它。公开名 `_select_approve_option` / `_select_reject_option` /
+  `_select_option_by_kind`(在 `manager/__init__.__all__` 导出、被 `test_acp_client_embedding.py`
+  引用)保留为薄包装——行为保持。(b)`interactions.py`——手搭 5 次的
+  `{"outcome":{"outcome":"selected","optionId":…}}` 信封现为 `_selected_outcome(option_id)`,而
+  `approve`/`reject`/`reply_interaction` 相同的 resolve → 发响应 → 从 `WAITING_FOR_USER` 转移
+  尾段现为 `_resolve_and_respond(...)`。**有据跳过:**(c)`models.py` 的 3× mode / 2× 重启边界
+  校验是**刻意的随上下文变化的消息**——`from_dict` / `_parse_non_interactive_policy` 在配置加载时
+  发出 *JSON 字段名* 错误(`'maxRecoverableRestarts'`、迁移提示),而 `__post_init__` 在 dataclass
+  构造时发出 *Python 属性* 错误;这些串是用户可见 UX(且部分被测试断言),合并会降级消息而非仅去重
+  ——正是"无危险漂移 → 留着"那类。(d)`client.py` 的 `send_prompt` 与 `send_prompt_nonblocking` +
+  `finish_prompt` 重叠位于并发测试守护的 JSON-RPC 发送/响应关联路径上,是四者中风险最高、回报
+  最低(LOW)的,按审计自己"不要为删这些而制造共享 API"的指引,留作记录。既有覆盖
+  (`TestSelectRejectOption`、`test_acp_client_cli.py` 里 `result["outcome"]["optionId"]` 信封断言、
+  `test_headless_runtime.py` 的 `accept_all` 自动拒绝测试)验证了这些合并是行为保持的。
+
+- **AC5/AC8 xhigh 代码评审轮(实现后)** —— 对 AC5/AC8 diff 的第二次 workflow 评审发现
+  **9 个不同缺陷,全部已修**(AC1/2/3/6/7 的 diff 另行评审为干净)。要害几处是我引入的:
+  1. **清理器漏了交互展示路径**(最高严重度)。`flush_to_console` 跳过 PERMISSION/INPUT 转交
+     `_handle_inline_interaction`(`cli/commands_ext/acp.py`),后者 `console.print` 服务器的
+     `toolCall.title` / `rawInput` / `content` / `interaction.prompt` **未清理**——正是 AC5 针对的
+     交互通道。修复:在第二个展示边界清理每个服务器可控字段(+3 个测试把 ESC/OSC 打进假 console)。
+  2. **`_cap_chunk` TypeError 回归** —— `len()`/切片假设 `str`;敌意 server 发来 JSON 数字的
+     `content.text` 会抛 `TypeError`(被 client 通知 try/except 吞掉 → 消息与 host 回调静默丢失),
+     而改动前直接返回该值。修复:加 `isinstance(text, str)` 直通守卫。
+  3. **清理器漏了 Unicode 双向覆盖控制符**(Trojan-Source / CVE-2021-42574):U+202A–202E /
+     U+2066–2069 / U+200E/200F/061C 无需 ESC 字节即可重排文本。加入 `_BIDI_CONTROLS`;刻意保留
+     ZWJ/ZWNJ/BOM(emoji / 阿拉伯-印度文合法)。
+  4. **上限的内存声明夸大** —— `_cap_chunk` 只限住*展示*串;`InboxMessage.raw = params` 仍留全量。
+     订正注释把声明缩到仅展示路径,并把真正的 payload / 进程读上限指向延期的 readline 帧上限。
+  5. **上限漏了同类服务器文本** —— 权限 `toolCall.title` 与 `ask_user` `question`/`message` 无上限
+     进入 `InboxMessage.text`。现改走 `_cap_chunk`。
+  6. **跨分片累积无界** —— 每片上限不限住交给 RichMarkdown 的 `agent_text_parts` 拼接(每次 flush 约
+     256×256 KiB)。加 `render._MAX_AGENT_RENDER_CHARS = 1 MiB` 限住聚合。
+  7. **非 ASCII 省略号** —— 截断标记的 `…` 在非 UTF-8 stdout 的 plain 路径可能 `UnicodeEncodeError`。
+     改为 ASCII `...`。
+  8. **debug log-only 分支** —— 未清理地记录服务器 `msg.text[:200]`(DEBUG 流 handler 会回显转义)。
+     现在记录前先清理。
+  9. **`_select_option_by_kind` 复制了 `_select_option` 的 pass 1** —— 提取共享的 `_first_id_by_kind`。
+     修复后全套绿。
+
+**净结果:** 三个真缺陷已处理(AC1 崩溃、AC2 锁、AC3 孤立孙进程),配有"证明有牙"/行为保持的
+覆盖;两个 Tier-3 重构在并发测试护航下落地(AC6 handshake 舞蹈合并、AC7 `prompt_once` 拆分);
+AC5 输出加固已发布(转义清理 + 分片上限;readline 级上限作为帧解析重写延期);AC8 的无漂移合并
+已落地(`_select_option`、`_selected_outcome`、`_resolve_and_respond`),两个消息-/并发-敏感项留作
+记录。AC4 的"死代码"桶仍降级为一个已实现的测试正确性项(AC4′)+ 一个维护者产品决定。

--- a/tests/test_acp_client_cli.py
+++ b/tests/test_acp_client_cli.py
@@ -177,6 +177,66 @@ class TestManagerInteractionBridge:
 
 
 # ---------------------------------------------------------------------------
+# AC5 — inline interaction display sanitizes server-controlled escapes
+# ---------------------------------------------------------------------------
+
+
+class TestInlineInteractionSanitized:
+    """_handle_inline_interaction must strip terminal escapes from server text.
+
+    The permission/input display path bypasses render.py's sanitizer (those
+    kinds are skipped in flush_to_console), so the inline handler is the second
+    display boundary and must sanitize on its own.
+    """
+
+    def _run_permission(self, details: dict) -> str:
+        import io
+        from rich.console import Console
+        from agentao.cli.commands_ext import acp as acp_mod
+
+        buf = io.StringIO()
+        fake_console = Console(file=buf, force_terminal=True, width=100)
+        i = PendingInteraction(
+            server="srv",
+            kind=InteractionKind.PERMISSION,
+            prompt=details.get("_prompt", "allow?"),
+            details=details,
+        )
+        mock_mgr = MagicMock()
+        with patch.object(acp_mod, "console", fake_console), patch.object(
+            acp_mod.readchar, "readkey", return_value="3"
+        ):
+            acp_mod._handle_inline_interaction(None, mock_mgr, "srv", i)
+        return buf.getvalue()
+
+    def test_permission_title_escapes_stripped(self) -> None:
+        out = self._run_permission(
+            {"toolCall": {"title": "run\x1b]0;PWNED\x07 tool", "kind": "exec"}}
+        )
+        assert "\x1b]" not in out
+        assert "\x07" not in out
+        assert "PWNED" in out  # inert residue survives; only the escapes are gone
+
+    def test_permission_rawinput_and_bidi_stripped(self) -> None:
+        out = self._run_permission(
+            {
+                "toolCall": {
+                    "title": "ok",
+                    "rawInput": {"path": "a\x1b[2Jb", "note": "x‮y"},
+                }
+            }
+        )
+        assert "\x1b[2J" not in out
+        assert "‮" not in out  # bidi override stripped
+
+    def test_permission_prompt_fallback_stripped(self) -> None:
+        # No toolCall dict -> falls back to interaction.prompt display.
+        out = self._run_permission({"_prompt": "do\x1b]0;x\x07 it"})
+        assert "\x1b]" not in out
+        assert "\x07" not in out
+
+
+# ---------------------------------------------------------------------------
 # Response sent back to server (P1 fix)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_acp_client_embedding.py
+++ b/tests/test_acp_client_embedding.py
@@ -942,15 +942,19 @@ class TestPromptOnceReusesSessionlessCachedClient:
             cached.connection_info.session_cwd = None
             cached.connection_info.session_mcp_servers_fingerprint = None
 
-            # Spy on _open_ephemeral_client: it MUST NOT fire.
+            # Spy on the ephemeral-client constructor: it MUST NOT fire.
+            # ``prompt_once`` reaches for ``_open_ephemeral_client_locked``
+            # (it already holds the handshake lock), NOT the lock-acquiring
+            # ``_open_ephemeral_client`` wrapper — so spy on the method the
+            # production path actually calls, or the assertion is vacuous.
             called = {"ephemeral": 0}
-            original = mgr._open_ephemeral_client
+            original = mgr._open_ephemeral_client_locked
 
             def _spy(*args, **kwargs):
                 called["ephemeral"] += 1
                 return original(*args, **kwargs)
 
-            monkeypatch.setattr(mgr, "_open_ephemeral_client", _spy)
+            monkeypatch.setattr(mgr, "_open_ephemeral_client_locked", _spy)
 
             result = mgr.prompt_once("srv", "hello", timeout=5)
             assert result.stop_reason == "end_turn"

--- a/tests/test_acp_client_inbox.py
+++ b/tests/test_acp_client_inbox.py
@@ -295,6 +295,248 @@ class TestRender:
 
 
 # ---------------------------------------------------------------------------
+# AC5 — terminal-escape sanitization of server-controlled display text
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalSanitization:
+    """A third-party ACP server's text must not carry terminal escapes."""
+
+    def test_sanitize_strips_c0_c1_keeps_whitespace(self) -> None:
+        from agentao.acp_client.render import _sanitize_terminal_text as san
+
+        # ESC (begins every CSI/OSC), BEL, DEL, and a C1 CSI are removed.
+        assert san("a\x1bb") == "ab"
+        assert san("ring\x07bell") == "ringbell"
+        assert san("del\x7fx") == "delx"
+        assert san("c1\x9bx") == "c1x"
+        # \n and \t are preserved; printable + higher Unicode untouched.
+        assert san("l1\nl2\tok 中文") == "l1\nl2\tok 中文"
+        assert san("plain text") == "plain text"
+        assert san("") == ""
+
+    def test_sanitize_strips_bidi_overrides_keeps_zwj(self) -> None:
+        # Trojan-Source (CVE-2021-42574): bidi controls reorder text with no ESC.
+        from agentao.acp_client.render import _sanitize_terminal_text as san
+
+        for cp in (0x202A, 0x202B, 0x202C, 0x202D, 0x202E,
+                   0x2066, 0x2067, 0x2068, 0x2069, 0x200E, 0x200F, 0x061C):
+            assert san("a" + chr(cp) + "b") == "ab", hex(cp)
+        # ZWJ / ZWNJ / BOM are legitimate (emoji, Arabic/Indic) — NOT stripped.
+        for cp in (0x200D, 0x200C, 0xFEFF):  # ZWJ, ZWNJ, BOM/ZWNBSP
+            assert san("a" + chr(cp) + "b") == "a" + chr(cp) + "b", hex(cp)
+
+    def test_render_plain_strips_escape_sequences(self) -> None:
+        # The plain fallback writes verbatim to stdout — the unambiguous vector.
+        msg = InboxMessage(
+            server="srv",
+            session_id="s",
+            kind=MessageKind.RESPONSE,
+            text="hello\x1b[2J\x1b]0;PWNED\x07world",
+        )
+        rendered = render_plain(msg)
+        assert "\x1b" not in rendered
+        assert "\x07" not in rendered
+        assert "hello" in rendered and "world" in rendered
+
+    def test_render_all_plain_strips_escapes(self) -> None:
+        msgs = [
+            InboxMessage(
+                server="a",
+                session_id="s",
+                kind=MessageKind.RESPONSE,
+                text="x\x1b[31mred",
+            ),
+        ]
+        assert "\x1b" not in render_all_plain(msgs)
+
+    def test_flush_to_console_strips_osc_from_prefixed_path(self) -> None:
+        from rich.console import Console
+        import io
+
+        buf = io.StringIO()
+        c = Console(file=buf, force_terminal=True, width=80)
+        msgs = [
+            InboxMessage(
+                server="srv",
+                session_id="s",
+                kind=MessageKind.RESPONSE,
+                text="setting title\x1b]0;PWNED\x07 done",
+            ),
+        ]
+        flush_to_console(msgs, c)
+        out = buf.getvalue()
+        # Rich emits its own CSI (\x1b[) color codes, but the server's OSC
+        # set-title introducer (\x1b]) and BEL terminator must be gone.
+        assert "\x1b]" not in out
+        assert "\x07" not in out
+
+    def test_flush_to_console_strips_escapes_from_agent_markdown(self) -> None:
+        from rich.console import Console
+        import io
+
+        buf = io.StringIO()
+        c = Console(file=buf, force_terminal=True, width=80)
+        msgs = [
+            InboxMessage(
+                server="srv",
+                session_id="s",
+                kind=MessageKind.RESPONSE,
+                text="agent reply\x1b]0;PWNED\x07 body",
+                update_kind="agent_message_chunk",
+            ),
+        ]
+        flush_to_console(msgs, c)
+        out = buf.getvalue()
+        assert "\x1b]" not in out
+        assert "\x07" not in out
+
+
+class TestChunkCap:
+    """AC5 — agent chunks are size-bounded so a server can't force GB buffering."""
+
+    def test_cap_chunk_passthrough_at_or_under_limit(self) -> None:
+        from agentao.acp_client.manager.helpers import (
+            _cap_chunk,
+            _MAX_CHUNK_DISPLAY_CHARS,
+        )
+
+        assert _cap_chunk("small") == "small"
+        exact = "x" * _MAX_CHUNK_DISPLAY_CHARS
+        assert _cap_chunk(exact) == exact  # exactly at the cap is untouched
+
+    def test_cap_chunk_truncates_pathological(self) -> None:
+        from agentao.acp_client.manager.helpers import (
+            _cap_chunk,
+            _MAX_CHUNK_DISPLAY_CHARS,
+        )
+
+        big = "y" * (_MAX_CHUNK_DISPLAY_CHARS + 5000)
+        capped = _cap_chunk(big)
+        body = capped.split("...[truncated", 1)[0]
+        assert len(body) == _MAX_CHUNK_DISPLAY_CHARS  # body bounded to the cap
+        assert "truncated 5000 chars" in capped
+        assert capped.isascii()  # marker is ASCII (no U+2026) — safe under LANG=C
+
+    def test_cap_chunk_passthrough_non_str(self) -> None:
+        # A hostile server may send a JSON number/bool for content.text; the cap
+        # must return it unchanged (no TypeError on len()), matching pre-cap code.
+        from agentao.acp_client.manager.helpers import _cap_chunk
+
+        assert _cap_chunk(42) == 42
+        assert _cap_chunk(None) is None
+        assert _cap_chunk(True) is True
+
+    def test_format_session_update_caps_agent_message_chunk(self) -> None:
+        from agentao.acp_client.manager.helpers import (
+            _format_session_update,
+            _MAX_CHUNK_DISPLAY_CHARS,
+        )
+
+        big = "z" * (_MAX_CHUNK_DISPLAY_CHARS + 100)
+        params = {
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"text": big},
+            }
+        }
+        out = _format_session_update(params)
+        assert len(out) <= _MAX_CHUNK_DISPLAY_CHARS + 64
+        assert "truncated 100 chars" in out
+
+    def test_format_session_update_caps_agent_thought_chunk(self) -> None:
+        from agentao.acp_client.manager.helpers import (
+            _format_session_update,
+            _MAX_CHUNK_DISPLAY_CHARS,
+        )
+
+        big = "t" * (_MAX_CHUNK_DISPLAY_CHARS + 7)
+        params = {
+            "update": {
+                "sessionUpdate": "agent_thought_chunk",
+                "content": {"text": big},
+            }
+        }
+        assert "truncated 7 chars" in _format_session_update(params)
+
+    def test_extract_display_text_caps_permission_title(self) -> None:
+        from agentao.acp_client.manager.helpers import (
+            _extract_display_text,
+            _MAX_CHUNK_DISPLAY_CHARS,
+        )
+
+        big = "T" * (_MAX_CHUNK_DISPLAY_CHARS + 500)
+        out = _extract_display_text(
+            "session/request_permission", {"toolCall": {"title": big}}
+        )
+        assert "truncated 500 chars" in out
+        assert len(out) <= _MAX_CHUNK_DISPLAY_CHARS + 64
+
+    def test_extract_display_text_caps_ask_user_question(self) -> None:
+        from agentao.acp_client.manager.helpers import (
+            _extract_display_text,
+            _MAX_CHUNK_DISPLAY_CHARS,
+        )
+
+        big = "Q" * (_MAX_CHUNK_DISPLAY_CHARS + 42)
+        out = _extract_display_text("_agentao.cn/ask_user", {"question": big})
+        assert "truncated 42 chars" in out
+
+
+class TestAggregateRenderCap:
+    """AC5 — the cross-chunk Markdown accumulation is bounded, not just per-chunk."""
+
+    def test_flush_bounds_accumulated_agent_text(self, monkeypatch) -> None:
+        import io
+        from rich.console import Console
+        import agentao.acp_client.render as render_mod
+
+        # Shrink the aggregate bound so the test stays cheap.
+        monkeypatch.setattr(render_mod, "_MAX_AGENT_RENDER_CHARS", 1000)
+        buf = io.StringIO()
+        c = Console(file=buf, force_terminal=True, width=120)
+        # 5 same-server chunks of 400 chars each -> 2000 accumulated > 1000 bound.
+        msgs = [
+            InboxMessage(
+                server="srv",
+                session_id="s",
+                kind=MessageKind.RESPONSE,
+                text="a" * 400,
+                update_kind="agent_message_chunk",
+            )
+            for _ in range(5)
+        ]
+        render_mod.flush_to_console(msgs, c)
+        assert "truncated 1000 chars" in buf.getvalue()
+
+
+class TestLogOnlySanitized:
+    """AC5 — the debug log-only branch must not echo raw server escapes."""
+
+    def test_log_only_message_text_is_sanitized(self, caplog) -> None:
+        import logging
+        import io
+        from rich.console import Console
+
+        buf = io.StringIO()
+        c = Console(file=buf, force_terminal=True, width=80)
+        msgs = [
+            InboxMessage(
+                server="srv",
+                session_id="s",
+                kind=MessageKind.NOTIFICATION,
+                text="reset\x1bc term",
+                update_kind="tool_call",  # a log-only kind
+            ),
+        ]
+        with caplog.at_level(logging.DEBUG, logger="agentao.acp_client"):
+            flush_to_console(msgs, c)
+        joined = "".join(r.getMessage() for r in caplog.records)
+        assert "\x1b" not in joined
+        assert "reset" in joined and "term" in joined
+
+
+# ---------------------------------------------------------------------------
 # Multi-server ordering
 # ---------------------------------------------------------------------------
 

--- a/tests/test_acp_client_process.py
+++ b/tests/test_acp_client_process.py
@@ -1,13 +1,17 @@
 """Tests for ACP client process handle and manager (Issue 02)."""
 
 import json
+import os
+import signal
 import sys
+import textwrap
 import time
 from pathlib import Path
 from typing import Dict
 
 import pytest
 
+import agentao.acp_client.process as acp_process
 from agentao.acp_client.manager import ACPManager
 from agentao.acp_client.models import (
     AcpClientConfig,
@@ -204,6 +208,142 @@ class TestACPProcessHandle:
         assert handle.state == ServerState.STOPPED
         assert sentinel.exists(), "child should exit gracefully on stdin EOF"
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+    def test_start_makes_child_process_group_leader(self) -> None:
+        """AC3 spawn-side: the child leads its own process group so a
+        force-stop can reap the whole tree via ``killpg(pid)`` without
+        signalling agentao's own group.
+        """
+        handle = ACPProcessHandle("pg", _sleeper_config())
+        handle.start()
+        try:
+            pid = handle.pid
+            assert pid is not None
+            assert os.getpgid(pid) == pid
+        finally:
+            handle.stop()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+    def test_force_stop_reaps_grandchildren(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC3 kill-side: a server that ignores both stdin-EOF and SIGTERM is
+        force-killed at the *whole-tree* level, so the grandchildren it spawned
+        (its own MCP/shell children) are not orphaned.
+        """
+        # Speed up the escalation so the test doesn't wait the real 5 s windows.
+        monkeypatch.setattr(acp_process, "_GRACEFUL_STOP_TIMEOUT", 0.3)
+        monkeypatch.setattr(acp_process, "_TERMINATE_STOP_TIMEOUT", 0.3)
+
+        gpid_file = tmp_path / "grandchild.pid"
+        prog = textwrap.dedent(f"""\
+            import signal, subprocess, sys, time
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            child = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(60)"]
+            )
+            open({str(gpid_file)!r}, "w").write(str(child.pid))
+            while True:
+                time.sleep(1)
+            """)
+        handle = ACPProcessHandle("tree", _make_config(args=["-c", prog]))
+        gpid = None
+        handle.start()
+        try:
+            # Wait for the server to spawn its grandchild and record the pid.
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                if gpid_file.exists() and gpid_file.read_text().strip():
+                    gpid = int(gpid_file.read_text().strip())
+                    break
+                time.sleep(0.05)
+            assert gpid is not None, "server never spawned its grandchild"
+            os.kill(gpid, 0)  # grandchild alive before stop
+
+            handle.stop()
+            assert handle.state == ServerState.STOPPED
+
+            # The grandchild must be gone: the force-stop reaped the whole tree
+            # rather than orphaning it. Poll until reaped (it re-parents to init
+            # and is cleaned up shortly after the SIGKILL).
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                try:
+                    os.kill(gpid, 0)
+                except ProcessLookupError:
+                    break
+                time.sleep(0.05)
+            else:
+                pytest.fail("grandchild survived force-stop (orphaned)")
+        finally:
+            handle.stop()
+            if gpid is not None:
+                try:
+                    os.kill(gpid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+    def test_force_stop_reaps_grandchildren_when_server_dies_on_sigterm(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC3 kill-side, code-review regression: a server that *dies* on the
+        child-scoped SIGTERM WITHOUT reaping its own grandchild must still have
+        that grandchild reaped by the unconditional whole-tree sweep. The
+        SIG_IGN test above only covers a server that *survives* SIGTERM, so it
+        would pass even if the reap only fired on the survive-SIGTERM branch.
+        """
+        monkeypatch.setattr(acp_process, "_GRACEFUL_STOP_TIMEOUT", 0.3)
+
+        gpid_file = tmp_path / "grandchild.pid"
+        # Default SIGTERM disposition (no SIG_IGN): the server dies on SIGTERM
+        # and never reaps its grandchild. It ignores stdin so the graceful
+        # window times out and the escalation runs.
+        prog = textwrap.dedent(f"""\
+            import subprocess, sys, time
+            child = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(60)"]
+            )
+            open({str(gpid_file)!r}, "w").write(str(child.pid))
+            while True:
+                time.sleep(1)
+            """)
+        handle = ACPProcessHandle("tree2", _make_config(args=["-c", prog]))
+        gpid = None
+        handle.start()
+        try:
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                if gpid_file.exists() and gpid_file.read_text().strip():
+                    gpid = int(gpid_file.read_text().strip())
+                    break
+                time.sleep(0.05)
+            assert gpid is not None, "server never spawned its grandchild"
+            os.kill(gpid, 0)  # grandchild alive before stop
+
+            handle.stop()
+            assert handle.state == ServerState.STOPPED
+
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                try:
+                    os.kill(gpid, 0)
+                except ProcessLookupError:
+                    break
+                time.sleep(0.05)
+            else:
+                pytest.fail(
+                    "grandchild orphaned: server died on SIGTERM without a "
+                    "whole-tree reap"
+                )
+        finally:
+            handle.stop()
+            if gpid is not None:
+                try:
+                    os.kill(gpid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
     def test_stdin_stdout_available(self) -> None:
         handle = ACPProcessHandle("test", _sleeper_config())
         handle.start()
@@ -327,3 +467,39 @@ class TestACPManager:
             h = mgr.get_handle(name)
             assert h.state == ServerState.STOPPED
             assert h.pid is None
+
+    def test_stop_all_survives_client_removed_mid_iteration(self) -> None:
+        """Regression (AC1): ``stop_all`` must snapshot ``_clients`` first.
+
+        A concurrent lock-free liveness poll (``get_status``/``readiness``
+        → ``_check_cached_client_alive`` → ``_clients.pop``) can evict a
+        server mid-loop. Reproduced deterministically here with a client
+        whose ``close()`` pops a sibling. Without the ``list()`` snapshot
+        this raised ``RuntimeError: dictionary changed size during
+        iteration`` and aborted teardown, leaking the remaining handles.
+        """
+        mgr = ACPManager(AcpClientConfig())
+
+        class _PoppingClient:
+            def __init__(self, manager: ACPManager, sibling: str) -> None:
+                self._manager = manager
+                self._sibling = sibling
+                self.closed = False
+
+            def close(self) -> None:
+                self.closed = True
+                # Stand in for the concurrent lock-free eviction.
+                self._manager._clients.pop(self._sibling, None)
+
+        client_a = _PoppingClient(mgr, "b")
+        client_b = _PoppingClient(mgr, "a")
+        mgr._clients["a"] = client_a
+        mgr._clients["b"] = client_b
+
+        mgr.stop_all()  # must not raise
+
+        # Every snapshotted client must actually be closed — not merely
+        # dropped by stop_all's unconditional ``_clients.clear()`` (which
+        # would make ``_clients == {}`` true even if a client were skipped).
+        assert client_a.closed and client_b.closed
+        assert mgr._clients == {}


### PR DESCRIPTION
## Summary

Lands the findings from `docs/design/acp-client-audit.md` — a four-dimension, June-grade audit of `agentao/acp_client/` (the ACP **client**, ~5.8k LOC, never previously in audit scope). Verdict: well-built, no security hole, no architectural emergency; the actionable items below.

### Real defects (bug fixes)
- **AC1** — `stop_all()` iterated a live `_clients` dict a concurrent liveness poll could pop mid-loop (dict-changed-size crash + subprocess leak). Snapshot with `list(...)`. Bites concurrent embedding, not the CLI.
- **AC2** — the handshake-fail-streak reset skipped `_recovery_lock` (every other write holds it). Now wrapped.
- **AC3** — server subprocesses spawned without their own process group, so a force-kill orphaned MCP/shell grandchildren. Spawn with `start_new_session` / `CREATE_NEW_PROCESS_GROUP` and route the final force-kill through `kill_process_tree`, with an **unconditional** whole-tree sweep after SIGTERM (a server that *dies* on SIGTERM without reaping its children would otherwise orphan them).

### Refactors (behavior-preserving, behind the concurrency tests)
- **AC6** — the sticky-fatal handshake dance (copy-pasted 5×) → `RecoveryMixin._handshake_guarded`; a `cleanup_before_accounting` flag preserves each site's terminal-state ordering (`FAILED` vs `STOPPED`).
- **AC7** — `prompt_once` **261 → 148 lines** via three extracted helpers; the turn-lock/handshake-lock ordering and `finally` teardown guards are preserved verbatim.
- **AC8** — `_select_option` / `_first_id_by_kind` / `_opt_id` dedup; `_selected_outcome` + `_resolve_and_respond` in `interactions.py`. (`models.py` validation + `client.py` send_prompt overlap **skipped with cause** — context-specific messages / concurrency-sensitive path.)

### Output hardening (AC5)
- `render._sanitize_terminal_text` strips C0/DEL/C1 **and** the Unicode bidi-override controls (Trojan-Source, CVE-2021-42574) on **every** display boundary — the render layer *and* the inline interaction handler (`cli/commands_ext/acp.py`).
- `helpers._cap_chunk` (256 KiB) bounds agent chunks + permission titles + ask_user questions; `render._MAX_AGENT_RENDER_CHARS` (1 MiB) bounds the cross-chunk Markdown accumulation. Non-str passthrough guard; ASCII truncation marker.
- **Deferred (documented):** the `process.py` readline-level frame cap (a bounded-frame NDJSON reader — a framing rewrite on the hottest path).

### AC4 — re-scoped, not deleted
The three "dead" surfaces are a designed-but-unwired feature, a test seam, and a vacuous spy test (**AC4′** fixed).

## Review
Two workflow review rounds. AC1/2/3/6/7 came back **clean**. The AC5/AC8 round found **9 defects — all fixed** (interaction-display sanitizer gap, `_cap_chunk` TypeError regression, bidi gap, over-claiming cap comment, uncapped sibling fields, unbounded accumulation, non-ASCII marker, unsanitized debug log, selector dup).

## Tests
Full default suite: **3590 passed, 2 skipped**. New teeth tests cover the AC1 crash, AC3 grandchild-reap (incl. die-on-SIGTERM), AC4′, the AC5 sanitizer (bidi + interactive-console ESC/OSC), the caps, and the AC8 consolidations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)