### PR TITLE
fix(tools): fold compatibility forms (NFKC) before fuzzy edit matching

### DIFF
--- a/agentao/tools/file_ops.py
+++ b/agentao/tools/file_ops.py
@@ -3,6 +3,7 @@
 import difflib
 import os
 import re
+import unicodedata
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -17,8 +18,10 @@ MAX_LINE_LENGTH = 2000
 BINARY_CHECK_SIZE = 8192
 
 # Codepoint table copied from codex-rs/apply-patch/src/seek_sequence.rs:79-92.
-# Mirrors the fuzzy behaviour of `git apply` — applied as the final fallback
-# in EditTool's match pyramid so byte-identical edits are unaffected.
+# Mirrors the fuzzy behaviour of `git apply`. This is the half of
+# ``_edit_normalize_for_match`` that NFKC cannot do; see that function for why
+# both passes exist. Applied as the final fallback in EditTool's match pyramid,
+# so byte-identical edits are unaffected.
 _EDIT_DASHES = "‐‑‒–—―−"
 _EDIT_SQUOTES = "‘’‚‛"
 _EDIT_DQUOTES = "“”„‟"
@@ -37,8 +40,21 @@ _EDIT_NORMALIZE_TABLE = str.maketrans(
 
 
 def _edit_normalize_for_match(s: str) -> str:
-    """Map common typographic codepoints to ASCII for fuzzy edit matching."""
-    return s.translate(_EDIT_NORMALIZE_TABLE)
+    """Map common typographic codepoints to ASCII for fuzzy edit matching.
+
+    Two passes, because neither subsumes the other. NFKC folds compatibility
+    variants the table has no entries for — most importantly full-width forms
+    (``Ａ`` → ``A``, ``（`` → ``(``, ``；`` → ``;``), which is what makes this
+    tier usable on a CJK source file mixing 全角 and 半角 punctuation. But
+    NFKC leaves smart quotes and en/em dashes alone (they have no
+    compatibility decomposition), and those are exactly what the table covers.
+
+    Order matters: NFKC runs first so a compatibility form that folds *into* a
+    table entry still reaches ASCII. U+FE31 ``︱`` and U+FE58 ``﹘`` (CJK
+    compatibility dashes) fold to U+2014, and U+207B ``⁻`` / U+208B ``₋`` fold
+    to U+2212; table-first would strand all four one step short.
+    """
+    return unicodedata.normalize("NFKC", s).translate(_EDIT_NORMALIZE_TABLE)
 
 
 # Success-message suffixes for non-exact match tiers. Tests assert against these,

--- a/tests/test_edit_unicode_fuzzy.py
+++ b/tests/test_edit_unicode_fuzzy.py
@@ -10,6 +10,11 @@ Tier 3 mirrors the fuzzy behaviour of `git apply` — it covers the case where
 the LLM emits ASCII punctuation but the source file (or vice versa) contains
 typographic Unicode (smart quotes, em-dash, NBSP, …). Higher tiers run first,
 so byte-identical edits never reach this code path.
+
+Tier 3 normalizes in two passes (NFKC, then a codepoint table). The
+``TestNfkcFolding`` class below pins the half NFKC contributes — full-width
+punctuation, which the table has no entries for and which is the common case
+in a CJK source file.
 """
 
 from __future__ import annotations
@@ -103,6 +108,104 @@ def test_mixed_typography_normalized(project_root):
 
     assert _EDIT_SUFFIX_UNICODE in result
     assert target.read_text() == 'say "hi" then continue\n'
+
+
+# ---------------------------------------------------------------------------
+# NFKC half of tier 3 — compatibility forms the codepoint table cannot reach
+# ---------------------------------------------------------------------------
+
+
+class TestNfkcFolding:
+    """Full-width and other compatibility forms must fold before matching.
+
+    The codepoint table only knows dashes, quotes and spaces, so before NFKC
+    every one of these fell through tier 3 to ``_not_found_hint``. Borrowed
+    from pi-mono ``edit-diff.ts::normalizeForFuzzyMatch``.
+    """
+
+    def test_fullwidth_punctuation_in_source_matches_ascii_prompt(self, project_root):
+        """The CJK case: source written with 全角 punctuation, prompt in 半角."""
+        target = project_root / "cjk.py"
+        target.write_text('print（"你好"）；\n')
+
+        tool = _bind(EditTool(), project_root)
+        result = tool.execute(
+            file_path="cjk.py",
+            old_text='print("你好");',
+            new_text='print("世界")',
+        )
+
+        assert _EDIT_SUFFIX_UNICODE in result
+        assert target.read_text() == 'print("世界")\n'
+
+    def test_fullwidth_alphanumerics_fold_to_ascii(self, project_root):
+        target = project_root / "fw.txt"
+        target.write_text("ＴＯＴＡＬ＝４２\n")
+
+        tool = _bind(EditTool(), project_root)
+        result = tool.execute(
+            file_path="fw.txt",
+            old_text="TOTAL=42",
+            new_text="TOTAL=43",
+        )
+
+        assert _EDIT_SUFFIX_UNICODE in result
+        assert target.read_text() == "TOTAL=43\n"
+
+    def test_prompt_is_fullwidth_and_source_is_ascii(self, project_root):
+        """Reverse direction: the *model* emitted 全角. Both sides normalize,
+        so tier 3 must still land."""
+        target = project_root / "rev.txt"
+        target.write_text("total = 42\n")
+
+        tool = _bind(EditTool(), project_root)
+        result = tool.execute(
+            file_path="rev.txt",
+            old_text="ｔｏｔａｌ　＝　４２",
+            new_text="total = 43",
+        )
+
+        assert _EDIT_SUFFIX_UNICODE in result
+        assert target.read_text() == "total = 43\n"
+
+    def test_nfkc_runs_before_the_codepoint_table(self, project_root):
+        """Ordering regression.
+
+        U+FE58 ``﹘`` (CJK compatibility small em-dash) has no table entry.
+        NFKC folds it to U+2014, which the table then maps to ASCII ``-``.
+        Table-first would strand it one step short and this falls to tier 4.
+        """
+        target = project_root / "order.txt"
+        target.write_text("a ﹘ b\n")
+
+        tool = _bind(EditTool(), project_root)
+        result = tool.execute(
+            file_path="order.txt",
+            old_text="a - b",
+            new_text="a + b",
+        )
+
+        assert _EDIT_SUFFIX_UNICODE in result
+        assert target.read_text() == "a + b\n"
+
+    def test_fullwidth_on_both_sides_still_uses_tier_1(self, project_root):
+        """NFKC must not steal a byte-exact match. A file and prompt that agree
+        on 全角 punctuation is tier 1, and the file keeps whatever new_text says.
+        """
+        target = project_root / "both_fw.py"
+        target.write_text('print（"你好"）\n')
+
+        tool = _bind(EditTool(), project_root)
+        result = tool.execute(
+            file_path="both_fw.py",
+            old_text='print（"你好"）',
+            new_text='print（"世界"）',
+        )
+
+        assert "Replaced" in result
+        assert _EDIT_SUFFIX_UNICODE not in result
+        assert _EDIT_SUFFIX_FLEXIBLE not in result
+        assert target.read_text() == 'print（"世界"）\n'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`EditTool`'s match pyramid ends at tier 3 with a codepoint table (dashes, quotes, spaces) copied from codex-rs `seek_sequence.rs`. The table has no entries for Unicode **compatibility forms**, so an edit whose `old_text` differs from the file only by full-width punctuation falls straight through to `_not_found_hint`.

In a CJK source file mixing 全角 and 半角 that is the common case, not an exotic one:

```python
# file:   print（"你好"）；
# prompt: print("你好");
# before: Error: Old text not found
```

## Fix

`agentao/tools/file_ops.py::_edit_normalize_for_match` now runs **NFKC first, then the table**.

Both passes are needed; neither subsumes the other:

| | full-width `（` `Ａ` `；` | ligatures `ﬁ` | space variants | smart quotes `“ ”` | en/em dash `– —` |
|---|---|---|---|---|---|
| NFKC | ✅ | ✅ | ✅ | ❌ | ❌ |
| codepoint table | ❌ | ❌ | ✅ | ✅ | ✅ |

### Ordering is load-bearing

Sweeping the Unicode planes finds exactly five characters that NFKC folds *into* a table entry without being in the table themselves:

`U+207B ⁻` · `U+208B ₋` · `U+FE31 ︱` · `U+FE32 ︲` · `U+FE58 ﹘`

The last three are CJK compatibility dashes. Table-first strands all five one step short of ASCII. `test_nfkc_runs_before_the_codepoint_table` is the tripwire.

### Why no byte-offset risk

NFKC changes string length, but `line_transform` is only used to build per-line comparison keys — the prefix table is built from the original `content_lines` lengths (`file_ops.py:322-332`), so spliced spans still index the original content. That is why this needs none of the preserve-unchanged-lines machinery pi-mono's equivalent carries.

Tier 3 is only reached after tiers 1 and 2 both miss, so byte-identical and whitespace-only-different edits are unaffected. The only behaviour change is that inputs which previously errored may now match.

## Tests

New `TestNfkcFolding` (5 cases) in `tests/test_edit_unicode_fuzzy.py`: full-width punctuation, full-width alphanumerics, the reverse direction (model emits 全角 against an ASCII file), the ordering regression, and a guard that NFKC does not steal a byte-exact match from tier 1.

**Both counterfactuals were run before landing**, so these are tripwires rather than restatements:

- revert to table-only → 4 of 5 fail, tier-1 guard correctly still passes
- table-first-then-NFKC → exactly the ordering test fails

Full suite: `3783 passed, 2 skipped`.

## Provenance

Borrowed from pi-mono `packages/agent/src/harness/tools/edit-diff.ts::normalizeForFuzzyMatch` (2026-08-02 pull review). agentao already had the codex table half; NFKC was the missing half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)