### PR TITLE
chore(release): prep 0.4.18 — web_fetch on Playwright, and off the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-_Targeting 0.4.18. Add entries under the relevant heading as work lands._
+_Targeting 0.4.19. Add entries under the relevant heading as work lands._
+
+---
+
+## [0.4.18] — 2026-07-30
+
+A **`web_fetch` release**, in two parts that had to ship together.
+
+The local JS-rendering fallback is rebuilt on Playwright directly, replacing
+crawl4ai — and the rebuild is mostly a security story, because the retired
+implementation had shipped since 0.4.7 with **zero** test coverage. Then
+`web_fetch` becomes agentao's first built-in `AsyncToolBase`, so driving
+Playwright's async API no longer requires blocking an async host's event loop.
+
+**Breaking:** the `[crawl4ai]` extra is replaced by `[playwright]`, `web_fetch`
+changes base class, and `Agentao.arun` no longer uses the event loop's default
+executor. Each is detailed below.
 
 ### Added
 
@@ -40,10 +56,16 @@ _Targeting 0.4.18. Add entries under the relevant heading as work lands._
 
 ### Changed
 
-- **`web_fetch` is now an `AsyncToolBase`, so it no longer blocks an async
-  host's event loop.** The tool's implementation moved from `execute` to
+- **BREAKING: `web_fetch` is now an `AsyncToolBase`, so it no longer blocks an
+  async host's event loop.** The tool's implementation moved from `execute` to
   `async_execute`; `execute` stays as a synchronous wrapper for embedders that
   are not async.
+
+  What breaks is the *type*, not the call: `web_fetch` is no longer an instance
+  of `Tool`, so host code that narrows the registry with `isinstance(t, Tool)`
+  — or annotates against it — now silently skips this tool and must widen to
+  `RegistrableTool`. Calling `WebFetchTool().execute(...)` from ordinary
+  synchronous code is unaffected.
 
   It had to drive an event loop of its own to reach Playwright's async API, and
   from inside a caller's running loop there is no way to do that without
@@ -85,9 +107,11 @@ _Targeting 0.4.18. Add entries under the relevant heading as work lands._
   is waiting on a deadline there, and a slow-but-working close should not be
   turned into a killed driver.)
 
-- **`Agentao.arun` no longer runs `chat()` on the event loop's default
+- **BREAKING: `Agentao.arun` no longer runs `chat()` on the event loop's default
   executor.** It uses a dedicated pool with the same capacity asyncio would have
-  given, so concurrency is unchanged.
+  given, so concurrency is unchanged — but a host that called
+  `loop.set_default_executor(...)` to size or instrument agentao's thread usage
+  no longer controls this path.
 
   A turn holds its worker for the whole turn, and partway through it blocks
   waiting on a tool coroutine running on the host loop. Once concurrent turns

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.18.dev0"
+__version__ = "0.4.18"
 
 
 def _ensure_utf8() -> None:

--- a/docs/releases/v0.4.18.md
+++ b/docs/releases/v0.4.18.md
@@ -1,0 +1,199 @@
+# Agentao 0.4.18
+
+A **`web_fetch` release**, in two parts that had to ship together.
+
+The local JS-rendering fallback is rebuilt on Playwright directly, replacing
+crawl4ai. Then `web_fetch` becomes agentao's first built-in `AsyncToolBase`, so
+reaching Playwright's async API no longer costs an async host its event loop.
+
+The headline:
+
+- **The JS fallback is now Playwright, and it is guarded.** The retired
+  implementation had shipped since 0.4.7 with **zero** test coverage; the
+  rebuild lands with a test file and closes a set of real SSRF holes in the
+  browser path.
+- **`web_fetch` no longer blocks a host's event loop.** It is an
+  `AsyncToolBase`; `await tool.async_execute(...)` is the path for hosts on a
+  loop, and it gains token-driven cancellation from the runtime for free.
+- **Three breaking changes**, all flagged `BREAKING` in the changelog: the
+  `[crawl4ai]` extra becomes `[playwright]`, `web_fetch` changes base class,
+  and `Agentao.arun` stops using the event loop's default executor.
+
+## Why this release
+
+Not a feature release. Both halves are corrections, and each one makes the other
+possible.
+
+The crawl4ai dependency was carried for roughly nine lines of use. Replacing it
+with Playwright directly is a smaller surface, but the reason it was worth doing
+now is that nothing under `tests/` exercised the fallback at all — the only
+reference to it was a `monkeypatch.delenv` clearing its environment variable.
+Code that renders attacker-controlled JavaScript is the last place to run
+untested, and the audit that came with the rewrite found what an untested path
+tends to accumulate.
+
+The async half is a different kind of correction. `web_fetch` had to drive an
+event loop of its own to reach Playwright, and from inside a caller's running
+loop there is no way to do that without blocking it: a synchronous function
+cannot yield, so the helper submitted the coroutine to a worker thread and
+waited on `Future.result()` **on the loop thread**. For that duration nothing
+else on the host's loop ran, and a `CancelledError` could not be delivered. The
+fix is not a better bridge — it is not needing one.
+
+## The browser path is now guarded
+
+The httpx path validated every redirect hop. Once Chromium took over, it chased
+redirects and client-side navigation unguarded, so a page that passed the guard
+and then navigated to `169.254.169.254` had that body returned to the model.
+
+Every in-browser request is now re-validated against the URL policy — all
+requests, not only navigations, because a permissive-CORS or JSONP endpoint lets
+the page's own JavaScript read an internal response and write it into the DOM,
+which is exactly what `page.content()` returns. The handler is installed on the
+browser **context**, not the page: a page-level route does not cover a popup
+opened with `window.open`, whose first request would otherwise go unchecked.
+
+Three holes that `route` alone does not close were closed separately:
+
+- **WebSockets** do not pass through `context.route` — Playwright intercepts
+  them via `route_web_socket`. Rendered JavaScript could otherwise open
+  `ws://169.254.169.254/` and copy accepted frames into the DOM. This is why
+  the extra floors at `playwright>=1.48.0`, where `route_web_socket` landed.
+- **Service workers** are blocked. Playwright's own documentation for `route`
+  says it "will not intercept requests intercepted by Service Worker" and
+  recommends `serviceWorkers='block'` when using request interception; the
+  default is `'allow'`.
+- **Downloads** are disabled. `new_context()` defaults `accept_downloads` to
+  true. `web_fetch` reads `page.content()` and nothing else, so a download could
+  only ever be a hostile page writing to the host's disk.
+
+Two further corrections worth naming:
+
+- **TLS verification stays on.** crawl4ai's `BrowserConfig` set
+  `ignore_https_errors=True`; the render context sets it explicitly to `False`.
+  The fallback runs *after* the certificate-verifying httpx path failed, so
+  ignoring cert errors would mean a site whose TLS is broken — or is being
+  intercepted — fails correctly on the primary path and is then rendered and
+  handed to the model as though it were fine.
+- **The browser gets a scrubbed environment.** `chromium.launch()` passed no
+  `env=`, so the browser tree inherited agentao's own provider credentials. It
+  now routes through `build_child_env()` like every other child agentao spawns.
+  This is the one child that executes attacker-controlled JavaScript.
+
+## The render is bounded, and the bounds are checked against each other
+
+`page.content()` takes no timeout at all, so the navigation timeouts bounded
+navigation only and a page that pegged its renderer afterwards blocked the
+caller forever. Startup, render, and teardown now each carry a budget, and a
+driver that blows through one is killed rather than left running.
+
+Bounding `browser.close()` alone was not enough: `async_playwright()`'s own
+`__aexit__` waits on the same driver with no deadline, and `__aenter__` can hang
+just as long if the driver spawns but never completes its handshake — a wedge
+that never reaches teardown at all. The context is driven by hand for that
+reason.
+
+The cancellation budgets are sized to fit inside the AsyncTool dispatcher's
+cleanup-ack window (`_ASYNC_CANCEL_ACK_TIMEOUT_S`, 5s): the HTML parse drain is
+3s and the cancelled-path browser and driver teardowns are 2s each. Cleanup that
+runs longer than the dispatcher will wait detaches exactly the work it was
+accounting for, with the invocation already reported complete. A *non-cancelled*
+`browser.close()` keeps its more generous 10s — nothing is waiting on a deadline
+there, and a slow-but-working close should not be turned into a killed driver.
+
+The kill is deliberately **not** `kill_process_tree()`. That helper documents its
+precondition — `start_new_session=True` makes the child a group leader, so
+`pid == pgid` and `killpg(pid)` reaps the tree. Playwright spawns its driver with
+no new session, so it shares agentao's process group and its pid is not a pgid.
+
+## What moved off the event loop
+
+Fixing only the Playwright bridge would have moved the ceiling without changing
+its nature, because the same `execute()` blocked on five separate things. All of
+them moved:
+
+| was | now |
+|---|---|
+| `socket.getaddrinfo` unbounded on the caller's thread | bounded off-loop thread |
+| `httpx.Client` sync HTTP | `httpx.AsyncClient` via `guarded_get_async` |
+| nested loop for the render | plain `await` |
+| decode + BeautifulSoup + text extraction inline | dedicated bounded thread pool |
+| the Jina fallback's sync client | async |
+
+The HTML work matters more than it looks. On a 2.2MB DOM (~0.7s in
+`html.parser`) a 10ms heartbeat task ticks **0** times with the parse inline and
+about **31** with it on a thread — CPython hands the GIL over between bytecodes,
+so a worker shares the CPU with the loop rather than locking it out. It is also
+what the sync tool got for free by being dispatched on an executor thread, so
+leaving it inline would have made this port a regression on its own headline
+axis.
+
+That work runs on a **dedicated** pool, not the loop's default executor. There
+are now three pools with no contention between them: `agentao-arun` for turns,
+`agentao-web-html` for parsing, and the loop's default executor left free.
+
+`web_search` is deliberately untouched. It never drove its own loop, and it
+blocks in exactly the way every other synchronous built-in does. Making it async
+is a separate question about the tool base class, not about this defect.
+
+## `url_policy` grows a paired async surface
+
+`validate_outbound_url_async` and `guarded_get_async`, both exported from
+`agentao.security`. The async validator **delegates to the sync one** on a
+bounded daemon thread rather than reimplementing the checks against an async
+resolver: the policy is security-critical and two copies would drift. The
+redirect-hop predicate is shared for the same reason, so the two `guarded_get`
+forms cannot disagree about what counts as a hop.
+
+Side effect worth naming: name resolution on the `web_fetch` primary path is now
+**bounded** for the first time. It previously inherited `getaddrinfo`'s
+effectively unbounded behaviour, which was tolerable only because it blocked its
+own thread.
+
+A latent bug in the resolver-thread accounting went with it. The process-wide cap
+reserves a slot before starting the thread, and only the thread's own `finally`
+releases it — so a `Thread.start()` that failed, at the OS thread limit say,
+burned a slot permanently. Enough failures and every later policy check is
+refused for the life of the process, long after the pressure cleared.
+
+## Breaking changes
+
+**1 — The `[crawl4ai]` extra is replaced by `[playwright]`.** Install
+`agentao[playwright]` instead, and keep running `playwright install chromium` on
+top of the pip install. `AGENTAO_WEB_FETCH_FALLBACK=crawl4ai` is renamed to
+`=playwright`; the retired value is still accepted as an alias and the
+substitution is now surfaced in the tool description rather than only logged.
+
+**2 — `web_fetch` changes base class.** It is an `AsyncToolBase`, and
+`AsyncToolBase` is a sibling of `Tool`, not a subclass. Host code that narrows
+the registry with `isinstance(t, Tool)` — or annotates against it — now silently
+skips this tool and should widen to `RegistrableTool`. Calling
+`WebFetchTool().execute(...)` from ordinary synchronous code is unaffected.
+
+**3 — `Agentao.arun` no longer uses the event loop's default executor.** It uses
+a dedicated pool with the same capacity asyncio would have given, so concurrency
+is unchanged; a host that called `loop.set_default_executor(...)` to size or
+instrument agentao's thread usage no longer controls this path.
+
+The reason it cannot go back: a turn holds its worker for the whole turn, and
+partway through it blocks waiting on a tool coroutine running on the host loop.
+Once concurrent turns reach the pool's worker count, anything on that loop
+needing a default-executor worker can never get one — and the turns are waiting
+on exactly that work. That includes code agentao does not control.
+`loop.getaddrinfo` submits to the default executor, so every `httpx.AsyncClient`
+connect to a hostname resolves through it.
+
+## Known limitation, deliberately not fixed
+
+`WebFetchTool.execute()` still blocks a running loop. That is inherent to
+demanding a synchronous return value from inside a loop — there is no version of
+that wrapper which avoids it. Callers already on a loop should
+`await async_execute(...)`, which is why it exists. The wrapper stays for sync
+embedders, and its cost is asserted by a test rather than left implied.
+
+## Upgrading
+
+`pip install -U agentao`. If you used the JS-rendering fallback, switch the
+extra to `agentao[playwright]`; if you set the environment variable to
+`crawl4ai`, it still works but should be updated to `playwright`. Hosts driving
+`web_fetch` from inside an event loop should move to `async_execute`.


### PR DESCRIPTION
Cuts 0.4.18 from #152 (Playwright fallback) and #154 (async `web_fetch`).

## What

- `agentao/__init__.py`: `0.4.18.dev0` → `0.4.18`
- `CHANGELOG.md`: `[Unreleased]` → `[0.4.18] — 2026-07-30`, `[Unreleased]` reopened targeting 0.4.19
- `docs/releases/v0.4.18.md`: new

## Changelog correction included

Both landed commits are marked `!`, but only the `[crawl4ai]` → `[playwright]`
extras rename carried a `BREAKING` marker. The two breaks from #154 are now
marked rather than left for a reader to infer from the commit subject:

1. **`web_fetch` changes base class.** `AsyncToolBase` is a *sibling* of `Tool`
   under `_BaseTool` (`agentao/tools/base.py:140` / `:164`), not a subclass, and
   `WebFetchTool(AsyncToolBase)` (`agentao/tools/web.py:728`). A host narrowing
   the registry with `isinstance(t, Tool)` now silently skips this tool and
   should widen to `RegistrableTool`. Checked against the class statements, not
   inferred from the `RegistrableTool` union.
2. **`Agentao.arun` leaves the loop's default executor.** A host that called
   `loop.set_default_executor(...)` to size or instrument agentao's thread usage
   no longer controls this path.

## Verification

Run on this tree, not inherited from CI:

- full suite after the version bump: **3753 passed, 2 skipped** — unchanged from
  the pre-bump run on the same tree
- `write_replay_schema.py --check` / `write_host_schema.py --check`: both up to date
- `mypy --strict --package agentao.host`: clean, 7 source files
- no test pins the version literal — the two `0.4.1[78]` hits under `tests/` are
  docstring prose, and `test_acp_initialize.py` imports `__version__` dynamically
- release note carries **zero relative links** (it doubles as the `--notes-file`
  body, and GitHub resolves those against the repo root)
- every constant quoted in the release note is read from source rather than
  transcribed: `_ASYNC_CANCEL_ACK_TIMEOUT_S` 5.0, `_CPU_CANCEL_DRAIN_TIMEOUT_S`
  3.0, `_BROWSER_CANCEL_CLOSE_TIMEOUT_S` 2.0, `_BROWSER_CLOSE_TIMEOUT_S` 10.0,
  `playwright>=1.48.0`

## Not done here

No Release object is created by this PR. `publish.yml` is gated on `on: release:`
and strict-validates tag == `__version__`, so this must merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
