### PR TITLE
feat(acp-client): bound the stdout frame reader (AC5 readline cap)

### DIFF
--- a/agentao/acp_client/process.py
+++ b/agentao/acp_client/process.py
@@ -11,12 +11,13 @@ layered on top in Issues 03–04.
 from __future__ import annotations
 
 import collections
+import io
 import logging
 import queue
 import subprocess
 import sys
 import threading
-from typing import List, Optional
+from typing import Callable, Iterator, List, Optional
 
 from ..capabilities.process import build_child_env, kill_process_tree
 from .models import AcpProcessInfo, AcpServerConfig, ServerState
@@ -35,7 +36,90 @@ _TERMINATE_STOP_TIMEOUT = 5.0
 # Final reap window after force-killing the process tree.
 _KILL_STOP_TIMEOUT = 2.0
 
+# Hard cap on a single stdout frame (one newline-delimited JSON-RPC line). A
+# malicious/buggy server can emit a gigantic line with no newline; the naive
+# ``for line in stdout`` (``readline``) would buffer the whole thing (GB in RAM)
+# before Python ever saw it. Frames larger than this are dropped whole — far
+# above any legitimate ACP message. See docs/design/acp-client-audit.md AC5.
+_MAX_FRAME_BYTES = 16 * 1024 * 1024
+# Slice size for the bounded reader's ``read1()`` calls — keeps line-at-a-time
+# streaming latency while never pulling more than this into memory per read.
+_STDOUT_READ_CHUNK = 64 * 1024
+
 logger = logging.getLogger("agentao.acp_client")
+
+
+def _read_bounded_lines(
+    stream: io.BufferedIOBase,
+    max_bytes: int,
+    *,
+    on_oversize: Callable[[int], None],
+    read_size: int = _STDOUT_READ_CHUNK,
+) -> Iterator[bytes]:
+    """Yield newline-terminated frames (``bytes``, incl. the trailing ``\\n``).
+
+    Reads *stream* (a binary file object) in bounded ``read_size`` slices via
+    ``read1`` — so a server that streams one line and waits still sees it
+    delivered promptly, exactly like ``for line in stream`` — and reassembles
+    frames across slices. When a single frame grows past *max_bytes* without a
+    terminating newline, the rest of that frame (up to the next newline) is
+    discarded and its total size reported via *on_oversize(nbytes)*.
+
+    Dropping (not truncating) is deliberate: a truncated line is not valid
+    JSON-RPC, so the client will time out the pending request normally rather
+    than mis-parse a corrupted frame. Peak memory is bounded to
+    ``max_bytes + read_size``.
+    """
+    read = getattr(stream, "read1", None) or stream.read
+    buf = bytearray()
+    dropping = False
+    dropped = 0
+    while True:
+        chunk = read(read_size)
+        if not chunk:
+            break
+        pos = 0
+        n = len(chunk)
+        while pos < n:
+            nl = chunk.find(b"\n", pos)
+            if nl == -1:
+                seg_len = n - pos
+                if dropping:
+                    dropped += seg_len
+                elif len(buf) + seg_len > max_bytes:
+                    # Overflow with no terminator yet — start dropping this frame.
+                    dropped = len(buf) + seg_len
+                    buf.clear()
+                    dropping = True
+                else:
+                    buf += chunk[pos:]
+                break
+            # A newline terminates the current frame at index ``nl``. Count the
+            # newline itself in the dropped total so the reported size matches the
+            # cap comparison (which uses ``nl + 1 - pos``) — otherwise a frame of
+            # exactly ``max_bytes`` content + newline reports the impossible
+            # "``max_bytes`` bytes > ``max_bytes`` cap".
+            if dropping:
+                dropped += nl + 1 - pos
+                on_oversize(dropped)
+                dropping = False
+                dropped = 0
+            elif len(buf) + (nl + 1 - pos) > max_bytes:
+                # The completed frame is itself oversized — drop it whole.
+                on_oversize(len(buf) + (nl + 1 - pos))
+                buf.clear()
+            else:
+                buf += chunk[pos:nl + 1]
+                yield bytes(buf)
+                buf.clear()
+            pos = nl + 1
+    # EOF: report a still-open oversized frame, or emit a final line that had no
+    # trailing newline (matching ``for line in stream`` semantics).
+    if dropping:
+        if dropped:
+            on_oversize(dropped)
+    elif buf:
+        yield bytes(buf)
 
 
 class ACPProcessHandle:
@@ -336,9 +420,20 @@ class ACPProcessHandle:
         stdout = proc.stdout
         if stdout is None:
             return
+
+        def _on_oversize(nbytes: int) -> None:
+            logger.warning(
+                "acp server '%s': dropped an oversized stdout frame "
+                "(%d bytes > %d cap) — a valid JSON-RPC message is never this "
+                "large; a pending request on it may time out",
+                self.name, nbytes, _MAX_FRAME_BYTES,
+            )
+
         last_sub = None
         try:
-            for raw_line in stdout:
+            for raw_line in _read_bounded_lines(
+                stdout, _MAX_FRAME_BYTES, on_oversize=_on_oversize
+            ):
                 with self._subscriber_lock:
                     sub = self._stdout_subscriber
                 # Only route to subscriber if this feeder's process is still

--- a/docs/design/acp-client-audit.md
+++ b/docs/design/acp-client-audit.md
@@ -206,9 +206,9 @@ The renderer prints a **third-party** ACP server's output to the user's terminal
   Fold in next time `render.py` / `helpers.py` is touched. (Trust posture: the
   same server already runs as a spawned child with scrubbed env — this is
   defense-in-depth on the *output* channel, not a headline hole.)
-- **Status: IMPLEMENTED** (escape sanitization on both paths + per-chunk cap);
-  the readline-level cap is **deferred** (framing rewrite). See the Implementation
-  status section below.
+- **Status: IMPLEMENTED** — escape sanitization on both paths + per-chunk cap,
+  **and** the readline-level frame cap (`process._read_bounded_lines`, drop-oversized
+  policy). See the Implementation status section below.
 
 ### AC6 — The re-session + sticky-fatal handshake "dance" is copy-pasted across 5 entry points · MEDIUM (dangerous duplication — consolidate)
 The classification *primitives* were already extracted (`_reclassify_as_handshake_fail`
@@ -487,14 +487,22 @@ dead). AC5 and AC8 remain recorded (opportunistic).
   buffering in the inbox + Markdown accumulator. The cap is far above any real
   streaming delta, so it never touches legitimate content. +9 teeth tests
   (`test_acp_client_inbox.py::TestTerminalSanitization`/`TestChunkCap`), incl.
-  Rich-path OSC-set-title/BEL removal. **Deferred (documented):** the
-  readline-level hard cap in `process.py` — the multi-GB buffering happens inside
-  the C-level `for raw_line in stdout` before any Python check can see the line, so
-  a real cap there needs a bounded-frame NDJSON reader with a *drop-oversized-frame*
-  policy (a mid-line truncation would corrupt a legitimately-large valid JSON-RPC
-  frame). That is a framing rewrite on the hottest client path; given the child is
-  already env-scrubbed and the display buffer is now bounded by `_cap_chunk`, it is
-  left as a recorded follow-up rather than shipped under the "opportunistic" label.
+  Rich-path OSC-set-title/BEL removal. **Readline-level frame cap — now also
+  implemented** (was the one deferred sub-part): `process._read_bounded_lines`
+  replaces `for raw_line in stdout` in `_feed_stdout`. It reads the pipe in bounded
+  64 KiB `read1()` slices (preserving line-at-a-time streaming) and reassembles
+  frames; when a single frame passes `_MAX_FRAME_BYTES = 16 MiB` without a newline
+  it **drops the whole frame** (up to the next newline) and logs the dropped size,
+  rather than mid-line-truncating (a truncated line is not valid JSON-RPC — the
+  pending request times out normally instead of mis-parsing). Peak per-frame memory
+  is bounded to `16 MiB + read_size`, closing the "one multi-GB line → GB in RAM"
+  vector. Dropped-byte counts include the terminating newline (matching the cap
+  comparison), so a warning can never read the impossible "N bytes > N cap" — a
+  Codex review round caught that off-by-one. +8 tests
+  (`test_acp_client_process.py::TestBoundedStdoutReader`) covering cross-slice
+  reassembly, oversized-then-recover, oversized-complete-frame (directly, via a
+  large read slice), the newline-inclusive count boundary, EOF-while-dropping,
+  exact-cap, and a `_feed_stdout` integration drop.
 
 - **AC8 — partially implemented (the no-drift wins), two items skipped with cause.**
   Done: (a) `helpers.py` — extracted a module-level `_opt_id` and a parameterized
@@ -563,8 +571,8 @@ dead). AC5 and AC8 remain recorded (opportunistic).
 **Net:** three real defects addressed (AC1 crash, AC2 lock, AC3 orphaned
 grandchildren) with teeth-proven / behavior-preserving coverage; two Tier-3
 refactors landed behind their concurrency tests (AC6 handshake-dance consolidation,
-AC7 `prompt_once` decomposition); AC5 output-hardening shipped (escape sanitization
-+ chunk cap; the readline-level cap deferred as a framing rewrite); AC8's no-drift
+AC7 `prompt_once` decomposition); AC5 output-hardening shipped in full (escape
+sanitization + chunk cap + the readline-level bounded-frame cap); AC8's no-drift
 consolidations landed (`_select_option`, `_selected_outcome`, `_resolve_and_respond`)
 with the two message-/concurrency-sensitive items left recorded. The AC4 "dead code"
 bucket stays downgraded to one implemented test-correctness item (AC4′) plus one

--- a/docs/design/acp-client-audit.zh.md
+++ b/docs/design/acp-client-audit.zh.md
@@ -158,8 +158,8 @@
 - **修复(顺手):** 在**两条**路径展示前剥离/替换 C0/C1 控制字节(保留 `\n`/`\t`),并对读取的
   每行/每片长度设上限。下次动 `render.py`/`helpers.py` 时并入。(信任姿态:同一 server 已作为
   env 被剥离的子进程运行——这是对*输出*通道的纵深防御,不是头号漏洞。)
-- **状态:已实现**(两条路径都做转义清理 + 每片尺寸上限);readline 级上限**延期**(需重写
-  帧解析)。详见下方"实现状态"。
+- **状态:已实现** —— 两条路径转义清理 + 每片尺寸上限,**以及** readline 级帧上限
+  (`process._read_bounded_lines`,丢弃超大帧策略)。详见下方"实现状态"。
 
 ### AC6 —— re-session + sticky-fatal 的 handshake"舞蹈"复制在 5 处入口 · MEDIUM(危险重复——合并)
 分类*原语*已被提取(`_reclassify_as_handshake_fail` / `_note_handshake_failure_and_maybe_fatal`
@@ -356,7 +356,7 @@ AC8 仍记录待办(顺手项)。
   `finally`;handshake 锁/turn 锁次序、fail-fast 的 `_rollback_ephemeral_on_busy` 门、"别停活赢家
   在用的 proc"守卫均原样保留(逐字搬进 helper)。绿:252 个 acp_client + headless 测试。
 
-- **AC5 —— 已实现(输出加固),一个子项延期。** 新增 `render._sanitize_terminal_text`(剥离 C0
+- **AC5 —— 已实现(输出加固)。** 新增 `render._sanitize_terminal_text`(剥离 C0
   含 ESC、DEL、C1 控制字符;保留 `\n`/`\t`),接入**两条**展示路径:plain 的 `render_plain` 回退
   (那条原样 `sys.stdout.write` 的载体)与 Rich 路径(agent-Markdown 累积 + 前缀行分支)。只剥 ESC
   字节即可让每个 CSI/OSC 序列失效——这是标准、稳健的做法——残留的 `[2J` 之类是惰性文本;我们
@@ -364,11 +364,13 @@ AC8 仍记录待办(顺手项)。
   = 256 KiB`)于 `agent_message_chunk` / `agent_thought_chunk`(唯二不截断返回的 kind),使被攻陷
   server 无法在 inbox + Markdown 累积器里强制多 GB 缓冲;上限远高于任何真实流式增量,故绝不触碰
   合法内容。+9 个有牙测试(`TestTerminalSanitization`/`TestChunkCap`,含 Rich 路径 OSC-设标题/BEL
-  剥离)。**延期(已记录):** `process.py` 的 readline 级硬上限——多 GB 缓冲发生在 C 层
-  `for raw_line in stdout` 内、任何 Python 检查看到该行之前,故真正的上限需要一个带*丢弃超大帧*
-  策略的定长帧 NDJSON 读取器(行内截断会破坏一个合法的超大 JSON-RPC 帧)。那是客户端最热路径上的
-  帧解析重写;鉴于子进程已 env 被剥离、展示缓冲现已被 `_cap_chunk` 限住,留作记录性后续,而不在
-  "顺手"名义下仓促发布。
+  剥离)。**readline 级帧上限——亦已实现**(原本延期的子项):`process._read_bounded_lines`
+  取代 `_feed_stdout` 里的 `for raw_line in stdout`。它以定长 64 KiB `read1()` 切片读管道(保住
+  逐行流式延迟)并跨切片重组帧;当单帧越过 `_MAX_FRAME_BYTES = 16 MiB` 仍无换行时**整帧丢弃**
+  (丢到下一个换行)并记录丢弃字节数,而非行内截断(截断后的行不是合法 JSON-RPC——挂起请求会正常
+  超时而非误解析)。单帧峰值内存被限到 `16 MiB + read_size`,堵住"一条多 GB 行 → 数 GB 驻留"的
+  载体。+7 个测试(`TestBoundedStdoutReader`)覆盖跨切片重组、超大后恢复、超大完整帧、丢弃中 EOF、
+  恰好到上限、以及 `_feed_stdout` 集成丢弃。
 
 - **AC8 —— 部分实现(无漂移的净收益),两项有据跳过。** 已做:(a)`helpers.py`——提取模块级
   `_opt_id` 与参数化的 `_select_option(options, *, canonical_kind, kind_prefix, hints)`;三份复制
@@ -415,6 +417,6 @@ AC8 仍记录待办(顺手项)。
 
 **净结果:** 三个真缺陷已处理(AC1 崩溃、AC2 锁、AC3 孤立孙进程),配有"证明有牙"/行为保持的
 覆盖;两个 Tier-3 重构在并发测试护航下落地(AC6 handshake 舞蹈合并、AC7 `prompt_once` 拆分);
-AC5 输出加固已发布(转义清理 + 分片上限;readline 级上限作为帧解析重写延期);AC8 的无漂移合并
+AC5 输出加固已全部发布(转义清理 + 分片上限 + readline 级定长帧上限);AC8 的无漂移合并
 已落地(`_select_option`、`_selected_outcome`、`_resolve_and_respond`),两个消息-/并发-敏感项留作
 记录。AC4 的"死代码"桶仍降级为一个已实现的测试正确性项(AC4′)+ 一个维护者产品决定。

--- a/tests/test_acp_client_process.py
+++ b/tests/test_acp_client_process.py
@@ -1,7 +1,9 @@
 """Tests for ACP client process handle and manager (Issue 02)."""
 
+import io
 import json
 import os
+import queue
 import signal
 import sys
 import textwrap
@@ -503,3 +505,98 @@ class TestACPManager:
         # would make ``_clients == {}`` true even if a client were skipped).
         assert client_a.closed and client_b.closed
         assert mgr._clients == {}
+
+
+# ---------------------------------------------------------------------------
+# AC5 — bounded stdout frame reader (drop-oversized-frame DoS backstop)
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedStdoutReader:
+    """A server must not force unbounded stdout buffering with a giant line."""
+
+    def _collect(self, data: bytes, max_bytes: int, read_size: int = 8):
+        over: list = []
+        lines = list(
+            acp_process._read_bounded_lines(
+                io.BytesIO(data),
+                max_bytes,
+                on_oversize=over.append,
+                read_size=read_size,
+            )
+        )
+        return lines, over
+
+    def test_multiline_reassembles_across_slices(self) -> None:
+        # read_size=8 forces frames to span multiple read1() slices.
+        lines, over = self._collect(b"a\nbb\nccc\n", 100)
+        assert lines == [b"a\n", b"bb\n", b"ccc\n"]
+        assert over == []
+
+    def test_trailing_unterminated_line_delivered(self) -> None:
+        # Matches ``for line in stream``: a final newline-less line is yielded.
+        lines, over = self._collect(b"x\ntail", 100)
+        assert lines == [b"x\n", b"tail"]
+        assert over == []
+
+    def test_oversized_newlineless_frame_dropped_then_recovers(self) -> None:
+        lines, over = self._collect(b"X" * 50 + b"more\n" + b"ok\n", 10)
+        assert lines == [b"ok\n"]  # the giant frame is dropped whole
+        # 50 X + "more" + the terminating newline = 55 bytes; the count includes
+        # the newline so it can never read "N bytes > N cap".
+        assert over == [55]
+        # Every delivered frame is within the cap.
+        assert all(len(l) <= 10 for l in lines)
+
+    def test_oversized_complete_frame_dropped(self) -> None:
+        # Frame has a terminator but is itself over the cap -> dropped whole.
+        # read_size large enough that the whole frame+newline arrives in one
+        # slice while buf is empty, directly exercising the completed-oversized
+        # branch (not the no-newline-overflow -> dropping path).
+        lines, over = self._collect(b"Y" * 20 + b"\n" + b"z\n", 10, read_size=1024)
+        assert lines == [b"z\n"]
+        assert over == [21]  # 20 Y + newline
+
+    def test_oversized_reported_count_includes_newline(self) -> None:
+        # Boundary: content exactly at the cap plus the terminator is dropped
+        # (content+newline = 5 > 4) and reported as 5, never the impossible
+        # "4 bytes > 4 cap".
+        lines, over = self._collect(b"abcd\n", 4, read_size=1024)
+        assert lines == []
+        assert over == [5]
+
+    def test_eof_while_dropping_reports_once(self) -> None:
+        # Unterminated giant frame that never ends before EOF.
+        lines, over = self._collect(b"Z" * 40, 10)
+        assert lines == []
+        assert over == [40]
+
+    def test_frame_exactly_at_cap_kept(self) -> None:
+        lines, over = self._collect(b"abc\n", 4)  # 3 content + newline = 4, at cap
+        assert lines == [b"abc\n"]
+        assert over == []
+
+    def test_feed_stdout_drops_oversized_frame(self, monkeypatch) -> None:
+        # Integration: the feeder routes valid frames to the subscriber and
+        # skips an oversized one, then delivers the EOF sentinel.
+        monkeypatch.setattr(acp_process, "_MAX_FRAME_BYTES", 10)
+
+        class _FakeProc:
+            def __init__(self, data: bytes) -> None:
+                self.stdout = io.BytesIO(data)
+
+        handle = ACPProcessHandle("t", _make_config(auto_start=False))
+        fake = _FakeProc(b"a\n" + b"X" * 50 + b"\n" + b"b\n")
+        handle._proc = fake  # feeder routes only while proc is self._proc
+        q: "queue.Queue" = queue.Queue()
+        handle.subscribe_stdout(q)
+
+        handle._feed_stdout(fake)
+
+        got = []
+        while True:
+            item = q.get_nowait()
+            if item is None:  # EOF sentinel
+                break
+            got.append(item)
+        assert got == [b"a\n", b"b\n"]  # the 51-byte middle frame was dropped


### PR DESCRIPTION
## Summary

Lands the one **deferred** sub-part of the `acp_client` audit's **AC5** (see `docs/design/acp-client-audit.md`): a hard cap on a single stdout frame so a malicious/buggy ACP server can't force unbounded in-memory buffering by emitting one gigantic newline-less line. The naive `for raw_line in stdout` (`readline`) would buffer such a line whole — GB in RAM — before Python ever saw it.

## What changed

`process._read_bounded_lines` replaces `for raw_line in stdout` in `_feed_stdout`:
- Reads the pipe in bounded **64 KiB `read1()` slices**, preserving line-at-a-time streaming (`read1` returns as soon as data is available — it does *not* wait for a full slice or EOF; Codex measured ~10 ms delivery on a real `BufferedReader`), and reassembles newline-delimited frames across slices.
- **Drops any single frame exceeding `_MAX_FRAME_BYTES` (16 MiB) whole**, up to the next newline, and logs the dropped size. Dropping (not mid-line truncation) is deliberate: a truncated line is not valid JSON-RPC, so the pending request times out normally rather than mis-parsing a corrupted frame.
- Peak per-frame memory is bounded to **16 MiB + read_size**.

Byte/newline delivery (lines are `bytes` incl. the trailing `\n`), the `read1`/`read` fallback, subscriber routing, the restart guard, and the EOF-sentinel logic in `_feed_stdout` are all **preserved**.

## Review

Codex (fresh thread) caught one **off-by-one**: the dropped-byte report used `nl - pos` while the cap comparison used `nl + 1 - pos`, so a frame of exactly cap-content + newline logged the impossible `N bytes > N cap`. Fixed both reporting sites to count the newline; **re-review clean** — Codex fuzzed **12,775 frame/cap/chunk-size cases** against reference behavior with no mismatches.

## Tests

+8 `TestBoundedStdoutReader` tests: cross-slice reassembly, oversized-then-recover, oversized-complete-frame (directly, via a large read slice), newline-inclusive count boundary (`b"abcd\n"` cap 4 → 5), EOF-while-dropping, exact-cap, and a `_feed_stdout` integration drop. Real ACP handshakes still read fine via `read1` (159 integration tests green). **Full suite: 3598 passed, 2 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)