### PR TITLE
fix(transport): log listener exceptions instead of swallowing them silently

### DIFF
--- a/agentao/transport/broadcast.py
+++ b/agentao/transport/broadcast.py
@@ -7,12 +7,16 @@ transport's ``emit`` calls its primary side-effect first, then
 the inner transport just consumed.
 
 Listener errors are swallowed — subscription is a side channel and
-must never break the primary emit path.
+must never break the primary emit path — but they are logged at
+WARNING, not dropped silently. See :meth:`EventBroadcaster.notify`.
 """
 
+import logging
 from typing import Callable, List
 
 from .events import AgentEvent
+
+_logger = logging.getLogger(__name__)
 
 EventListener = Callable[[AgentEvent], None]
 
@@ -36,7 +40,26 @@ class EventBroadcaster:
         return _unsubscribe
 
     def notify(self, event: AgentEvent) -> None:
-        """Call every listener in order; swallow any exceptions they raise."""
+        """Call every listener in order; log-and-swallow anything they raise.
+
+        Swallowing keeps a broken subscriber from breaking the emit path.
+        Logging is what makes the swallow debuggable: the symptom a host
+        sees is "my listener does nothing", and without this record there
+        is no trace of the cause anywhere. WARNING-and-swallow is the
+        convention the host contract already documents for the other
+        side-channel sink, ``HostReplaySink`` (docs/reference/host-api.md).
+
+        Logged rather than re-emitted as an error *event*: an event would
+        re-enter this same loop, so a listener that raises on everything
+        would spin forever. (pi-mono's ``handler_error`` event carries an
+        explicit recursion guard for exactly that reason; a log call has
+        no such edge.)
+
+        Only ``event.type`` is recorded, never ``event.data``. Payloads
+        carry tool arguments, full tool results and LLM text — large, and
+        the credential redaction lives on agentao's *own* file handler, so
+        an embedded host's handlers would receive the payload unredacted.
+        """
         if not self._listeners:
             return
         # Snapshot iteration keeps mid-notify subscribe/unsubscribe from
@@ -46,7 +69,13 @@ class EventBroadcaster:
             try:
                 listener(event)
             except Exception:
-                pass
+                _logger.warning(
+                    "event listener %r raised while handling %s; "
+                    "delivery continues to the remaining listeners",
+                    listener,
+                    event.type.value,
+                    exc_info=True,
+                )
 
     def listener_count(self) -> int:
         return len(self._listeners)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,5 +1,7 @@
 """Tests for the Transport abstraction layer."""
 
+import logging
+
 from agentao.transport import (
     AgentEvent,
     EventType,
@@ -81,6 +83,88 @@ class TestSdkTransport:
 
     def test_satisfies_transport_protocol(self):
         assert isinstance(SdkTransport(), Transport)
+
+
+class TestSubscriberErrorReporting:
+    """A raising subscriber is swallowed — but not silently.
+
+    Swallowing keeps the side channel from breaking the emit path; the
+    WARNING is what makes it debuggable. Without it the only symptom a
+    host gets is "my listener does nothing", with nothing in any log to
+    explain why.
+    """
+
+    def test_raising_subscriber_does_not_break_emit(self):
+        t = SdkTransport()
+        t.subscribe(lambda e: (_ for _ in ()).throw(RuntimeError("oops")))
+        t.emit(AgentEvent(EventType.TURN_START))  # must not raise
+
+    def test_raising_subscriber_does_not_stop_later_subscribers(self):
+        seen = []
+        t = SdkTransport()
+        t.subscribe(lambda e: (_ for _ in ()).throw(RuntimeError("oops")))
+        t.subscribe(seen.append)
+        e = AgentEvent(EventType.TURN_START)
+        t.emit(e)
+        assert seen == [e]
+
+    def test_subscriber_error_is_logged_with_event_type(self, caplog):
+        def boom(event):
+            raise RuntimeError("listener blew up")
+
+        t = SdkTransport()
+        t.subscribe(boom)
+        with caplog.at_level(logging.WARNING, logger="agentao.transport.broadcast"):
+            t.emit(AgentEvent(EventType.TOOL_START, {"tool": "shell"}))
+
+        records = [r for r in caplog.records if r.name == "agentao.transport.broadcast"]
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
+        # The event type is what lets a host find which emit site broke.
+        assert "tool_start" in records[0].getMessage()
+        # exc_info carries the traceback — a swallowed exception with no
+        # stack is barely more useful than silence.
+        assert records[0].exc_info is not None
+        assert "listener blew up" in caplog.text
+
+    def test_subscriber_error_log_omits_event_payload(self, caplog):
+        """``event.data`` must never reach the log record.
+
+        Payloads carry tool arguments, full tool results and LLM text.
+        Credential redaction lives on agentao's *own* file handler, so a
+        payload logged here would reach an embedded host's handlers
+        unredacted — and the type alone is what identifies the emit site.
+        """
+        def boom(event):
+            raise RuntimeError("nope")
+
+        t = SdkTransport()
+        t.subscribe(boom)
+        with caplog.at_level(logging.WARNING, logger="agentao.transport.broadcast"):
+            t.emit(
+                AgentEvent(
+                    EventType.TOOL_START,
+                    {"tool": "shell", "args": {"cmd": "curl -H 'Authorization: sk-secret'"}},
+                )
+            )
+
+        # Assert the record exists FIRST. Without this the payload
+        # assertions below pass vacuously the moment logging is removed
+        # or the logger is renamed — a spy that reports success because
+        # it never observed anything.
+        records = [r for r in caplog.records if r.name == "agentao.transport.broadcast"]
+        assert len(records) == 1
+        assert "tool_start" in records[0].getMessage()
+
+        assert "sk-secret" not in caplog.text
+        assert "Authorization" not in caplog.text
+
+    def test_no_log_when_subscriber_succeeds(self, caplog):
+        t = SdkTransport()
+        t.subscribe(lambda e: None)
+        with caplog.at_level(logging.WARNING, logger="agentao.transport.broadcast"):
+            t.emit(AgentEvent(EventType.TURN_START))
+        assert [r for r in caplog.records if r.name == "agentao.transport.broadcast"] == []
 
 
 class TestBuildCompatTransport:


### PR DESCRIPTION
## Problem

`EventBroadcaster.notify` caught every subscriber exception with a bare `except Exception: pass` — no log, no counter, nothing:

```python
for listener in list(self._listeners):
    try:
        listener(event)
    except Exception:
        pass
```

Swallowing is correct and stays — a subscriber is a side channel and must never break the emit path. Being *silent* about it is not. The only symptom an embedded host gets is "my listener does nothing", with no record anywhere of the cause, and the swallow sits three call frames away from any code they wrote.

WARNING-and-swallow is already the documented convention for the other side-channel sink on this contract: `HostReplaySink` errors are "logged at WARNING and swallowed" (`docs/reference/host-api.md:204`). `broadcast.py` was the one place that didn't follow it.

## Three choices worth naming

All recorded in the `notify` docstring.

**Logged, not re-emitted as an error event.** An event would re-enter `notify`, so a listener that raises on everything would spin forever. This is why pi-mono's `handler_error` event — the design this borrows from — carries an explicit recursion guard. A log call has no such edge, so agentao needs none of that machinery.

**`event.type` only, never `event.data`.** Payloads carry tool arguments, full tool results and LLM text. The credential redaction is a `Formatter` on agentao's own file handler, deliberately *not* a `Filter`, precisely so it doesn't leak into an embedded host's handlers — which means a payload logged here would reach those handlers **unredacted**. The type alone identifies the emit site.

**`exc_info=True`.** A swallowed exception with no stack is barely better than silence.

## Tests

New `TestSubscriberErrorReporting` (5 cases): emit survives a raising subscriber; later subscribers still receive; the failure is logged at WARNING with the event type and a traceback; the payload never reaches the log; nothing is logged on success.

**Both counterfactuals were run before landing:**

| counterfactual | result |
|---|---|
| revert to silent swallow | `test_subscriber_error_is_logged_with_event_type` fails |
| log `event.to_dict()` instead of the type | `test_subscriber_error_log_omits_event_payload` fails, with the planted `sk-secret` visible in the captured output |

The payload test also asserts the record **exists** before asserting what's absent — without that it passed vacuously, since `"sk-secret" not in caplog.text` is trivially true when nothing was logged at all.

Full suite: `3788 passed, 2 skipped`.

## Provenance

Borrowed from pi-mono's `handler_error` (`harness-v2.md` §10 / `harness.md` §9). Note it is **design-only there** — zero hits in `packages/agent/src` and `packages/coding-agent/src`; what ships in pi today is the narrower extensions-only `ExtensionError`.

The hook half of that design already has an agentao equivalent and is untouched here: plugin hooks are subprocesses, so their timeout / spawn-failure / non-zero-exit paths are each already logged (`agentao/plugins/hooks/_dispatcher.py:273,278,333`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)