### PR TITLE
chore: open 0.4.17 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+_Targeting 0.4.17. Add entries under the relevant heading as work lands._
+
+### Added
+
+### Changed
+
+### Fixed
+
+---
+
 ## [0.4.16] — 2026-07-25
 
 A **boundary-hardening release**. 0.4.15 was about the harness not lying about

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.16"
+__version__ = "0.4.17.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Post-release housekeeping for [v0.4.16](https://github.com/jin-bo/agentao/releases/tag/v0.4.16) (published, live on PyPI). Mirrors `8dc68ee`, the equivalent commit that opened 0.4.16.

- **`CHANGELOG.md`** — fresh `[Unreleased]` block above `[0.4.16]`, with `### Added` / `### Changed` / `### Fixed` pre-created.
- **`agentao/__init__.py`** — `0.4.16` → `0.4.17.dev0`.

No runtime code touched.

## One note for whoever preps 0.4.17

Last cycle those three headings stayed empty while 8 PRs landed, so the 0.4.16 prep had to reconstruct every entry from `git log` and PR bodies after the fact — which is how the two `acp_client` security fixes (#137, #138) came within one review of shipping undocumented.

Entries are cheaper to write at merge time than to excavate at release time. Not proposing any tooling or CI gate for it here; just recording why the headings exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)