### PR TITLE
chore(release): prep 0.4.16 — boundary hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,49 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased]
+## [0.4.16] — 2026-07-25
 
-_Targeting 0.4.16. Add entries under the relevant heading as work lands._
+A **boundary-hardening release**. 0.4.15 was about the harness not lying about
+its own internals; 0.4.16 extends that to the seams where agentao talks to
+something it does not control — an ACP server subprocess, an MCP server over
+HTTP, a keyless search backend, a clipboard helper — and to the audit trail
+meant to record what happened at those seams.
+
+No breaking changes. It upgrades in place.
 
 ### Added
+
+- **A host embedding the interactive CLI can now inject its own runtime.**
+  `Agentao` has accepted `extra_tools` / `disable_tools` / `enabled_tools` for
+  several releases and `build_from_environment(**overrides)` forwards them, but
+  `AgentaoCLI` called the factory with a fixed kwarg set and `main()`
+  constructed the CLI and ran it immediately — so that contract was unreachable
+  from the CLI surface. The only workaround was patching module globals, which
+  fails silently: `cli/app.py` imported a name it never used, and four test
+  modules had been patching that dead name while intercepting nothing.
+
+  Both entry points now take a keyword-only `agent_factory`, called as
+  `factory(transport=self, max_context_tokens=…, plan_session=…)` — the shape
+  `acp/session_new.py` already used. Default `None` takes the existing path, so
+  console startup is unchanged.
+
+  ```python
+  main(agent_factory=partial(
+      build_from_environment,
+      extra_tools=[NewsSearchTool(), PublishTool()],
+      disable_tools={"web_search"},
+  ))
+  ```
+
+  The returned runtime is checked against the post-conditions the CLI relies on
+  — required attributes reported together in one `TypeError`, a non-`None`
+  `permission_engine`, a `_plan_session` identical to the CLI's, and the CLI
+  reachable from both `agent.transport` and `tool_runner._transport` — so a
+  mis-wired factory names the violated contract instead of failing later as an
+  `AttributeError` on `None`. A `functools.partial` that pre-binds `transport=`
+  is rejected before the call, since Python resolves `partial(f, k=v)(k=w)` to
+  `w` and would silently discard the host's value while every post-condition
+  still passed. (#133)
 
 ### Changed
 
@@ -52,7 +90,91 @@ _Targeting 0.4.16. Add entries under the relevant heading as work lands._
   spec-conformant client already handles all five, but a client that hardcoded
   the previous four will see a value it did not expect.
 
+- **MCP URL-transport requests now identify themselves.** SSE and Streamable
+  HTTP traffic — the content-type preflight, the handshake, and every tool call
+  — went out with httpx's bare `python-httpx/x.y.z`, leaving agentao anonymous
+  in server logs and indistinguishable from any other Python client. They now
+  send `User-Agent: agentao-mcp/<version>`. A `User-Agent` set in the server's
+  `headers` block still wins, matched case-insensitively, and the config dict is
+  copied rather than mutated, so a reconnect does not accumulate state. stdio
+  servers are unaffected. This does change what remote servers see on the wire:
+  a server or WAF that filters on User-Agent may need its allow-list updated,
+  which the `headers` override covers. (#136)
+
+- `run_loop`'s 31-branch slash-command if/elif chain is now a dispatch table
+  (353 → 127 LOC, cyclomatic complexity 74 → 26); no behavior change, and
+  `/sandbox` gained the tab-completion entry it had always been missing. (#142)
+
 ### Fixed
+
+- **`web_search` no longer reports a bot-challenge page as "no results".**
+  `html.duckduckgo.com` answers HTTP 202 with a captcha page instead of a result
+  set. `raise_for_status()` waves 202 through (it is 2xx), the result-div scan
+  yields zero, and the formatter turned that into a confident
+  `No search results found for: <query>` — indistinguishable from a genuine
+  empty answer. On a keyless host that was the entire search surface failing
+  quietly, since `duckduckgo` is the only backend in the chain when no key
+  resolves. The backend now raises when the response is 202 **or** the `#links`
+  results container is absent; a real zero-hit SERP still renders `#links` and
+  stays terminal. Relatedly, six sites claiming the `jina` backend works without
+  a key were corrected — `s.jina.ai` began requiring one after 0.4.14. (#135)
+
+- **`/copy` can no longer hang the input loop.** It called `subprocess.run`
+  three times with no `timeout=`, so a `pbcopy` wedged on an unresponsive
+  pasteboard server blocked the loop with no way out but `Ctrl+C`. Every attempt
+  is now bounded at 5s and routed through `run_captured`, so a grandchild
+  holding the captured pipe cannot outlive the bound. A timeout or non-zero exit
+  now also falls through to the next utility instead of aborting the chain —
+  a failing `pbcopy` previously reported "Copy failed" without ever trying
+  `xclip` or `xsel`. (#139)
+
+- **Replay's v1.2 audit events are rendered, not just recorded.**
+  `tool_lifecycle`, `subagent_lifecycle`, and `permission_decision` exist so an
+  embedded host has one audit artifact instead of two parallel streams. The
+  JSONL side was correct; both CLI views were not — `--raw` degraded them to a
+  sorted payload-key preview, and the default grouped view dropped them
+  entirely, because `_print_turn`'s event loop is an allowlist that silently
+  skips an unnamed kind. A turn containing a **denied** permission decision and
+  a **failed** tool rendered as a bare `└─ ok`. (#141)
+
+- **`stop_all()` no longer crashes mid-shutdown and leaks servers.** It iterated
+  the live `_clients` dict that a concurrent liveness poll could pop from,
+  raising `dictionary changed size during iteration` and leaving the remaining
+  subprocesses running. Now snapshots with `list(...)`. Bites concurrent
+  embedding, not the CLI. (#137)
+
+- **Killing an ACP server no longer orphans its grandchildren.** Server
+  subprocesses were spawned without their own process group, so a force-kill
+  reaped the server and left the MCP or shell children it had spawned running.
+  They now start with `start_new_session` / `CREATE_NEW_PROCESS_GROUP`, the
+  final force-kill routes through `kill_process_tree`, and a whole-tree sweep
+  runs **unconditionally** after SIGTERM — a server that dies on SIGTERM without
+  reaping its own children would otherwise still orphan them. (#137)
+
+- The ACP handshake-fail-streak reset now holds `_recovery_lock`, like every
+  other write to that state. (#137)
+
+### Security
+
+- **A hostile or buggy ACP server can no longer write escape sequences to your
+  terminal.** `render._sanitize_terminal_text` strips C0/DEL/C1 controls and the
+  Unicode bidi-override characters behind Trojan-Source (CVE-2021-42574) at
+  **every** display boundary — the render layer *and* the inline interaction
+  handler in `cli/commands_ext/acp.py`. The second one is the point: a sanitizer
+  that covers all but one display path is not a sanitizer. (#137)
+
+- **Server output is bounded at three levels.** `helpers._cap_chunk` caps agent
+  chunks, permission titles, and `ask_user` questions at 262,144 chars;
+  `render._MAX_AGENT_RENDER_CHARS` bounds cross-chunk Markdown accumulation at
+  1,048,576 chars; and `process._read_bounded_lines` caps a single stdout frame
+  at 16 MiB.
+  The last closes the deepest hole: `for raw_line in stdout` would buffer one
+  gigantic newline-less line whole — gigabytes in RAM — before Python ever saw
+  it. The reader now consumes the pipe in 64 KiB `read1()` slices, reassembles
+  newline-delimited frames across them, and **drops** an oversized frame whole
+  rather than truncating it, because a truncated line is not valid JSON-RPC and
+  would mis-parse instead of letting the pending request time out cleanly. Peak
+  per-frame memory is 16 MiB + one read slice. (#137, #138)
 
 ---
 

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.16.dev0"
+__version__ = "0.4.16"
 
 
 def _ensure_utf8() -> None:

--- a/docs/releases/v0.4.16.md
+++ b/docs/releases/v0.4.16.md
@@ -1,0 +1,352 @@
+# Agentao 0.4.16
+
+A **boundary-hardening release** on top of 0.4.15. **No breaking changes** — it
+upgrades in place via `pip install -U agentao`.
+
+0.4.15 was about the harness not lying about its own internals: an interrupted
+turn, an atomic write, a turn that produced no answer. 0.4.16 points the same
+discipline outward, at the seams where agentao talks to something it does not
+control.
+
+The headline:
+
+- **The ACP client got its first audit.** ~5.8k LOC that had never been in audit
+  scope. A hostile or buggy ACP server can no longer paint your terminal with
+  escape sequences, exhaust your memory with one enormous line, or leave
+  grandchild processes running after you kill it.
+- **`web_search` stopped failing silently.** DuckDuckGo's captcha page was being
+  reported as "no search results found" — on a keyless host, that was the entire
+  search surface failing quietly.
+- **`/copy` can no longer hang the input loop** on a wedged clipboard helper.
+- **Replay renders the audit events it was already recording.** A denied
+  permission and a failed tool used to render as a bare `└─ ok`.
+- **A host embedding the interactive CLI can inject its own runtime** —
+  `agent_factory` on `AgentaoCLI` and `cli.main()`.
+- **MCP requests identify themselves** as `agentao-mcp/<version>` instead of
+  going out as anonymous httpx traffic.
+
+## Why this release
+
+Every fix here lives at a boundary with a process or service agentao launched
+but does not own: an ACP server subprocess, an MCP server over HTTP, a search
+backend, a clipboard binary — plus the audit trail that is supposed to record
+what happened at those boundaries.
+
+The common failure is the same one 0.4.15 chased, one layer out. Something on
+the other side of the seam behaved badly, and agentao either trusted it more
+than it had earned or swallowed the failure and reported success. A captcha page
+became an empty result set. A server that ignored SIGTERM kept its children. A
+frame with no newline in it became unbounded memory. An event that was recorded
+faithfully to disk was dropped on the way to the screen.
+
+None of these needs an attacker to show up. They are what happens when a remote
+service changes its bot policy on an ordinary Wednesday, or a pasteboard server
+wedges, or a subprocess exits in the wrong order.
+
+## The ACP client, hardened
+
+`agentao/acp_client/` — the client that launches and drives external ACP
+servers — had never been audited. The four-dimension audit
+(`docs/design/acp-client-audit.md`) returned no security hole and no
+architectural emergency; what follows is what it did find.
+
+**Terminal output is sanitized at every display boundary.**
+`render._sanitize_terminal_text` strips C0/DEL/C1 controls and the Unicode
+bidi-override characters behind Trojan-Source (CVE-2021-42574). The
+"every" is load-bearing: the first implementation covered the render layer and
+missed the inline interaction handler in `cli/commands_ext/acp.py`, which is
+also a display path. A sanitizer with one uncovered boundary is not a sanitizer.
+
+**Server output is bounded at three levels.**
+
+| Bound | Where | Cap |
+|---|---|---|
+| Single stdout frame | `process._MAX_FRAME_BYTES` | 16 MiB (bytes) |
+| Agent chunk, permission title, `ask_user` question | `helpers._MAX_CHUNK_DISPLAY_CHARS` | 262,144 chars |
+| Cross-chunk Markdown accumulation | `render._MAX_AGENT_RENDER_CHARS` | 1,048,576 chars |
+
+The frame cap closes the deepest hole. The naive `for raw_line in stdout` calls
+`readline`, which buffers a newline-less line **whole** — gigabytes in RAM —
+before Python ever sees it, so no downstream cap could help. The reader now
+consumes the pipe in 64 KiB `read1()` slices (which return as soon as data is
+available, preserving line-at-a-time streaming) and reassembles newline-delimited
+frames across them.
+
+An oversized frame is **dropped whole**, not truncated. That is deliberate: a
+truncated line is not valid JSON-RPC, so truncation would mis-parse a corrupted
+frame where dropping lets the pending request time out normally. Peak per-frame
+memory is 16 MiB plus one read slice.
+
+**Killing a server no longer orphans its grandchildren.** Server subprocesses
+were spawned without their own process group, so a force-kill reaped the server
+and left the MCP or shell children it had spawned running. They now start with
+`start_new_session` / `CREATE_NEW_PROCESS_GROUP`, the final force-kill goes
+through `kill_process_tree`, and a whole-tree sweep runs **unconditionally**
+after SIGTERM — a server that dies on SIGTERM without reaping its own children
+would otherwise still leave them behind.
+
+**Two concurrency defects.** `stop_all()` iterated the live `_clients` dict that
+a concurrent liveness poll could pop from, raising `dictionary changed size
+during iteration` and leaving the remaining subprocesses running; it now
+snapshots with `list(...)`. The handshake-fail-streak reset was the one write to
+that state not holding `_recovery_lock`; it is now wrapped. Both bite concurrent
+embedding rather than the CLI.
+
+**Refactors, behavior-preserving.** The sticky-fatal handshake dance was
+copy-pasted at five call sites and is now `RecoveryMixin._handshake_guarded`,
+with a `cleanup_before_accounting` flag preserving each site's terminal-state
+ordering. `prompt_once` went 261 → 148 lines via three extracted helpers, with
+the turn-lock/handshake-lock ordering and `finally` teardown guards preserved
+verbatim. Selector and interaction-resolution duplication was consolidated;
+`models.py` validation and the `client.py` `send_prompt` overlap were **skipped
+with cause** (context-specific messages, concurrency-sensitive path).
+
+## Search that fails loudly
+
+`html.duckduckgo.com/html/` now answers **HTTP 202** with a captcha page
+(*"Select all squares containing a duck"*) instead of a result set:
+
+```
+$ GET html.duckduckgo.com/html/?q=anthropic+claude
+202, 14235 bytes, div.result count -> 0
+```
+
+`raise_for_status()` waves 202 through — it is 2xx — the result-div scan yields
+zero, and the formatter turned that into a confident answer:
+
+```
+before:  No search results found for: anthropic claude
+after:   Error performing duckduckgo search: duckduckgo: bot-challenge page,
+         not a result set (HTTP 202, no '#links' results container)
+```
+
+That is worse than it looks. `duckduckgo` is last in every auto chain and the
+*only* entry when no key resolves, so on a keyless host this was the whole
+search surface failing in a way nothing downstream could detect.
+
+The backend now raises when the response is 202 **or** the `#links` results
+container is absent. A genuine zero-hit SERP still renders `#links` (with a
+`.no-results` child), so it stays terminal and is unaffected.
+
+Separately: **`jina` is no longer keyless.** `s.jina.ai` returns
+`401 AuthenticationRequiredError` without a key. It *was* keyless when the
+backend landed in 0.4.14 — the claim was true when written and went stale
+upstream. Six sites promising "works keyless, a key only lifts rate limits" are
+corrected. The **reader** endpoint `r.jina.ai` (used by `web_fetch` when
+`AGENTAO_WEB_FETCH_FALLBACK=jina`) *is* still keyless; the docs previously
+described the two as one key with one behavior. A keyless `backend="jina"` pin
+stays constructible on purpose, so hosts that pinned it before the upstream
+change get a legible search error rather than a startup crash.
+
+## Embedding the interactive CLI
+
+`Agentao` has accepted `extra_tools` / `disable_tools` / `enabled_tools` for
+several releases, and `build_from_environment(**overrides)` forwards them — but
+`AgentaoCLI` called the factory with a fixed kwarg set and `main()` constructed
+the CLI and ran it immediately. The tool-injection contract was unreachable from
+the CLI surface.
+
+The only workaround was patching module globals, which fails silently. That
+failure mode was already live in-tree: `cli/app.py` imported `Agentao` without
+using it, and four CLI test modules patched that dead name. The patches
+intercepted nothing and the tests passed anyway.
+
+Both entry points now take a keyword-only `agent_factory`:
+
+```python
+from functools import partial
+from agentao.cli import main
+from agentao.embedding import build_from_environment
+
+main(agent_factory=partial(
+    build_from_environment,
+    extra_tools=[NewsSearchTool(), PublishTool()],
+    disable_tools={"web_search"},
+))
+```
+
+It is called as `factory(transport=self, max_context_tokens=…,
+plan_session=…)`, mirroring the ACP precedent in `acp/session_new.py`. Default
+`None` takes the exact existing path, so console startup is unchanged.
+
+The CLI binds several attributes off the returned agent, so the post-conditions
+are checked up front rather than failing far from the cause: required attributes
+reported together in one `TypeError`; `permission_engine` non-`None` (otherwise
+a bare `AttributeError: 'NoneType' has no attribute 'set_mode'`); `_plan_session`
+identical to the CLI's (dropping it leaves `/plan` switching the CLI but not the
+runtime, hiding `plan_save`/`plan_finalize` from the model with no way to finish
+the plan); and the CLI **reachable** from both `agent.transport` and
+`tool_runner._transport` — reachability rather than identity, because wrapping is
+agentao's own convention (`ReplayManager.start()` splices a `ReplayAdapter`
+exposing `inner`).
+
+One hazard is rejected before the call rather than diagnosed after: Python
+resolves `partial(f, k=v)(k=w)` to `w`, so a `functools.partial` pre-binding
+`transport=` would have its value silently discarded while the runtime ended up
+correctly bound and every post-condition passed — undetectable afterward.
+
+A second ordering bug fell out of the same seam: the permission mode was read
+before the factory ran, from a cwd-derived root later rebound to
+`agent.working_directory`. Without a re-read, a project's saved posture is
+ignored at startup and overwritten by the next `/mode`. The old code was correct
+only because the CLI passed no `working_directory`.
+
+## MCP requests identify themselves
+
+MCP SSE and Streamable HTTP traffic — the content-type preflight, the handshake,
+and every tool call — went out with httpx's bare `python-httpx/x.y.z`, leaving
+agentao anonymous in server logs and indistinguishable from any other Python
+client. `web_fetch` already sent a User-Agent; MCP did not.
+
+A default `User-Agent: agentao-mcp/<version>` is injected in the shared
+`_prepare_url_connect` preamble, so all three identify consistently.
+
+- A `User-Agent` you set in the server's `headers` block **wins**, matched
+  case-insensitively (HTTP header names are case-insensitive).
+- The config dict is **copied, never mutated** — `self.config['headers']` is
+  re-read on every reconnect.
+- **stdio** servers are unaffected; there is no HTTP.
+
+The UA is informational, not an auth or trust signal. It is visible to remote
+servers, so a server or WAF that filters on User-Agent may need its allow-list
+updated — the `headers` override covers that case.
+
+## The audit trail renders what it records
+
+`tool_lifecycle`, `subagent_lifecycle`, and `permission_decision` exist so an
+embedded host has **one** audit artifact instead of two parallel streams
+(`EventKind` docstring, replay schema v1.2). The JSONL side was correct. Both
+CLI views were not: `--raw` degraded them to a sorted payload-key preview, and
+the default grouped view dropped them entirely, because `_print_turn`'s event
+loop is an allowlist that silently skips an unnamed kind.
+
+A turn containing a **denied** permission decision and a **failed** tool
+rendered as:
+
+```
+━ Turn t1 ━
+   user    (0 chars)
+   asst   done (4 chars)
+  └─  ok
+```
+
+Now:
+
+```
+━ Turn t1 ━
+   user    (0 chars)
+  perm    deny run_shell_command mode=read-only blocked in read-only
+  tool*   error run_shell_command · PermissionDenied
+  agent*  completed task=bg-7 audit the config
+   asst   done (4 chars)
+  └─  ok
+```
+
+The guard against regression is a probe-based exhaustiveness test over
+`EventKind`. The five intentionally-unrendered kinds are listed with a per-entry
+reason, and a companion test fails if one of them *gains* a renderer — so the
+exemption list cannot go stale silently. Both guards were verified red with
+their fix reverted.
+
+## Fixes
+
+- **`/copy` is bounded.** `_copy_last_response` called `subprocess.run` three
+  times with no `timeout=`, so a `pbcopy` wedged on an unresponsive pasteboard
+  server hung the input loop with no way out but `Ctrl+C`. Every attempt is now
+  bounded at 5s and routed through `run_captured`, so a grandchild holding the
+  captured pipe cannot outlive the bound. A timeout or non-zero exit also falls
+  through to the next utility instead of aborting the chain — a failing `pbcopy`
+  previously reported "Copy failed" without ever trying `xclip` or `xsel`. The
+  two error cases stay distinct: "No clipboard utility found" only when every
+  candidate was absent, otherwise the last real error. (#139)
+- **ACP `session/prompt` reports why a turn actually ended** rather than always
+  `end_turn`, and `stopReason` gained the `max_tokens` member the local enum had
+  been missing. See the [CHANGELOG](../../CHANGELOG.md) for the full outcome
+  mapping and the reasoning behind `llm_error → end_turn`. (#131)
+- `run_loop`'s 31-branch slash-command if/elif chain is now a dispatch table
+  (353 → 127 LOC, cyclomatic complexity 74 → 26); no behavior change, and
+  `/sandbox` gained the tab-completion entry it had always been missing. (#142)
+
+## Breaking changes
+
+**None.** Every change upgrades in place.
+
+The only change visible outside the process is the MCP `User-Agent` described
+above. It is informational, it is overridable through the server's `headers`
+block, and no agentao behavior depends on it — but if you operate a remote MCP
+server that filters clients by User-Agent, that is the one thing to check.
+
+## Tests & review
+
+3649 passed, 2 skipped (plus 9 `slow`-marked tests deselected by default), on
+Python 3.10 / 3.11 / 3.12, alongside `mypy --strict` on the host surface,
+schema-drift checks (`write_replay_schema.py --check`,
+`write_host_schema.py --check`), clean-install smoke tests, and the example
+integrations.
+
+New test coverage: bounded-stdout-reader framing, the AC1 shutdown crash, the
+AC3 grandchild reap (including a server that dies on SIGTERM), the terminal
+sanitizer (bidi plus interactive-console ESC/OSC), the three output caps, the
+`agent_factory` seam and its post-conditions, `/copy` (which had none), the
+DuckDuckGo challenge-page cases, MCP User-Agent injection, and a probe-based
+exhaustiveness guard over `EventKind`.
+
+Review found real defects **in the fixes themselves**, which is the point of
+running it:
+
+- The AC5/AC8 round found **9**, all fixed — including the interaction-display
+  sanitizer gap (a display boundary the first pass missed), a `_cap_chunk`
+  `TypeError` regression, the bidi gap, uncapped sibling fields, unbounded
+  accumulation, and an unsanitized debug log.
+- Codex caught an **off-by-one** in the frame reader's dropped-byte report
+  (`nl - pos` against a cap comparison of `nl + 1 - pos`), then fuzzed **12,775**
+  frame/cap/chunk-size combinations against reference behavior with no
+  mismatches.
+- The dispatch-table review found a **critical test-fixture defect**: routing
+  `/clear` through the real handler reached `MemoryManager.clear()`, which at
+  `scope=None` clears the **user** store at `~/.agentao/memory.db` regardless of
+  the fixture's `working_directory`. Every `pytest tests/` run had been
+  soft-deleting the developer's real cross-project memories, silently, all
+  green. The fixture now redirects `HOME`, with a test asserting the redirect
+  took. No data was lost where this was found.
+
+## Upgrade
+
+```bash
+pip install -U agentao          # library
+pip install -U 'agentao[cli]'   # interactive CLI
+pip install -U 'agentao[full]'  # all optional extras
+```
+
+Nothing is required to migrate from 0.4.15. Two things are worth a look:
+
+1. If you pinned `backend="jina"` for `web_search`, set `JINA_API_KEY` — the
+   upstream search endpoint now requires one. The failure is a legible search
+   error, not a crash.
+2. If a remote MCP server filters clients by User-Agent, it will now see
+   `agentao-mcp/<version>`.
+
+## Out of scope (deferred)
+
+- **`llm_error` still maps to ACP `end_turn`.** The closed `stopReason` enum has
+  no member for "the model call failed", and `refusal` means the agent declined
+  on content grounds — reporting an API outage that way would trade a vague
+  answer for a false one. The failure stays visible as the turn's streamed
+  `[LLM API error: …]` content. Surfacing it as a JSON-RPC error would be more
+  truthful but changes the response *shape*, so it needs its own decision.
+- **The `agent_factory` post-conditions are `hasattr` / `is` probes.** A `Mock`
+  or `__getattr__` proxy satisfies them vacuously. Closing that needs
+  `isinstance(agent, Agentao)`, which would forbid the proxy and wrapper
+  runtimes this seam exists to serve — recorded as an open question rather than
+  decided unilaterally.
+- **`llm_client=` is not inherited by sub-agents.** `AgentToolWrapper` rebuilds
+  a stock client from raw scalars, so `/agent` bypasses a host's proxy, auth, or
+  instrumentation. Pre-existing, outside the `agent_factory` diff, recorded.
+- **Four refactor candidates were declined with evidence**, not skipped for lack
+  of time: the June review's Tier 3 long functions (churn refutes the
+  maintenance-cost premise — `tool_executor.py` saw 7 commits and 2 fixes in 12
+  months, and one item is additionally breaking), the mypy per-package ratchet
+  (27 of 89 `runtime` errors are mixin false positives needing Protocol
+  scaffolding), broad linter adoption (~2800 findings, ~92 signal), and lazy
+  regex compilation in the hardline scanner (17 ms of a 130 ms cold start,
+  one-time). See `docs/design/refactor-audit-2026-07.md`.


### PR DESCRIPTION
Clears the four blockers standing between `main` and a `v0.4.16` tag. No runtime code changes — CHANGELOG, version, release notes.

## 1. CHANGELOG was 8 PRs short

`[Unreleased]` documented only #131 (ACP `stopReason`). `### Added` and `### Fixed` were **empty headings** despite the acp_client audit and three user-facing bug fixes having landed.

| Heading | Backfilled |
|---|---|
| Added | #133 `agent_factory` on `AgentaoCLI` / `cli.main()` |
| Changed | #136 MCP default User-Agent · #142 `run_loop` dispatch table (one line) |
| Fixed | #135 DDG bot-challenge · #139 `/copy` hang · #141 replay v1.2 audit render · #137 AC1/AC2/AC3 |
| Security | #137 AC5 terminal sanitize · #137/#138 the three output caps |

Heading flipped to `## [0.4.16] — 2026-07-25`, matching what `8d93d71` did for 0.4.15. A follow-up "open 0.4.17 dev cycle" commit restores `[Unreleased]` after the Release is published.

## 2. Version bump — a hard gate

`agentao/__init__.py` `0.4.16.dev0` → `0.4.16`. `.github/workflows/publish.yml:22-45` compares the release tag against `__version__` and `SystemExit`s on mismatch, so tagging `v0.4.16` against a `.dev0` fails the PyPI publish job rather than shipping something wrong.

## 3. `docs/releases/v0.4.16.md`

The `gh release create --notes-file` artifact. Follows v0.4.15's structure (headline → Why this release → topic sections → Fixes → Breaking changes → Tests & review → Upgrade → Out of scope).

## #136 is Changed, not Breaking

The UA is informational, not an auth or trust signal; it is overridable through the server's `headers` block; and no agentao behavior depends on it. The one operator-visible consequence — a remote MCP server or WAF that filters clients by User-Agent — is called out under **Breaking changes** ("None", with the caveat named) and in **Upgrade**, rather than being labelled a break.

## Verification

Run on this tree, not inherited from main's CI:

- **3649 passed, 2 skipped**, 9 `slow` deselected
- `mypy --strict --package agentao.host` — clean
- `write_replay_schema.py --check` / `write_host_schema.py --check` — up to date
- The `agent_factory` example in the release note was **executed** against the real signatures of `cli.main` and `AgentaoCLI.__init__`, not transcribed from the PR body
- The three `acp_client` caps are quoted from the constants (`_MAX_FRAME_BYTES`, `_MAX_CHUNK_DISPLAY_CHARS`, `_MAX_AGENT_RENDER_CHARS`). Two of them count **characters**, not bytes — the PR bodies said "256 KiB" / "1 MiB"; corrected here.

## After merge

`gh release create v0.4.16 --notes-file docs/releases/v0.4.16.md` — that is the step that publishes to PyPI, and it is deliberately not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)