### PR TITLE
fix(env): present-but-empty env var no longer masks the real value in .env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ _Targeting 0.4.19. Add entries under the relevant heading as work lands._
 
 ### Fixed
 
+- **An empty ambient env var no longer permanently masks the real value in
+  `.env`.** `safe_load_dotenv` assigned via `os.environ.setdefault`, so a key
+  that was *present but empty* counted as set: no-override declined to write,
+  and every downstream `os.getenv` saw `""` forever. This is not hypothetical
+  — Claude Code injects `ANTHROPIC_API_KEY=""` into child processes to neuter
+  their LLM calls, so **any agentao invoked from a Claude Code session failed
+  with "no API key" while a valid key sat unread in `.env`**. Present-but-empty
+  (or whitespace-only) is now treated as absent; a non-empty ambient value
+  still wins, which is the part of no-override callers actually rely on. NUL
+  scrubbing — the reason this wrapper exists — is unchanged and now covered by
+  a test. See `tests/test_env_dotenv.py`.
+
 ---
 
 ## [0.4.18] — 2026-07-30

--- a/agentao/_env.py
+++ b/agentao/_env.py
@@ -23,8 +23,20 @@ def safe_load_dotenv(dotenv_path: Optional[Union[str, Path]] = None) -> None:
 
     ``dotenv_values`` parses the file in pure Python without touching
     ``os.environ``, so it does not raise on NUL-containing values. We
-    then strip NULs and assign via ``setdefault`` to match the default
-    no-override behavior of ``load_dotenv``.
+    then strip NULs and assign, preserving the default no-override
+    behavior of ``load_dotenv`` — with one deliberate exception.
+
+    **Present-but-empty is treated as absent.** A plain ``setdefault``
+    lets an empty string in the ambient environment permanently mask the
+    real value in ``.env``: the key *is* set, so no-override declines to
+    write, and every downstream ``os.getenv`` sees ``""``. That is not
+    hypothetical — Claude Code injects ``ANTHROPIC_API_KEY=""`` into
+    child processes to neuter their LLM calls, so any agentao invoked
+    from a Claude Code session fails with "no API key" while a valid key
+    sits unread in ``.env``. An empty or whitespace-only value carries no
+    configuration meaning, so letting ``.env`` fill it in loses nothing
+    and unbreaks that case. A non-empty ambient value still wins, which
+    is the part of no-override callers actually rely on.
     """
     path = str(dotenv_path) if dotenv_path is not None else find_dotenv(usecwd=True)
     if not path:
@@ -32,4 +44,6 @@ def safe_load_dotenv(dotenv_path: Optional[Union[str, Path]] = None) -> None:
     for key, value in dotenv_values(path).items():
         if value is None:
             continue
-        os.environ.setdefault(key, value.replace("\x00", ""))
+        if os.environ.get(key, "").strip():
+            continue  # a real ambient value wins (load_dotenv's no-override)
+        os.environ[key] = value.replace("\x00", "")

--- a/tests/test_env_dotenv.py
+++ b/tests/test_env_dotenv.py
@@ -1,0 +1,79 @@
+"""``safe_load_dotenv`` — NUL hygiene, no-override, and the empty-value carve-out.
+
+The carve-out exists because a plain ``setdefault`` lets an ambient empty
+string permanently mask the real value in ``.env``. Claude Code injects
+``ANTHROPIC_API_KEY=""`` into child processes, so before this change every
+agentao invoked from a Claude Code session reported "no API key" while a
+valid key sat unread in ``.env``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentao._env import safe_load_dotenv
+
+
+@pytest.fixture
+def dotenv(tmp_path: Path):
+    """Write a ``.env`` and return its path."""
+
+    def _write(text: str) -> Path:
+        path = tmp_path / ".env"
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    return _write
+
+
+def test_loads_when_key_absent(dotenv, monkeypatch):
+    monkeypatch.delenv("AGENTAO_PROBE_KEY", raising=False)
+    safe_load_dotenv(dotenv("AGENTAO_PROBE_KEY=from-dotenv\n"))
+    import os
+
+    assert os.environ["AGENTAO_PROBE_KEY"] == "from-dotenv"
+
+
+def test_real_ambient_value_still_wins(dotenv, monkeypatch):
+    """No-override is preserved for the case callers actually rely on."""
+    import os
+
+    monkeypatch.setenv("AGENTAO_PROBE_KEY", "from-environment")
+    safe_load_dotenv(dotenv("AGENTAO_PROBE_KEY=from-dotenv\n"))
+    assert os.environ["AGENTAO_PROBE_KEY"] == "from-environment"
+
+
+@pytest.mark.parametrize("poison", ["", "   ", "\t\n"])
+def test_present_but_empty_is_treated_as_absent(dotenv, monkeypatch, poison):
+    """An empty / whitespace-only ambient value must not mask ``.env``.
+
+    This is the Claude Code ``ANTHROPIC_API_KEY=""`` case: the key *is* set,
+    so ``setdefault`` used to decline, and every downstream ``os.getenv``
+    saw ``""`` forever.
+    """
+    import os
+
+    monkeypatch.setenv("AGENTAO_PROBE_KEY", poison)
+    safe_load_dotenv(dotenv("AGENTAO_PROBE_KEY=from-dotenv\n"))
+    assert os.environ["AGENTAO_PROBE_KEY"] == "from-dotenv"
+
+
+def test_nul_bytes_are_stripped(dotenv, monkeypatch):
+    """The original reason this wrapper exists: pasted keys with embedded NULs
+    crash ``os.environ[k] = v``. Guard it — the assignment moved off
+    ``setdefault`` and must keep scrubbing."""
+    import os
+
+    monkeypatch.delenv("AGENTAO_PROBE_KEY", raising=False)
+    safe_load_dotenv(dotenv('AGENTAO_PROBE_KEY="pre\x00post"\n'))
+    assert os.environ["AGENTAO_PROBE_KEY"] == "prepost"
+
+
+def test_missing_file_is_a_noop(tmp_path, monkeypatch):
+    import os
+
+    monkeypatch.delenv("AGENTAO_PROBE_KEY", raising=False)
+    safe_load_dotenv(tmp_path / "nope.env")
+    assert "AGENTAO_PROBE_KEY" not in os.environ


### PR DESCRIPTION
## The bug

`safe_load_dotenv` assigned via `os.environ.setdefault`, which treats a key that is **present but empty** as already set: no-override declines to write, and every downstream `os.getenv` sees `""` — permanently, for the life of the process.

This is not hypothetical. **Claude Code injects `ANTHROPIC_API_KEY=""` into child processes** to neuter their LLM calls, so any agentao invoked from a Claude Code session reports "no API key" while a valid key sits unread in `.env`.

Measured end to end before the fix:

```python
os.environ["ANTHROPIC_API_KEY"] = ""
safe_load_dotenv(".env")            # .env has ANTHROPIC_API_KEY=sk-real
os.getenv("ANTHROPIC_API_KEY")      # -> ''      (masked)
discover_llm_kwargs()["api_key"]    # -> ''      (propagates)
```

## The fix

Present-but-empty (or whitespace-only) is treated as absent. A **non-empty** ambient value still wins — that is the part of no-override callers actually rely on, and it stays.

An empty value carries no configuration meaning, so letting `.env` fill it in loses nothing.

## Why not fix it in `discover_llm_kwargs`

Tempting one-liner: skip the empty value at the read site (`if (v := os.getenv(...)) is not None and v.strip()`). **That is not sufficient** — it only turns `api_key=''` into a missing key. The real key in `.env` still never loads, because the mask is applied *before* discovery ever runs. The fix has to be in the loader.

## Tests

New `tests/test_env_dotenv.py` — 7 cases: absent key loads · real ambient value wins (no-override preserved) · present-but-empty × three whitespace shapes overridden · NUL stripped · missing file is a no-op.

NUL scrubbing is the original reason this wrapper exists, and the assignment moved off `setdefault`, so it is now pinned by a test rather than assumed.

Verified the three empty-value cases **fail** against the old `setdefault` and pass after. Full suite: **3760 passed / 2 skipped**.

## Context

Surfaced by a reverse review of `garrytan/gbrain` #1249, which hit the same class of bug in TypeScript (an unconditional `process.env` spread letting the injected empty string override a valid config key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)