### PR TITLE
chore(release): prep 0.4.17 — mcp SDK 2.x compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-_Targeting 0.4.17. Add entries under the relevant heading as work lands._
+_Targeting 0.4.18. Add entries under the relevant heading as work lands._
+
+---
+
+## [0.4.17] — 2026-07-29
+
+An **SDK-compatibility release**. `mcp` 2.0.0 landed on 2026-07-28 as a breaking
+rewrite of the wire models, and agentao's dependency floor had no upper bound —
+so a fresh install of 0.4.16 already resolved to it, and every MCP path failed.
+0.4.17 makes agentao run on both majors and puts CI in a position to notice next
+time.
+
+No breaking changes. It upgrades in place.
 
 ### Added
 
@@ -32,6 +44,17 @@ _Targeting 0.4.17. Add entries under the relevant heading as work lands._
   majors rather than forcing hosts off 1.x. The floor rises only when agentao
   actually needs a 2.x-only capability, and on a major boundary. The lockfile
   tracks the newest 2.x; the floor and the newest 1.x are held by CI.
+
+- **The four-domain taxonomy is stated once in the system prompt** (#147).
+  `identity`, `task_classification`, and `completion_standard` each enumerated
+  the same four domains from a different angle, so no section was authoritative
+  and all three were free to drift. They now share one table in
+  `task_classification` (Domain | Covers | Deliver | Done when); `identity`
+  keeps the bare names and `completion_standard` points at the "Done when"
+  column. `## Failure retry discipline` was a near-verbatim restatement of
+  Reliability #3 and is folded into it. No rule is dropped. Static sections go
+  2542 → 2320 tokens (−8.7%), but that saving sits in the cached stable prefix —
+  the point is removing the drift surface, not the tokens.
 
 ### Fixed
 

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.17.dev0"
+__version__ = "0.4.17"
 
 
 def _ensure_utf8() -> None:

--- a/docs/releases/v0.4.17.md
+++ b/docs/releases/v0.4.17.md
@@ -1,0 +1,217 @@
+# Agentao 0.4.17
+
+An **SDK-compatibility release**. **No breaking changes** — it upgrades in place
+via `pip install -U agentao`.
+
+`mcp` 2.0.0 shipped on **2026-07-28** as a breaking rewrite of the protocol's
+wire models. Agentao declared a bare `mcp>=1.26.0`, with no upper bound. So from
+the moment 2.0.0 hit PyPI, a fresh `pip install agentao` resolved to it —
+against code that only spoke 1.x — and **every MCP path was broken on a new
+install of 0.4.16**. The test suite stayed fully green throughout.
+
+The headline:
+
+- **Agentao now runs on both mcp majors**, 1.x and 2.x, with the differences
+  probed off the installed SDK rather than guessed from a version string.
+- **The dependency is bounded**: `mcp>=1.26.0,<3`. The lockfile follows the
+  newest 2.x; the floor and the newest 1.x are held by a new CI job.
+- **The MCP test fixtures now come from the real SDK models.** They were the
+  reason a 3,600-test suite reported success while the feature was dead.
+
+## Why this release
+
+This is not a feature. It is the closing of a window in which the published
+package was broken for anyone who installed it fresh.
+
+The interesting part is not that an upstream SDK made a breaking change — 2.0 is
+a major version and is entitled to. It is that agentao's own test suite could
+not see it. Three separate fixtures each described the *old* wire shape from
+memory rather than obtaining it from the SDK, so the tests and the code shared
+one stale model of the world and agreed with each other perfectly.
+
+That is the failure this release is really about, and why the fix includes a CI
+job rather than just a patch.
+
+## What actually broke
+
+Four independent breaks, each verified against both majors installed side by
+side rather than read off a changelog.
+
+**1 — Every wire field was renamed.** mcp 2.0 moved its models into the
+split-out `mcp-types` package and renamed each field from its camelCase JSON
+name to a snake_case Python attribute, demoting the old name to a Pydantic
+alias. Aliases work for *construction*; attribute access does not honor them.
+
+`Tool.inputSchema` is the fatal one: the tool schema is rebuilt on **every
+turn**, so the very first turn with any MCP server connected raised
+`AttributeError` and the agent was unusable. Also hit: `CallToolResult.isError`,
+`.structuredContent`, `ImageContent.mimeType`, and the `ToolAnnotations` hints.
+
+**2 — The HTTP stack moved to `httpx2`.** `create_mcp_http_client` now returns
+an `httpx2.AsyncClient` and wants an `httpx2.Timeout`; the `httpx.Timeout`
+agentao passed raised `TypeError: unhashable type: 'Timeout'`.
+
+**3 — The transport tuple lost an element.** `streamable_http_client` used to
+yield `(read, write, get_session_id)`. In 2.0 every transport yields the same
+2-tuple, so a 3-element unpack raised `ValueError: not enough values to unpack
+(expected 3, got 2)`.
+
+Breaks 2 and 3 together meant **Streamable HTTP — the default transport for a
+bare `url` — could not connect at all**.
+
+**4 — Timeouts changed units.** `read_timeout_seconds` went from `timedelta` to
+plain float seconds, and flows into `anyio.fail_after`, where a `timedelta`
+raises `TypeError`.
+
+## How both majors are supported
+
+`agentao/mcp/_compat.py` absorbs all four, and every one of them is resolved by
+**asking the installed SDK**, never by parsing a version string:
+
+| Difference | How it is resolved |
+|---|---|
+| camelCase / snake_case fields | `hasattr` dispatch, on the object that will be read |
+| `httpx` vs `httpx2` | read off `create_mcp_http_client.__module__` — the flavour that factory will actually accept |
+| `timedelta` vs float | read off `ClientSession.call_tool`'s own signature |
+| annotation key names | `model_dump(by_alias=True)` — a no-op on 1.x, where the field names already *are* the spec names |
+
+A version string is a second source of truth that a vendored, patched, or
+prerelease install makes wrong. The module asks the object that will receive the
+value.
+
+One consequence worth stating: **`McpTool.mcp_annotations` keeps camelCase keys
+on both majors.** It has been a documented host-introspection surface since
+0.4.3, and hosts reading `readOnlyHint` / `destructiveHint` are unaffected.
+Without `by_alias=True`, a trusted server's `destructiveHint=true` would have
+stopped forcing confirmation on 2.x — latent rather than live, since the schema
+crash above fires first on every turn, but a real hole once that crash was
+fixed.
+
+## Why the suite did not catch it
+
+Because the fixtures asserted agentao's assumption about the wire shape instead
+of the SDK's:
+
+- `tests/support/mcp.py` handed back
+  `SimpleNamespace(content=…, structuredContent=…, isError=…)`.
+- The Streamable HTTP fake hardcoded the 1.x 3-tuple.
+- `tests/test_mcp_tool.py` built tool definitions with `MagicMock` — which is
+  not a neutral stub here but an **actively wrong** one. A `MagicMock` answers
+  `hasattr` for every name, so it satisfies a 2.x-shaped probe *even on a 1.x
+  SDK*. A version-compat shim cannot be tested against a mock at all.
+
+All three now build from real `mcp.types` models — constructed with the
+camelCase spec names, which are field names on 1.x and aliases on 2.x, so one
+call site works on both. Where the shape genuinely differs, the test is
+parameterized over **both real shapes** rather than picking one.
+
+The fix was checked for teeth: reverting the production change turns the
+`[mcp2-2tuple]` parameter red with the exact `ValueError` from production.
+
+The tuple arity deserves a note of its own. It is invisible to a signature or a
+field-name audit — the return annotation was
+`AsyncGenerator[TransportStreams, None]`, and the arity only appears at the
+`yield`. It was found by review, not by introspection, and it is the reason the
+answer to "does this still work?" has to be *run it on both*, not *read both
+APIs*.
+
+## The new CI job
+
+`mcp-compat` runs the MCP boundary tests against three targets:
+
+```
+mcp==1.26.0    the declared floor
+mcp>=1,<2      whatever upstream ships as the newest 1.x
+mcp>=2,<3      whatever upstream ships as the newest 2.x
+```
+
+Specs rather than pins for the latter two, so a future release that breaks the
+shim fails here instead of in a user's install. `build` gates on this job: a
+wheel whose MCP path is broken on a major its own metadata claims to support
+should not be publishable.
+
+The lockfile can only ever exercise one version, which is exactly how all four
+breaks above reached a green suite.
+
+## Dependency policy
+
+`mcp>=1.26.0,<3`.
+
+Upstream still ships v1 — **1.29.0 landed the same day as 2.0.0** — so agentao
+tracks both majors rather than forcing hosts off 1.x. Agentao uses tool
+discovery, tool calls, and the three transports; it does not use any 2.x-only
+capability. The floor rises when that changes, and on a major boundary.
+
+The pydantic question is a non-issue in practice: mcp 1.26 declares
+`pydantic>=2.11.0` and a clean install of it already lands 2.13.4, while 2.0
+declares `>=2.12.0`. The real footprint delta on a `[full]` install is
+`+httpx2 +opentelemetry-api +mcp-types -httpx-sse -pydantic-settings`;
+cryptography, uvicorn, and starlette were already in 1.26's closure.
+
+## Also in this release
+
+- **The four-domain taxonomy is stated once in the system prompt** (#147).
+  `identity`, `task_classification`, and `completion_standard` each enumerated
+  the same four domains from a different angle, so no section was authoritative
+  and all three were free to drift. They now share one table in
+  `task_classification`. `## Failure retry discipline` was a near-verbatim
+  restatement of Reliability #3 and is folded into it. No rule is dropped.
+  Static sections go 2542 → 2320 tokens (−8.7%), but that saving sits in the
+  cached stable prefix — the point is removing the drift surface, not the
+  tokens.
+
+- `tests/data/full_extras_baseline.txt` is refreshed, as at every release cut.
+  Its drift here was pre-existing and not caused by the MCP change: the old
+  unbounded `mcp>=1.26.0` resolves to 2.0.0 today exactly as `<3` does, and of
+  the 50 packages whose pins moved, 43 are unrelated upstream releases since
+  v0.4.12.
+
+- `docs/design/mcp-streamable-http.md` (and its `.zh.md` companion) carry
+  mcp-2.0 update blocks in §5.1 and §5.3. Worth recording: §5.1's original call
+  — import the canonical `streamable_http_client` rather than the deprecated
+  `streamablehttp_client` alias — is why that import survived the major bump
+  untouched. The deprecation warning it was avoiding turned out to be a removal
+  notice.
+
+## Breaking changes
+
+None.
+
+Hosts pinned to `mcp` 1.x are unaffected and stay on 1.x. Hosts on 2.x now work
+where they previously did not.
+
+## Tests & review
+
+Verified on the tree, not inherited from CI:
+
+```
+mcp 2.0.0    full suite   3650 passed,  2 skipped
+mcp 1.26.0   full suite   3648 passed   (+2 mypy skips in the scratch venv)
+mcp 1.29.0   full suite   3648 passed   (+2 mypy skips in the scratch venv)
+committed lock            3650 passed,  2 skipped
+slow clean-install           9 passed   (built wheel, fresh venv)
+mypy --strict --package agentao.host    clean
+write_replay_schema.py --check          up to date
+write_host_schema.py --check            up to date
+```
+
+All three SDK runs reconcile to 3650. CI on #148 concluded 18/18 SUCCESS,
+including the three `mcp-compat` targets and the `build` job gated behind them.
+
+## Upgrade
+
+```bash
+pip install -U agentao
+```
+
+If you pinned `mcp` yourself, nothing changes — both majors are supported. If
+you did not, and you installed agentao 0.4.16 after 2026-07-28, your MCP servers
+were failing; this release fixes that with no configuration change.
+
+## Out of scope (deferred)
+
+- **Raising the floor to `mcp>=2`.** Deliberately not done — see Dependency
+  policy above.
+- **A broad dependency refresh.** ~84 unrelated packages have newer releases;
+  that is its own change with its own blast radius, not something to bundle with
+  a compatibility fix.


### PR DESCRIPTION
Cuts 0.4.17. Contents: **#148** (mcp SDK 2.x compatibility) plus **#147** (the four-domain prompt taxonomy).

| File | Change |
|---|---|
| `agentao/__init__.py` | `0.4.17.dev0` → `0.4.17` |
| `CHANGELOG.md` | `[Unreleased]` cut to `[0.4.17] — 2026-07-29`; `[Unreleased]` reset to target 0.4.18 |
| `docs/releases/v0.4.17.md` | new |

#147 landed without a CHANGELOG entry — it is the only other change in this cycle, so it is recorded here rather than left out.

## What the release is about

`mcp` 2.0.0 shipped **2026-07-28** as a breaking rewrite of the wire models, and agentao declared a bare `mcp>=1.26.0`. From that moment a fresh `pip install agentao` resolved to it against 1.x-only code, so **every MCP path was broken on a new install of 0.4.16** — with a fully green test suite throughout.

The release note leads with that second half. Three fixtures each described the old wire shape from memory instead of obtaining it from the SDK, so the tests and the code shared one stale model and agreed with each other perfectly. That is why the fix shipped with a CI job (`mcp-compat`, three targets, gating `build`) and not just a patch.

**No breaking changes.** Hosts pinned to `mcp` 1.x are unaffected; hosts on 2.x now work where they previously did not.

## Verified on this tree, not inherited from CI

- Full suite **after** the version bump: **3650 passed, 2 skipped**
- `write_replay_schema.py --check` / `write_host_schema.py --check`: still up to date — the bump feeds `_MCP_USER_AGENT`, which no snapshot pins
- No test pins the version literal: `test_acp_initialize.py` imports `__version__` dynamically, and the `0.3.1.dev0` strings in `test_acp_schema.py` are example payloads rather than assertions

## Every figure in the release note is measured

- **Baseline drift** — of the 50 pins that moved in `full_extras_baseline.txt`, **7 are MCP-related and 43 are unrelated upstream releases** since v0.4.12. Computed by diffing the two baseline files, not eyeballed. This is what supports the claim that the drift was pre-existing rather than caused by #148.
- **The pydantic non-issue** — mcp 1.26 declares `pydantic>=2.11.0` and a clean venv of it lands 2.13.4; 2.0 declares `>=2.12.0`. Read from the installed `METADATA`, both installed side by side.
- **`1.29.0` landed the same day as `2.0.0`** — from the PyPI release index, which is what supports "upstream still maintains v1" and therefore the decision not to hard-cut.
- **`mcp_annotations` documented since 0.4.3** — quoted from `docs/releases/v0.4.3.md`.
- **#147's 2542 → 2320 token figures** — quoted from its own commit, not recomputed.
- **18/18 CI SUCCESS on #148**, including the three `mcp-compat` targets and the `build` job gated behind them.

## Release order

This PR must merge to `origin/main` **before** `gh release create` — `publish.yml` triggers on `release: published` and publishes to PyPI from whatever is on main at that point.

`#149` (the OpenWorker design review) is green and also intended for this release; it needs to merge before the Release is created for its docs to ship in 0.4.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)