### PR TITLE
chore: open 0.4.18 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 _Targeting 0.4.18. Add entries under the relevant heading as work lands._
 
+### Added
+
+### Changed
+
+### Fixed
+
 ---
 
 ## [0.4.17] — 2026-07-29

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.17"
+__version__ = "0.4.18.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Mirrors `35b004b` (the 0.4.17 open).

| File | Change |
|---|---|
| `CHANGELOG.md` | Added / Changed / Fixed headings pre-created under the `[Unreleased]` block that the 0.4.17 prep already reset |
| `agentao/__init__.py` | `0.4.17` → `0.4.18.dev0` |

## The note in `35b004b` fired again

That commit carried a warning for whoever prepped 0.4.17: the previous cycle left those headings empty while 8 PRs landed, so the prep had to reconstruct entries from `git log` and PR bodies — and two `acp_client` security fixes nearly shipped undocumented.

**It happened again this cycle.** #147 landed with no CHANGELOG entry. It was the only non-MCP change in 0.4.17, so the prep reconstructed it from the commit message — including the `2542 → 2320` token figures, which exist nowhere else. That worked only because the cycle held two changes and both were trivially enumerable. A cycle with eight would not have been.

So the note is restated for 0.4.18 with one addition:

> Write the entry in the PR that lands the change, and put any figure the entry will need into the commit message — because that is where the prep will have to go looking for it.

## Verified

```
full suite     3650 passed, 2 skipped
write_replay_schema.py --check    up to date
write_host_schema.py --check      up to date
```

The version literal is not pinned by any test (`test_acp_initialize.py` imports `__version__` dynamically; the `0.3.1.dev0` strings in `test_acp_schema.py` are example payloads), so the bump is inert — but the suite was run rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)