### PR TITLE
chore: open 0.4.19 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 _Targeting 0.4.19. Add entries under the relevant heading as work lands._
 
+### Added
+
+### Changed
+
+### Fixed
+
 ---
 
 ## [0.4.18] — 2026-07-30

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.18"
+__version__ = "0.4.19.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Opens the 0.4.19 development cycle, following #151.

## What

- `agentao/__init__.py`: `0.4.18` → `0.4.19.dev0`
- `CHANGELOG.md`: re-add the empty `### Added` / `### Changed` / `### Fixed`
  headings under `[Unreleased]` (the prep PR already retargeted the section to
  0.4.19; its previous headings were consumed by the 0.4.18 cut)

The literal is the PEP 440 canonical `0.4.19.dev0`, **not** the hyphenated
`0.4.19-dev` that the 0.4.10 and 0.4.11 cycle-opens drifted to. Both build
identically — hatchling normalizes the hyphen form in wheel/metadata — but the
hyphen form leaves `agentao.__version__` exposing a string that differs from the
distribution version.

## 0.4.18 is out

- Release: `v0.4.18`, `publish.yml` green
- `pypi.org/pypi/agentao/0.4.18/json` → HTTP 200, wheel + sdist both listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
