### PR TITLE
docs(release): drop the relative link from the 0.4.16 notes

### DIFF
--- a/docs/releases/v0.4.16.md
+++ b/docs/releases/v0.4.16.md
@@ -261,8 +261,8 @@ their fix reverted.
   candidate was absent, otherwise the last real error. (#139)
 - **ACP `session/prompt` reports why a turn actually ended** rather than always
   `end_turn`, and `stopReason` gained the `max_tokens` member the local enum had
-  been missing. See the [CHANGELOG](../../CHANGELOG.md) for the full outcome
-  mapping and the reasoning behind `llm_error → end_turn`. (#131)
+  been missing. `CHANGELOG.md` carries the full outcome mapping and the
+  reasoning behind `llm_error → end_turn`. (#131)
 - `run_loop`'s 31-branch slash-command if/elif chain is now a dispatch table
   (353 → 127 LOC, cyclomatic complexity 74 → 26); no behavior change, and
   `/sandbox` gained the tab-completion entry it had always been missing. (#142)


### PR DESCRIPTION
Caught during release pre-flight, before `gh release create`.

`docs/releases/v0.4.16.md` is both an in-tree doc and the `--notes-file` for the GitHub Release. GitHub resolves relative links in a Release body against the repository root, so `[CHANGELOG](../../CHANGELOG.md)` — correct when the file is read under `docs/releases/` — would render as a broken link on the published release page.

Replaced with a plain `CHANGELOG.md` reference. v0.4.15's notes contain no links at all; this restores that convention.

Docs-only; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)