### PR TITLE
docs: extract the adding-components recipe into a tracked guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,10 @@ The authoritative list with full subcommand syntax lives in `agentao/cli/help_te
 - `/clear` — saves current session, clears conversation + **all memories**, starts a new one.
 - `/model`, `/provider`, `/temperature`, `/thinking` — LLM config. `/thinking [minimal|low|medium|high|off]` sets thinking depth (`reasoning_effort`) on the live client's `extra_body` passthrough (`cli/commands/provider.py::handle_thinking_command`); `off` clears it. No auto-recovery — a model that rejects `reasoning_effort` fails until `off` (see `docs/design/host-llm-extra-params.md`).
 
+## Adding new components
+
+Adding a built-in tool or a skill to this repo: see [docs/guides/adding-components.md](docs/guides/adding-components.md). The non-obvious part is that tools register in `agentao/tooling/registry.py::register_builtin_tools()`, not in `agent.py`.
+
 ## Common gotchas
 
 - **`cli.py` was split into the `cli/` package** in 0.4.x. Older docs and design notes may still say `cli.py` — grep `agentao/cli/` for the actual handler.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ Pick the path that matches your goal:
 - Logging and debugging: [guides/logging.md](guides/logging.md)
 - Model and provider switching: [guides/model-switching.md](guides/model-switching.md)
 - Skills and runtime extension: [guides/skills.md](guides/skills.md)
+- Adding a built-in tool or skill to this repo: [guides/adding-components.md](guides/adding-components.md)
 
 ## Start
 
@@ -58,6 +59,7 @@ Task-oriented how-to guides and per-feature documentation.
 | [guides/logging.md](guides/logging.md) | You are debugging sessions, tool calls, or model behavior |
 | [guides/model-switching.md](guides/model-switching.md) | You want to switch providers or models cleanly |
 | [guides/skills.md](guides/skills.md) | You are creating, installing, or managing skills |
+| [guides/adding-components.md](guides/adding-components.md) | You are adding a built-in tool or skill to the Agentao codebase |
 | [guides/memory-quickstart.md](guides/memory-quickstart.md) | Memory usage from a user perspective |
 | [guides/memory-management.md](guides/memory-management.md) | Memory behavior and implementation details |
 | [guides/session-replay.md](guides/session-replay.md) | Structured JSONL replay of runtime events |

--- a/docs/guides/adding-components.md
+++ b/docs/guides/adding-components.md
@@ -1,0 +1,28 @@
+# Adding New Components
+
+How to add a new **tool** or a new **skill** to the Agentao codebase.
+
+This is about extending Agentao itself. If you are an embedding host injecting tools at
+construction time instead, see [../design/host-tool-injection.md](../design/host-tool-injection.md).
+
+## A tool
+
+1. Create `agentao/tools/<module>.py` and implement `Tool` (or `AsyncToolBase` for async).
+   Both live in `agentao/tools/base.py`; `RegistrableTool = Tool | AsyncToolBase`.
+2. Set `requires_confirmation=True` for anything dangerous: arbitrary shell, network
+   requests, file writes, deletions. This is what routes the tool through
+   `PermissionEngine` — see [tool-confirmation.md](tool-confirmation.md).
+3. Register in `agentao/tooling/registry.py::register_builtin_tools()`.
+
+Note that `agent.py::_register_tools()` is a thin delegation — the real wiring lives in
+`register_builtin_tools()`, so registering in `agent.py` is the wrong place.
+
+## A skill
+
+1. Create `skills/<my-skill>/SKILL.md` with YAML frontmatter (`name:`, `description:` —
+   the trigger text the model sees).
+2. Optionally add `references/*.md` files. These load only on activation, which keeps the
+   always-resident cost to just the name and description.
+3. Restart the agent or run `/skills reload`.
+
+For discovery, activation, and the full frontmatter schema, see [skills.md](skills.md).


### PR DESCRIPTION
## Why

The `## Adding new components` section was cut from `CLAUDE.md` during a context trim and replaced with a skill under `.claude/skills/`. That directory is gitignored (`.gitignore:47`), so the guidance was effectively **deleted for anyone else cloning the repo** — they'd get the trimmed `CLAUDE.md` and no skill.

## What

- **New** `docs/guides/adding-components.md` — the tool and skill recipes as a standalone guide, cross-linked to `tool-confirmation.md`, `skills.md`, and `design/host-tool-injection.md` (for the host-side injection case, which is a different thing).
- `docs/README.md` — indexed in both the quick-links list and the "when to read what" table.
- `CLAUDE.md` — a two-line pointer that keeps the one non-obvious fact resident: tools register in `tooling/registry.py::register_builtin_tools()`, not in `agent.py`.
- Removed the local `.claude/skills/agentao-add-component/` (untracked) so the content lives in exactly one place.

## Verification

Guide claims checked against the code rather than paraphrased:

- `Tool` / `AsyncToolBase` / `RegistrableTool` — `agentao/tools/base.py:140,164,195`
- `register_builtin_tools` — `agentao/tooling/registry.py:83`
- `_register_tools` delegation — `agentao/agent.py:939`
- `/skills reload` — `agentao/cli/commands/skills.py:80`
- All four internal doc links resolve.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)