### PR TITLE
feat(runtime): report when a provider never said why generation stopped

### DIFF
--- a/agentao/cli/run.py
+++ b/agentao/cli/run.py
@@ -638,9 +638,11 @@ def _run_pipeline(
     tool_calls_count = 0
     captured_turn_id: Optional[str] = None
     incomplete_reason: Optional[str] = None
+    finish_reason_missing = False
 
     def _on_tool_event(event: Any) -> None:
         nonlocal tool_calls_count, captured_turn_id, incomplete_reason
+        nonlocal finish_reason_missing
         ev_type = getattr(event, "type", None)
         # ``run_turn`` clears ``agent._current_turn_id`` in its finally
         # block, so by the time we serialize RunResult the field is
@@ -653,8 +655,13 @@ def _run_pipeline(
         # classifier below turns that into a non-zero exit so a pipeline
         # can't read "the model said nothing" as success.
         if ev_type == EventType.TURN_END:
-            incomplete_reason = (getattr(event, "data", None) or {}).get(
-                "incomplete_reason"
+            _turn_data = getattr(event, "data", None) or {}
+            incomplete_reason = _turn_data.get("incomplete_reason")
+            # Reported on the envelope, never fed to ``_classify_outcome``:
+            # exiting non-zero on this would fail every run against a provider
+            # that never sends finish_reason. See RunResult.
+            finish_reason_missing = bool(
+                _turn_data.get("finish_reason_missing", False)
             )
             return
         # ToolExecutor fires TOOL_START *before* the deny check, so
@@ -722,6 +729,7 @@ def _run_pipeline(
         replay_path=replay_path,
         usage=usage,
         tool_calls=tool_calls_count,
+        finish_reason_missing=finish_reason_missing,
         warnings=warnings,
     )
 

--- a/agentao/cli/run_models.py
+++ b/agentao/cli/run_models.py
@@ -292,6 +292,17 @@ class RunResult(BaseModel):
     replay_path: Optional[str] = None
     usage: Optional[RunUsage] = None
     tool_calls: Optional[int] = None
+    #: True when at least one LLM call in the turn ended without the provider
+    #: reporting *why* generation stopped, so ``final_text`` may be a truncated
+    #: fragment that agentao's ``"stop"`` fallback presented as complete.
+    #:
+    #: Deliberately does **not** affect ``status`` or the exit code: the
+    #: servers that omit the field omit it on every call, so gating on it would
+    #: fail every run against them. A pipeline that wants the strict reading
+    #: checks this key itself. Without it the fact is unreachable from
+    #: ``agentao run`` — there is no ``TurnOutcome`` on that surface, only this
+    #: envelope.
+    finish_reason_missing: bool = False
     warnings: List[str] = Field(default_factory=list)
 
     model_config = ConfigDict(extra="ignore")

--- a/agentao/context_manager.py
+++ b/agentao/context_manager.py
@@ -90,6 +90,19 @@ class ContextManager:
         # Circuit breaker: stop auto-compact after too many consecutive failures
         self._consecutive_compact_failures: int = 0
 
+        # True when the most recent ``_summarize_messages`` call ended without
+        # the provider reporting a finish_reason. That call does not go through
+        # ``ChatLoopRunner`` — it is issued straight against ``llm_client`` —
+        # so the runner's detector never sees it, yet it is the one call whose
+        # output *permanently replaces* conversation history. A truncated
+        # summary is inherited by every later turn.
+        #
+        # Recorded here rather than written to the agent directly: this class
+        # deliberately holds no agent reference (it borrows ``llm_client`` and
+        # ``memory_tool``). The compaction call sites in
+        # ``runtime/chat_loop/_compaction.py`` own turn state and fold it in.
+        self.last_summary_finish_reason_missing: bool = False
+
         # Stats from the last completed compaction (surfaced via get_usage_stats)
         self._last_compact_stats: Optional[Dict[str, Any]] = None
 
@@ -559,6 +572,11 @@ class ContextManager:
         Returns:
             Formatted summary text, or empty string on failure.
         """
+        # Per-call, so the flag describes *this* summarization and not one
+        # from an earlier compaction. ``run_turn`` additionally clears it per
+        # turn, for the case where ``compress_messages`` returns without ever
+        # reaching this method.
+        self.last_summary_finish_reason_missing = False
         try:
             to_summarize = [
                 m for m in messages
@@ -573,6 +591,12 @@ class ContextManager:
                 {"role": "user", "content": f"Summarize this conversation:\n\n{formatted}"},
             ]
             response = self.llm_client.chat(messages=recall_messages, tools=None)
+            # Same two-producer test the chat loop applies (see
+            # ``runtime/chat_loop/_runner.py``): a falsy finish_reason, or a
+            # streamed response whose provider never sent one.
+            _fr = getattr(response.choices[0], "finish_reason", None)
+            if not _fr or not getattr(response, "finish_reason_reported", True):
+                self.last_summary_finish_reason_missing = True
             raw = response.choices[0].message.content or ""
             return self._format_summary(raw)
         except Exception as e:

--- a/agentao/llm/_logging.py
+++ b/agentao/llm/_logging.py
@@ -231,7 +231,20 @@ class _LoggingMixin:
 
         # Log basic info
         self.logger.info(f"Model: {response.model}")
-        self.logger.info(f"Finish Reason: {choice.finish_reason}")
+        # When the provider never sent a finish_reason the value above is
+        # agentao's own "stop" fallback, so the bare line would assert a clean
+        # provider-confirmed stop for a stream that may have been cut off.
+        # agentao.log is the documented first stop for debugging LLM behaviour
+        # (CLAUDE.md), so the qualifier has to be here and not only on
+        # ``TurnOutcome``.
+        if getattr(response, "finish_reason_reported", True):
+            self.logger.info(f"Finish Reason: {choice.finish_reason}")
+        else:
+            self.logger.info(
+                f"Finish Reason: {choice.finish_reason} "
+                "(NOT reported by provider — agentao fallback; the stream "
+                "ended without one, so this response may be truncated)"
+            )
 
         # Log usage stats if available
         if hasattr(response, 'usage') and response.usage:

--- a/agentao/llm/_stream_response.py
+++ b/agentao/llm/_stream_response.py
@@ -47,6 +47,18 @@ class _StreamAccumulator:
         self._tc_last_key: Optional[int] = None
         self._tc_next_key: int = 0
         self.finish_reason: str = "stop"
+        # Whether the provider ever sent a ``finish_reason``. The default
+        # above is a *fallback*, not an observation: a stream that ends
+        # without one (a gateway closing the SSE body after its own upstream
+        # timeout, a partially-compatible local server) is otherwise
+        # indistinguishable from a clean completion, and the turn is reported
+        # as a finished answer. Kept separate from ``finish_reason`` so the
+        # fallback stays "stop" on the wire — flipping it to ``None`` would
+        # change LLM_CALL_COMPLETED payloads and replay renders for every
+        # provider that omits the field. Surfaced on the built response and
+        # folded into ``TurnOutcome.finish_reason_missing``; it never changes
+        # control flow here.
+        self.finish_reason_reported: bool = False
         self.response_model: str = model
         self.usage_data: Any = None
         # True only after on_text_chunk has fired with non-empty text — i.e.,
@@ -91,6 +103,7 @@ class _StreamAccumulator:
             content="".join(self.content_parts) if self.content_parts else None,
             tool_calls_data=self.tool_calls_data,
             finish_reason=self.finish_reason,
+            finish_reason_reported=self.finish_reason_reported,
             usage=self.usage_data,
             reasoning_content="".join(self.reasoning_parts) if self.reasoning_parts else None,
         )
@@ -137,11 +150,26 @@ class _StreamResponse:
         content: Optional[str],
         tool_calls_data: Dict[int, Dict[str, str]],
         finish_reason: str,
+        finish_reason_reported: bool,
         usage: Any = None,
         reasoning_content: Optional[str] = None,
     ):
         self.model = model
         self.usage = usage  # populated when provider supports stream_options include_usage
+        # False when the stream ended without the provider ever sending a
+        # ``finish_reason`` — ``choices[0].finish_reason`` is then the "stop"
+        # fallback rather than something the provider said. A real
+        # ``ChatCompletion`` has no such attribute, so readers use
+        # ``getattr(response, "finish_reason_reported", True)``; on that path
+        # the same condition shows up as a falsy ``finish_reason``.
+        #
+        # Required, deliberately: a default would have to be ``True`` to match
+        # the getattr fallback, and a second construction site that forgot the
+        # kwarg would then assert the provider reported a stop reason for a
+        # stream that never did — failing open, silently, with no test able to
+        # catch it. ``build()`` is the only caller today; keep it that way or
+        # pass the value.
+        self.finish_reason_reported = finish_reason_reported
 
         tool_calls = None
         if tool_calls_data:

--- a/agentao/llm/client.py
+++ b/agentao/llm/client.py
@@ -763,6 +763,7 @@ class LLMClient(_LoggingMixin):
 
             if choice.finish_reason:
                 acc.finish_reason = choice.finish_reason
+                acc.finish_reason_reported = True
 
             if hasattr(chunk, "model") and chunk.model:
                 acc.response_model = chunk.model

--- a/agentao/replay/adapter.py
+++ b/agentao/replay/adapter.py
@@ -74,6 +74,7 @@ class ReplayAdapter:
         error: Optional[str] = None,
         tool_count: Optional[int] = None,
         incomplete_reason: Optional[str] = None,
+        finish_reason_missing: bool = False,
     ) -> None:
         turn_id = self._turn_id
         if turn_id is None:
@@ -92,6 +93,12 @@ class ReplayAdapter:
             # turn and give a triager no way to see why the run reported a
             # failure.
             payload["incomplete_reason"] = incomplete_reason
+        if finish_reason_missing:
+            # Only written when true, like ``incomplete_reason``: an audit
+            # trail of a turn whose provider never said why it stopped is the
+            # whole point of recording it, but stamping ``false`` on every
+            # ordinary turn would bloat every replay file for no signal.
+            payload["finish_reason_missing"] = True
         self._recorder.record(
             EventKind.TURN_COMPLETED,
             turn_id=turn_id,
@@ -266,6 +273,9 @@ class ReplayAdapter:
                     tool_count=tc if isinstance(tc, int) else None,
                     incomplete_reason=(
                         incomplete if isinstance(incomplete, str) else None
+                    ),
+                    finish_reason_missing=bool(
+                        data.get("finish_reason_missing", False)
                     ),
                 )
             except Exception:

--- a/agentao/runtime/chat_loop/_compaction.py
+++ b/agentao/runtime/chat_loop/_compaction.py
@@ -70,6 +70,12 @@ class _CompactionMixin:
         pre_tokens = agent.context_manager.estimate_tokens(messages_with_system)
         pre_msgs = len(agent.messages)
         agent.messages = agent.context_manager.compress_messages(agent.messages, is_auto=True)
+        # The summarization LLM call bypasses the runner's detector (it goes
+        # straight to ``llm_client``), so fold its observation in here. This is
+        # the call whose output permanently rewrites history, so a turn that
+        # compacted against an unconfirmed summary must say so.
+        if agent.context_manager.last_summary_finish_reason_missing:
+            agent._turn_finish_reason_missing = True
         agent.context_manager.invalidate_token_anchor()  # prefix rewritten; real count is stale
         system_prompt = agent._build_system_prompt()
         messages_with_system = [

--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -396,6 +396,36 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             assistant_message = response.choices[0].message
             finish_reason = getattr(response.choices[0], "finish_reason", None)
 
+            # Did the provider actually say why generation stopped? Two
+            # producers, one question: the streaming path carries an explicit
+            # flag (its ``finish_reason`` falls back to "stop"), while a real
+            # ChatCompletion that omits the field simply reports ``None``.
+            #
+            # Sticky for the whole turn, set by *any* call — not just the last.
+            # An intermediate call that ends without a finish_reason may have
+            # had its tool-call arguments cut off with nothing to detect it:
+            # ``_is_length_truncation`` never fires, so those arguments are
+            # executed. That is the sharper hazard, and it is invisible if only
+            # the final call is inspected.
+            #
+            # Reported, never acted on. This deliberately does NOT join
+            # ``INCOMPLETE_ANSWER_REASONS`` (see that set's comment): every
+            # value there becomes a CLI error envelope, which would turn a
+            # merely-unconfirmed turn into a hard failure for every provider
+            # that omits the field — the strict behaviour agentao chose not to
+            # adopt. It rides its own axis, like ``max_iterations``.
+            # ``not finish_reason`` rather than ``is None``: the streaming
+            # recorder gates on truthiness (``if choice.finish_reason:`` in
+            # client.py), so a provider sending ``""`` leaves the flag False
+            # there. Testing ``is None`` here would call the identical ``""``
+            # reported, and the answer would then depend on whether the turn
+            # happened to take the streaming or the bypass path — a transport
+            # detail no host can see.
+            if not finish_reason or not getattr(
+                response, "finish_reason_reported", True
+            ):
+                agent._turn_finish_reason_missing = True
+
             if assistant_message.tool_calls:
                 if _is_length_truncation(finish_reason):
                     # The message hit the output-token limit mid-stream, so the
@@ -1102,6 +1132,10 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             t0 = time.monotonic()
             pre_msgs = len(agent.messages)
             agent.messages = agent.context_manager.compress_messages(agent.messages)
+            # Same fold-in as the threshold path in ``_compaction.py``: the
+            # summarization call never passes the detector above.
+            if agent.context_manager.last_summary_finish_reason_missing:
+                agent._turn_finish_reason_missing = True
             agent.context_manager.invalidate_token_anchor()  # prefix rewritten; anchor is stale
             system_prompt = agent._build_system_prompt()
             messages_with_system = [

--- a/agentao/runtime/llm_call.py
+++ b/agentao/runtime/llm_call.py
@@ -163,12 +163,20 @@ def run_llm_call(
         raise
 
     finish_reason: Optional[str] = None
+    # False when the value above is agentao's "stop" fallback rather than
+    # something the provider sent. Additive key on LLM_CALL_COMPLETED so a
+    # per-call consumer can tell the two apart; ``finish_reason`` itself keeps
+    # its existing value so payloads and replay renders do not shift.
+    finish_reason_reported: bool = True
     prompt_tokens: Optional[int] = None
     completion_tokens: Optional[int] = None
     try:
         choices = getattr(response, "choices", None)
         if choices:
             finish_reason = getattr(choices[0], "finish_reason", None)
+        finish_reason_reported = bool(
+            finish_reason
+        ) and getattr(response, "finish_reason_reported", True)
         usage = getattr(response, "usage", None)
         if usage is not None:
             prompt_tokens = getattr(usage, "prompt_tokens", None)
@@ -186,6 +194,7 @@ def run_llm_call(
         "error_class": None,
         "error_message": None,
         "finish_reason": finish_reason,
+        "finish_reason_reported": finish_reason_reported,
         "prompt_tokens": prompt_tokens,
         "completion_tokens": completion_tokens,
     }))

--- a/agentao/runtime/outcome.py
+++ b/agentao/runtime/outcome.py
@@ -31,6 +31,11 @@ class TurnOutcome:
                             ``length_truncated`` / ``doom_loop`` / ``llm_error``.
         tool_count        — tool calls the model made across the turn
         error             — error detail when ``status != "ok"``, else ``None``
+        finish_reason_missing
+                          — at least one LLM call in this turn ended without
+                            the provider reporting *why* generation stopped.
+                            See below; ``False`` on a cancelled turn, where the
+                            absence is explained by the cancellation itself.
     """
 
     text: str
@@ -38,6 +43,22 @@ class TurnOutcome:
     incomplete_reason: Optional[str]
     tool_count: int
     error: Optional[str] = None
+    #: A separate axis from ``incomplete_reason``, deliberately.
+    #:
+    #: A stream can end without the provider ever sending ``finish_reason`` —
+    #: a gateway closing the SSE body after its own upstream timeout, or a
+    #: partially-compatible local server that never emits the field. agentao
+    #: falls back to ``"stop"``, so such a turn is otherwise indistinguishable
+    #: from a clean completion: the text may be a truncated fragment reported
+    #: as a finished answer.
+    #:
+    #: This flag reports that, and nothing more. It does **not** make the turn
+    #: incomplete and does **not** affect :attr:`is_answer`, because for the
+    #: servers that simply never send the field, every turn would otherwise
+    #: become a failure. Hosts that would rather be strict can treat
+    #: ``finish_reason_missing`` as fatal themselves; hosts on a known-lenient
+    #: provider can keep ignoring it. agentao does not guess which you are.
+    finish_reason_missing: bool = False
 
     @property
     def is_answer(self) -> bool:
@@ -47,6 +68,12 @@ class TurnOutcome:
         reply: the turn ended ``"ok"`` and nothing classified it as incomplete.
         A cancelled or errored turn, or one the harness could not get an answer
         out of, is ``False``.
+
+        :attr:`finish_reason_missing` is deliberately *not* part of this: the
+        answer is complete as far as anything agentao can observe, and the
+        providers that omit the field omit it on every call. A host that wants
+        the stricter reading writes ``o.is_answer and not
+        o.finish_reason_missing``.
         """
         return self.status == "ok" and self.incomplete_reason is None
 

--- a/agentao/runtime/turn.py
+++ b/agentao/runtime/turn.py
@@ -91,6 +91,18 @@ def run_turn(
     # rejects outright, and under ``from __future__ import annotations`` the
     # annotation is inert anyway — it matches the un-annotated sibling above.
     agent._turn_incomplete_reason = None
+    # Turn-level "at least one LLM call in this turn ended without the
+    # provider reporting a finish_reason" flag, typed bool. Set by the chat
+    # loop; reset per turn like the two above.
+    agent._turn_finish_reason_missing = False
+    # The compaction summarizer records its own observation on the context
+    # manager (it bypasses the chat loop's detector); clear it here so a
+    # truncated summary from an earlier turn cannot leak into this one's flag
+    # via a ``compress_messages`` call that never re-summarizes.
+    try:
+        agent.context_manager.last_summary_finish_reason_missing = False
+    except Exception:
+        pass
     # Snapshot the latest session-summary id so the inner loop can
     # fire SESSION_SUMMARY_WRITTEN each time compress_messages writes
     # a new one. Held on the instance so compression paths inside the
@@ -181,12 +193,29 @@ def run_turn(
             if status == "ok"
             else None
         )
+        # Cancellation is suppressed, errors are not — the two differ.
+        #
+        # A cancelled turn breaks out of the chunk loop before any
+        # finish_reason can arrive, so the flag would fire on *every*
+        # cancellation and say nothing ``status`` does not already say.
+        #
+        # An errored turn is the opposite case: a stream truncated mid
+        # tool-call arguments can get those arguments repaired into something
+        # parseable-but-wrong, run the tool, and raise. Reporting ``False``
+        # there would tell a triager the provider confirmed a clean stop for
+        # the very turn it truncated — the case this field exists to expose.
+        finish_reason_missing = (
+            bool(getattr(agent, "_turn_finish_reason_missing", False))
+            if status != "cancelled"
+            else False
+        )
         agent._last_turn_outcome = TurnOutcome(
             text=final_text,
             status=status,
             incomplete_reason=incomplete_reason,
             tool_count=tool_count,
             error=error_detail,
+            finish_reason_missing=finish_reason_missing,
         )
         try:
             agent.transport.emit(AgentEvent(EventType.TURN_END, {
@@ -195,6 +224,7 @@ def run_turn(
                 "error": error_detail,
                 "tool_count": tool_count,
                 "incomplete_reason": incomplete_reason,
+                "finish_reason_missing": finish_reason_missing,
             }))
         except Exception:
             pass

--- a/agentao/transport/events.py
+++ b/agentao/transport/events.py
@@ -70,7 +70,8 @@ class AgentEvent:
         TURN_END      {"final_text": "...", "status": "ok"|"error"|"cancelled",
                        "error": None, "tool_count": 3,
                        "incomplete_reason": None|"no_output"|"reasoning_only"
-                       |"length_truncated"|"doom_loop"}
+                       |"length_truncated"|"doom_loop",
+                       "finish_reason_missing": False}
         TOOL_START    {"tool": "run_shell_command", "args": {...}, "call_id": "uuid"}
         TOOL_OUTPUT   {"tool": "run_shell_command", "chunk": "hello\\n", "call_id": "uuid"}
         TOOL_COMPLETE {"tool": "run_shell_command", "call_id": "uuid",

--- a/developer-guide/en/part-4/2-agent-events.md
+++ b/developer-guide/en/part-4/2-agent-events.md
@@ -74,7 +74,7 @@ Distinct from `TURN_START` (which fires per LLM iteration). `TURN_BEGIN` carries
 | Field | Description |
 |-------|-------------|
 | Trigger | Once at the end of each user-driven turn, after the final assistant reply (or on error / cancellation) |
-| `data` | `{"final_text": "...", "status": "ok"\|"error"\|"cancelled", "error": None, "tool_count": 3, "incomplete_reason": None}` |
+| `data` | `{"final_text": "...", "status": "ok"\|"error"\|"cancelled", "error": None, "tool_count": 3, "incomplete_reason": None, "finish_reason_missing": False}` |
 | Typical use | Close the turn frame; flush per-turn metrics — `tool_count` is the number of tool calls the LLM made across all iterations of the turn, so a host can size a turn without replaying every `TOOL_START` |
 
 `incomplete_reason` is `None` on an ordinary turn. It is set when the turn ended without a complete, model-authored answer, and says why:
@@ -90,6 +90,8 @@ Distinct from `TURN_START` (which fires per LLM iteration). `TURN_BEGIN` carries
 This is a **single closed vocabulary**: every turn-ending path commits exactly one of these, or `None` for a real answer — there is no unclassified ending. The first two mean the turn ended normally with no answer; the middle two mean the harness stopped a turn that was not converging; the last means the provider call never yielded a turn. (`max_iterations` is a sixth way a turn ends without a complete answer, but it is a deliberately separate axis — a sticky transport flag with its own exit code 4 and its own `on_max_iterations` interaction, not a value here.)
 
 Prefer it over string-matching `final_text` — the harness substitutes a placeholder or a canned notice there (including the `[LLM API error: …]` notice, now classified `llm_error`), and a Stop hook may decorate it, so the text is not a reliable signal. A cancelled turn is never reported via `incomplete_reason` (it carries `status: "cancelled"`). `agentao run` maps a non-`None` value to a non-zero exit; other hosts are free to retry, prompt, or ignore.
+
+`finish_reason_missing` is a **separate axis**, not a member of that vocabulary. It is `True` when at least one LLM call in the turn ended without the provider reporting *why* generation stopped — a gateway closing the SSE body after its own upstream timeout, or a partially-compatible server that never emits the field — so agentao's `"stop"` fallback, rather than the provider, is what says the answer is complete. It does **not** affect `incomplete_reason`, `is_answer`, or the `agentao run` exit code: the servers that omit the field omit it on every call, so gating on it would fail every turn against them. A host that wants the strict reading checks the key itself. Suppressed on a cancelled turn (the cancellation already explains the absence), reported on an errored one.
 
 Replay recorders pair this with `TURN_BEGIN` to delimit a turn. Drives the runtime → replay handoff that used to be a direct call into the replay adapter.
 

--- a/developer-guide/zh/part-4/2-agent-events.md
+++ b/developer-guide/zh/part-4/2-agent-events.md
@@ -74,7 +74,7 @@ TURN_END   -> (turn 结束；携带最终 assistant 文本 + status/error)
 | 字段 | 说明 |
 |------|------|
 | 触发时机 | 每个用户驱动 turn 结束时**一次**，在最终 assistant 回复之后（或出错 / 被取消时） |
-| `data` | `{"final_text": "...", "status": "ok"\|"error"\|"cancelled", "error": None, "tool_count": 3, "incomplete_reason": None}` |
+| `data` | `{"final_text": "...", "status": "ok"\|"error"\|"cancelled", "error": None, "tool_count": 3, "incomplete_reason": None, "finish_reason_missing": False}` |
 | 典型用法 | 关闭 turn 帧；刷出 per-turn 指标 —— `tool_count` 是这个 turn 内所有迭代里 LLM 发起的工具调用总数，宿主无需重放每个 `TOOL_START` 就能掂量这一 turn 的规模 |
 
 `incomplete_reason` 在普通 turn 上为 `None`。当 turn 结束但没有拿到完整的、模型撰写的答案时它会被置位，并说明原因：
@@ -90,6 +90,8 @@ TURN_END   -> (turn 结束；携带最终 assistant 文本 + status/error)
 这是**一套单一封闭的词表**：每一条 turn 结束路径都恰好提交其中一个取值，或对真实答案提交 `None`——不存在未被分类的结束。前两者表示 turn 正常结束但没有答案；中间两者表示 harness 停掉了一个不收敛的 turn；最后一个表示 provider 调用根本没产出一个 turn。（`max_iterations` 是第六种"结束但无完整答案"的方式，但它是刻意独立的一根轴——一个带自己退出码 4 和 `on_max_iterations` 交互的粘性 transport 标志，不是这里的取值。）
 
 优先用它来判断，而不要去字符串匹配 `final_text` —— harness 会在那里替换占位符或固定话术（包括现已被分类为 `llm_error` 的 `[LLM API error: …]` 提示），而 Stop hook 还可能装饰它，所以文本并不是可靠信号。被取消的 turn 不会通过 `incomplete_reason` 上报（它携带 `status: "cancelled"`）。`agentao run` 会把非 `None` 的值映射为非零退出码；其他宿主可以自行选择重试、追问或忽略。
+
+`finish_reason_missing` 是**另一根独立的轴**，不属于上面那套词表。当这个 turn 里至少有一次 LLM 调用结束时 provider 从未说明生成为何停止（网关在自己的上游超时后关掉 SSE body，或者部分兼容的服务端根本不发这个字段），它为 `True`——也就是说"答案完整"这句话是 agentao 的 `"stop"` 兜底说的，不是 provider 说的。它**不影响** `incomplete_reason`、`is_answer`，也不影响 `agentao run` 的退出码：不发这个字段的服务端是每次都不发，以它为门会让针对这些服务端的每个 turn 都失败。想要严格语义的宿主自己检查这个键。被取消的 turn 上会被抑制（取消本身已经解释了缺失），出错的 turn 上照常上报。
 
 Replay 录制器靠它和 `TURN_BEGIN` 配对来界定一个 turn。它替代了运行时直接调用 replay adapter 的旧路径。
 

--- a/docs/guides/embed-for-agents.md
+++ b/docs/guides/embed-for-agents.md
@@ -403,10 +403,19 @@ if not outcome.is_answer:
 `agent.last_turn` mirrors the `TURN_END` payload — `text`, `status`,
 `incomplete_reason` (a single closed vocabulary: `no_output` /
 `reasoning_only` / `length_truncated` / `doom_loop` / `llm_error`, or
-`None` for a real answer), `tool_count`, `error` — as a synchronous
-read-after, no subscription required. `outcome.is_answer` is the one
-check that folds all of it together: `True` only when the turn ended
-`"ok"` with nothing classifying it incomplete.
+`None` for a real answer), `tool_count`, `error`, `finish_reason_missing`
+— as a synchronous read-after, no subscription required.
+`outcome.is_answer` is the one check that folds all of it together:
+`True` only when the turn ended `"ok"` with nothing classifying it
+incomplete.
+
+`finish_reason_missing` is deliberately outside that fold. It is `True`
+when at least one LLM call in the turn ended without the provider saying
+*why* generation stopped, so agentao's `"stop"` fallback is what claims
+the answer is complete. It does not affect `is_answer`, because a server
+that omits the field omits it on every call and every turn would
+otherwise become a failure. Write `outcome.is_answer and not
+outcome.finish_reason_missing` if you want the strict reading.
 
 This is a pull surface: it answers "how did the turn I just awaited
 end?". If instead you need the outcome *pushed* to an async observer

--- a/docs/reference/host-api.md
+++ b/docs/reference/host-api.md
@@ -431,8 +431,18 @@ meaning changed under a name consumers already read.
   `agent.last_turn` returns a `TurnOutcome` (`text`, `status`,
   `incomplete_reason` over a single closed vocabulary — `no_output`,
   `reasoning_only`, `length_truncated`, `doom_loop`, `llm_error`, or
-  `None`; `tool_count`; `error`), and `.is_answer` folds it into one
-  check. That is a **pull** surface: it answers "how did the turn I just
+  `None`; `tool_count`; `error`; `finish_reason_missing`), and
+  `.is_answer` folds it into one check.
+
+  `finish_reason_missing` is a third separate axis, alongside
+  `max_iterations`: at least one LLM call in the turn ended without the
+  provider reporting *why* generation stopped, so agentao's `"stop"`
+  fallback — not the provider — is what says the answer is complete. It
+  does **not** affect `.is_answer`, because the servers that omit the
+  field omit it on every call and every turn would become a failure. A
+  host that wants the strict reading writes `o.is_answer and not
+  o.finish_reason_missing`; one on a known-lenient provider keeps
+  ignoring it. That is a **pull** surface: it answers "how did the turn I just
   awaited end?", which covers `chat()` / `arun()` callers, `agentao
   run`, and any embedder. What is **not** on the stable contract is the
   **push** shape — a `HostEvent` an async observer that does *not* drive

--- a/docs/reference/host-api.zh.md
+++ b/docs/reference/host-api.zh.md
@@ -360,7 +360,16 @@ for ev in events:
   可以同步拿到：`agent.last_turn` 返回一个 `TurnOutcome`（`text`、`status`、
   一套单一封闭词表的 `incomplete_reason`——`no_output`、`reasoning_only`、
   `length_truncated`、`doom_loop`、`llm_error`，或 `None`；`tool_count`；
-  `error`），`.is_answer` 把它折成一个判断。这是一个 **pull** 面：它回答
+  `error`；`finish_reason_missing`），`.is_answer` 把它折成一个判断。
+
+  `finish_reason_missing` 是与 `max_iterations` 并列的第三根独立轴：这个
+  turn 里至少有一次 LLM 调用结束时，provider 从未说明生成为何停止，所以
+  "答案完整"这句话是 agentao 的 `"stop"` 兜底说的，不是 provider 说的。
+  它**不影响** `.is_answer`——不发这个字段的服务端是每次都不发，否则每个
+  turn 都会变成失败。想要严格语义的宿主自己写 `o.is_answer and not
+  o.finish_reason_missing`；确知 provider 宽松的宿主继续忽略它即可。
+
+  这是一个 **pull** 面：它回答
   "我刚 await 完的这个 turn 是怎么结束的"，覆盖 `chat()` / `arun()` 调用方、
   `agentao run` 和任何嵌入方。**尚未**进稳定契约的是 **push** 形态——一个
   不驱动 turn 的异步观察者可以订阅的 `HostEvent`。这个缺口现在**只剩主循环**：

--- a/tests/test_finish_reason_missing.py
+++ b/tests/test_finish_reason_missing.py
@@ -1,0 +1,538 @@
+"""``TurnOutcome.finish_reason_missing`` — "the provider never said why it stopped".
+
+A stream can end without the provider ever sending ``finish_reason``: a gateway
+closing the SSE body after its own upstream timeout, or a partially-compatible
+local server that never emits the field. agentao falls back to ``"stop"``, so
+such a turn is otherwise indistinguishable from a clean completion — a truncated
+fragment is reported as a finished answer, and ``is_answer`` says True.
+
+This flag reports that and only that. It is deliberately **not** a member of
+``INCOMPLETE_ANSWER_REASONS``: every value in that closed set becomes a CLI error
+envelope, so joining it would make each turn a hard failure on every provider
+that omits the field. It rides its own axis, like ``max_iterations``.
+
+Streaming responses here come from the **real** producers —
+``client.chat_stream`` and ``_StreamAccumulator.build()`` — so a regression that
+stops propagating the flag through ``build()`` fails these tests instead of
+being restated by them.
+
+``_plain()`` is a ``SimpleNamespace``, matching the established fixture style in
+this repo's runner tests. Be aware of what that does *not* prove: the
+non-streaming half of the detector rests on a provider-omitted ``finish_reason``
+surfacing as ``None`` on a real ``ChatCompletion``, which is a property of
+openai-python's lenient ``construct_type`` rather than of the model signature.
+If a future SDK surfaced a sentinel instead, these tests would stay green while
+every Gemini-bypass turn went unflagged — the failure mode CLAUDE.md's MCP
+section records. ``test_sdk_reports_none_for_an_omitted_finish_reason`` pins
+that assumption against the installed SDK so the drift is caught at the source
+rather than here.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentao import Agentao
+from agentao.cancellation import CancellationToken
+from agentao.llm._stream_response import _StreamAccumulator
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — chunk shapes as the OpenAI SDK yields them
+# ---------------------------------------------------------------------------
+
+
+def _chunk(content=None, finish=None):
+    delta = SimpleNamespace(content=content, tool_calls=None, reasoning_content=None)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=delta, finish_reason=finish)],
+        usage=None,
+        model="test-model",
+    )
+
+
+def _make_client():
+    with patch("agentao.llm.client.OpenAI") as openai_cls:
+        openai_cls.return_value = MagicMock()
+        from agentao.llm.client import LLMClient
+
+        return LLMClient(
+            api_key="test-key",
+            base_url="https://example.test/v1",
+            model="test-model",
+        )
+
+
+def _make_agent() -> Agentao:
+    return Agentao(
+        api_key="test-key",
+        base_url="https://example.test/v1",
+        model="test-model",
+        working_directory=Path.cwd(),
+    )
+
+
+def _streamed(content, *, finish):
+    """A real ``_StreamResponse``, built the way the streaming path builds it.
+
+    ``finish=None`` models a stream that ended without the provider ever
+    sending a finish_reason.
+    """
+    acc = _StreamAccumulator("test-model")
+    acc.content_parts.append(content)
+    if finish is not None:
+        acc.finish_reason = finish
+        acc.finish_reason_reported = True
+    return acc.build()
+
+
+def _plain(content, *, finish_reason, tool_calls=None):
+    """A non-streaming ChatCompletion-shaped response (no flag attribute)."""
+    message = SimpleNamespace(
+        content=content, tool_calls=tool_calls, reasoning_content=None
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+        usage=None,
+        model="test-model",
+    )
+
+
+def _tool_call(call_id, name, arguments):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _scripted(responses):
+    """An ``_llm_call`` stub yielding ``responses`` in order."""
+    it = iter(responses)
+
+    def _call(messages, tools, token):
+        return next(it)
+
+    return _call
+
+
+# ---------------------------------------------------------------------------
+# Producer: chat_stream must record whether the provider reported one
+# ---------------------------------------------------------------------------
+
+
+class TestStreamProducer:
+    def test_reported_when_provider_sends_finish_reason(self):
+        """Uses ``"length"``, NOT ``"stop"``.
+
+        ``"stop"`` is the accumulator's own fallback, so asserting it here
+        would be satisfied whether or not the chunk's value was ever read —
+        deleting ``acc.finish_reason = choice.finish_reason`` would keep this
+        green while silently bypassing ``_is_length_truncation`` in production.
+        A value the fallback cannot produce makes both assertions load-bearing.
+        """
+        client = _make_client()
+        client.client.chat.completions.create = MagicMock(
+            return_value=iter([_chunk(content="hi"), _chunk(content=" there", finish="length")])
+        )
+
+        response = client.chat_stream(
+            messages=[{"role": "user", "content": "hi"}], tools=None, max_tokens=64
+        )
+
+        assert response.finish_reason_reported is True
+        assert response.choices[0].finish_reason == "length"
+
+    def test_empty_string_finish_reason_counts_as_unreported(self):
+        """A gateway sending ``""`` must not read as a provider-confirmed stop.
+
+        The streaming recorder gates on truthiness, so the detector's
+        non-streaming arm has to test falsiness too — otherwise the same ``""``
+        answers differently depending on which transport the turn took.
+        """
+        client = _make_client()
+        client.client.chat.completions.create = MagicMock(
+            return_value=iter([_chunk(content="hi", finish="")])
+        )
+
+        response = client.chat_stream(
+            messages=[{"role": "user", "content": "hi"}], tools=None, max_tokens=64
+        )
+
+        assert response.finish_reason_reported is False
+
+    def test_not_reported_when_stream_just_ends(self):
+        """The gateway-timeout shape: content, then the body simply closes."""
+        client = _make_client()
+        client.client.chat.completions.create = MagicMock(
+            return_value=iter([_chunk(content="a partial answ")])
+        )
+
+        response = client.chat_stream(
+            messages=[{"role": "user", "content": "hi"}], tools=None, max_tokens=64
+        )
+
+        assert response.finish_reason_reported is False
+        # The wire value keeps its "stop" fallback on purpose: flipping it to
+        # None would change LLM_CALL_COMPLETED payloads and replay renders for
+        # every provider that omits the field. The fact rides the flag instead.
+        assert response.choices[0].finish_reason == "stop"
+
+
+# ---------------------------------------------------------------------------
+# Turn level: the flag reaches TurnOutcome without changing the verdict
+# ---------------------------------------------------------------------------
+
+
+class TestTurnOutcomeFlag:
+    def test_normal_turn_is_not_flagged(self):
+        agent = _make_agent()
+        agent._llm_call = lambda messages, tools, token: _streamed("42", finish="stop")
+
+        agent.chat("what is 6*7?")
+
+        assert agent.last_turn.finish_reason_missing is False
+        assert agent.last_turn.is_answer is True
+
+    def test_streamed_turn_without_finish_reason_is_flagged(self):
+        agent = _make_agent()
+        agent._llm_call = lambda messages, tools, token: _streamed("42", finish=None)
+
+        agent.chat("what is 6*7?")
+
+        assert agent.last_turn.finish_reason_missing is True
+
+    def test_flag_does_not_make_the_turn_a_non_answer(self):
+        """The whole point of choosing a marker over the strict default.
+
+        A provider that never sends the field would otherwise fail every
+        single turn.
+        """
+        agent = _make_agent()
+        agent._llm_call = lambda messages, tools, token: _streamed("42", finish=None)
+
+        agent.chat("what is 6*7?")
+
+        assert agent.last_turn.is_answer is True
+        assert agent.last_turn.incomplete_reason is None
+        assert agent.last_turn.status == "ok"
+
+    def test_non_streaming_none_finish_reason_is_flagged(self):
+        """A real ChatCompletion has no flag attribute; ``None`` is the signal."""
+        agent = _make_agent()
+        agent._llm_call = lambda messages, tools, token: _plain("42", finish_reason=None)
+
+        agent.chat("what is 6*7?")
+
+        assert agent.last_turn.finish_reason_missing is True
+        assert agent.last_turn.is_answer is True
+
+    def test_non_streaming_empty_string_is_flagged(self):
+        """The two producers must agree on a falsy-but-not-None value.
+
+        The streaming recorder gates on truthiness, so a gateway sending ``""``
+        leaves ``finish_reason_reported`` False there. If the detector's
+        non-streaming arm tested ``is None``, the identical ``""`` would read
+        as reported, and the flag would flip depending on whether the turn took
+        the streaming or the Gemini/fallback bypass — a transport detail no
+        host can see, making the failures look nondeterministic.
+        """
+        agent = _make_agent()
+        agent._llm_call = lambda messages, tools, token: _plain("42", finish_reason="")
+
+        agent.chat("what is 6*7?")
+
+        assert agent.last_turn.finish_reason_missing is True
+
+    def test_non_streaming_with_finish_reason_is_not_flagged(self):
+        agent = _make_agent()
+        agent._llm_call = lambda messages, tools, token: _plain("42", finish_reason="stop")
+
+        agent.chat("what is 6*7?")
+
+        assert agent.last_turn.finish_reason_missing is False
+
+    def test_flag_resets_between_turns(self):
+        agent = _make_agent()
+        agent._llm_call = lambda messages, tools, token: _streamed("42", finish=None)
+        agent.chat("first")
+        assert agent.last_turn.finish_reason_missing is True
+
+        agent._llm_call = lambda messages, tools, token: _streamed("43", finish="stop")
+        agent.chat("second")
+        assert agent.last_turn.finish_reason_missing is False
+
+    def test_sticky_across_calls_within_one_turn(self, tmp_path):
+        """Set by *any* call in the turn, not just the last one.
+
+        An intermediate call that ends without a finish_reason may have had its
+        tool-call arguments cut off with nothing to detect it — the length
+        guard never fires, so those arguments get executed. Inspecting only the
+        final call would miss exactly that, which is why the flag is sticky.
+
+        Driven through the real loop: call 1 is a tool call with no reported
+        finish_reason, call 2 is a clean final answer. The turn therefore *ends*
+        on a well-behaved call.
+        """
+        target = tmp_path / "note.txt"
+        target.write_text("hello\n")
+
+        agent = _make_agent()
+        agent._llm_call = _scripted([
+            _plain(
+                "let me look",
+                finish_reason=None,  # unreported
+                tool_calls=[_tool_call("call_1", "read_file", f'{{"file_path": "{target}"}}')],
+            ),
+            _plain("the file says hello", finish_reason="stop"),  # clean, and last
+        ])
+
+        agent.chat("what is in that file?")
+
+        assert agent.last_turn.finish_reason_missing is True
+        # Evidence the intermediate call really executed: a tool *result*
+        # message carrying the file's content. ``tool_count`` would not do —
+        # it counts calls the model made, not calls that ran, so it stays 1
+        # even if the read is denied or the file never existed.
+        tool_msgs = [m for m in agent.messages if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert "hello" in tool_msgs[0]["content"]
+        # Still an answer — the flag reports, it does not classify.
+        assert agent.last_turn.is_answer is True
+
+
+    def test_errored_turn_keeps_the_flag(self):
+        """Errors are NOT suppressed, unlike cancellation.
+
+        A stream truncated mid tool-call arguments can get them repaired into
+        something parseable-but-wrong, run the tool, and raise. Zeroing the
+        flag there would tell a triager the provider confirmed a clean stop for
+        the very turn it truncated.
+
+        Targets `run_turn`'s gate directly — the flag is set, then the inner
+        loop raises — rather than staging a whole tool-failure scenario. The
+        gate is the line this test exists to pin.
+        """
+        agent = _make_agent()
+        _orig_inner = agent._chat_inner
+
+        def _inner(user_message, max_iterations, token, **kwargs):
+            agent._turn_finish_reason_missing = True
+            raise RuntimeError("tool blew up on repaired arguments")
+
+        agent._chat_inner = _inner
+
+        with pytest.raises(RuntimeError):
+            agent.chat("hi")
+
+        assert agent.last_turn.status == "error"
+        assert agent.last_turn.finish_reason_missing is True
+
+    def test_cancelled_turn_is_not_flagged(self):
+        """Gated on ``status == "ok"``, same as ``incomplete_reason``.
+
+        Cancellation breaks out of the chunk loop before any finish_reason can
+        arrive, so an ungated flag would fire on every single cancellation and
+        say nothing the status does not already say.
+        """
+        agent = _make_agent()
+        token = CancellationToken()
+
+        def _llm(messages, tools, cancellation_token):
+            token.cancel("sigint")
+            return _streamed("", finish=None)
+
+        agent._llm_call = _llm
+
+        agent.chat("hi", cancellation_token=token)
+
+        assert agent.last_turn.status == "cancelled"
+        assert agent.last_turn.finish_reason_missing is False
+
+
+class TestSdkAssumption:
+    def test_sdk_reports_none_for_an_omitted_finish_reason(self):
+        """The non-streaming arm's premise, pinned against the installed SDK.
+
+        `_plain()` fixtures cannot prove this — they *are* the assumption. If a
+        future openai-python surfaces a sentinel instead of ``None`` for an
+        omitted field, every Gemini-bypass turn would silently stop being
+        flagged; this fails at the source instead.
+        """
+        from openai.types.chat import ChatCompletion
+
+        parsed = ChatCompletion.construct(
+            **{
+                "id": "cmpl-1",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "test-model",
+                # finish_reason deliberately absent, as a lenient gateway sends it
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}}],
+            }
+        )
+        assert getattr(parsed.choices[0], "finish_reason", None) is None
+
+
+# ---------------------------------------------------------------------------
+# Coverage the observation must reach beyond TurnOutcome
+# ---------------------------------------------------------------------------
+
+
+class TestDownstreamCoverage:
+    def test_compaction_summary_without_finish_reason_flags_the_turn(self):
+        """The summarization call bypasses the chat loop's detector.
+
+        It is also the one call whose output permanently replaces history, so a
+        truncated summary that went unflagged would be inherited by every later
+        turn.
+        """
+        agent = _make_agent()
+        agent._llm_call = lambda messages, tools, token: _streamed("done", finish="stop")
+
+        cm = agent.context_manager
+
+        def _compress(msgs, is_auto=False):
+            # What `_summarize_messages` does when its own provider call ends
+            # without a finish_reason. Set *inside* the turn on purpose:
+            # `run_turn` clears this attribute at turn start, so seeding it
+            # beforehand would prove nothing (and would have hidden the reset).
+            cm.last_summary_finish_reason_missing = True
+            return msgs
+
+        cm.compress_messages = _compress
+        cm.needs_compression = lambda *a, **k: True
+        cm.needs_microcompaction = lambda *a, **k: False
+
+        agent.chat("summarize and answer")
+
+        # The turn's own LLM call reported "stop"; only the summarizer did not.
+        assert agent.last_turn.finish_reason_missing is True
+
+    def test_stale_summary_flag_does_not_leak_into_a_later_turn(self):
+        """`run_turn` clears the context manager's flag at turn start.
+
+        The leak needs all three conditions, so the test has to stage all
+        three: turn 1 summarizes badly, turn 2 *also* compacts (otherwise the
+        fold-in never runs and any assertion passes vacuously), and turn 2's
+        `compress_messages` returns without re-summarizing — the early-return
+        path, where `_summarize_messages`' own per-call reset never fires.
+        Without `run_turn`'s reset, turn 2 inherits turn 1's verdict.
+        """
+        agent = _make_agent()
+        agent._llm_call = lambda messages, tools, token: _streamed("done", finish="stop")
+        cm = agent.context_manager
+        cm.needs_compression = lambda *a, **k: True
+        cm.needs_microcompaction = lambda *a, **k: False
+
+        def _compress_and_flag(msgs, is_auto=False):
+            cm.last_summary_finish_reason_missing = True
+            return msgs
+
+        cm.compress_messages = _compress_and_flag
+        agent.chat("turn one, summary came back truncated")
+        assert agent.last_turn.finish_reason_missing is True
+
+        # Turn 2 compacts again, but nothing re-summarizes this time.
+        cm.compress_messages = lambda msgs, is_auto=False: msgs
+        agent.chat("turn two, nothing new to summarize")
+
+        assert agent.last_turn.finish_reason_missing is False
+
+    def test_replay_turn_completed_records_the_flag(self):
+        from agentao.transport import AgentEvent, EventType
+
+        recorded = []
+        adapter_mod = __import__(
+            "agentao.replay.adapter", fromlist=["ReplayAdapter"]
+        )
+        adapter = adapter_mod.ReplayAdapter.__new__(adapter_mod.ReplayAdapter)
+        adapter._turn_id = "turn-1"
+        adapter._recorder = SimpleNamespace(
+            record=lambda kind, turn_id, payload: recorded.append(payload)
+        )
+
+        adapter.end_turn(
+            "a truncated answer",
+            status="ok",
+            error=None,
+            tool_count=0,
+            incomplete_reason=None,
+            finish_reason_missing=True,
+        )
+
+        assert recorded[0]["finish_reason_missing"] is True
+
+    def test_replay_omits_the_key_on_an_ordinary_turn(self):
+        recorded = []
+        adapter_mod = __import__(
+            "agentao.replay.adapter", fromlist=["ReplayAdapter"]
+        )
+        adapter = adapter_mod.ReplayAdapter.__new__(adapter_mod.ReplayAdapter)
+        adapter._turn_id = "turn-2"
+        adapter._recorder = SimpleNamespace(
+            record=lambda kind, turn_id, payload: recorded.append(payload)
+        )
+
+        adapter.end_turn("fine", status="ok", error=None, tool_count=0)
+
+        assert "finish_reason_missing" not in recorded[0]
+
+
+# ---------------------------------------------------------------------------
+# The flag must also reach the TURN_END wire payload
+# ---------------------------------------------------------------------------
+
+
+def test_turn_end_event_carries_the_flag():
+    """``TurnOutcome`` is documented as mirroring TURN_END field-for-field."""
+    from agentao.transport import EventType
+
+    seen = []
+    agent = _make_agent()
+    agent.transport.subscribe(
+        lambda e: seen.append(e) if e.type == EventType.TURN_END else None
+    )
+    agent._llm_call = lambda messages, tools, token: _streamed("42", finish=None)
+
+    agent.chat("what is 6*7?")
+
+    assert len(seen) == 1
+    assert seen[0].data["finish_reason_missing"] is True
+
+
+# ---------------------------------------------------------------------------
+# It must stay off the closed incomplete_reason vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_flagged_turn_still_exits_zero_from_agentao_run():
+    """The exit-code half of the product decision, driven through the real
+    classifier rather than asserted against a frozenset.
+
+    A membership assertion (``"finish_reason_missing" not in
+    INCOMPLETE_ANSWER_REASONS``) cannot fail for the risk it names: if
+    ``_classify_outcome`` were later changed to consult the flag, `agentao run`
+    would start exiting non-zero on every turn against a provider that never
+    sends finish_reason — the hard failure this design rejected — and a
+    frozenset check would stay green. So drive the classifier itself.
+    """
+    from agentao.cli.run import _classify_outcome
+    from agentao.cancellation import CancellationToken
+
+    transport = SimpleNamespace(rejection=None, max_iterations_hit=False)
+
+    error, exit_code, status = _classify_outcome(
+        transport=transport,
+        token=CancellationToken(),
+        runtime_error=None,
+        max_iterations=100,
+        incomplete_reason=None,   # the flag is NOT one of these
+        final_text="a possibly-truncated answer",
+    )
+
+    assert exit_code == 0
+    assert status == "ok"
+    assert error is None


### PR DESCRIPTION
## Problem

A stream can end without the provider ever sending `finish_reason` — a gateway closing the SSE body after its own upstream timeout, a partially-compatible local server that never emits the field. `_StreamAccumulator` falls back to `"stop"`, so such a turn was **indistinguishable from a clean completion**: a truncated fragment came back as a finished answer and `is_answer` said `True`.

## What this adds

`TurnOutcome.finish_reason_missing`, plus a matching key on TURN_END.

**Reported, not classified.** Deliberately *not* a member of `INCOMPLETE_ANSWER_REASONS` and deliberately no effect on `is_answer` — every value in that closed set becomes a CLI error envelope, so joining it would make each turn a hard failure on every provider that never sends the field. It rides its own axis, the way `max_iterations` does.

```python
outcome.is_answer                                  # unchanged
outcome.is_answer and not outcome.finish_reason_missing   # the strict reading, if you want it
```

The wire value of `finish_reason` keeps its `"stop"` fallback — flipping it to `None` would shift LLM_CALL_COMPLETED payloads and replay renders for every provider that omits the field.

### Detection

Falsy `finish_reason`, **or** a streamed response whose accumulator never saw one. Falsy rather than `is None` because the streaming recorder gates on truthiness — testing `is None` would let the same `""` answer differently depending on whether the turn took the streaming or the Gemini/fallback bypass, a transport detail no host can see.

Sticky across **every** LLM call in the turn, not just the last: an intermediate call that ends without a finish_reason may have had its tool-call arguments cut off with nothing to detect it, since `_is_length_truncation` never fires and the arguments get executed.

The compaction summarizer bypasses the chat loop entirely, so it records its own observation on the context manager and the two compaction call sites fold it in. That is the one call whose output *permanently rewrites history* — a truncated summary is inherited by every later turn.

Suppressed on a cancelled turn (the cancellation already explains the absence). Reported on an errored one, where it does not.

### Where the fact surfaces

| Surface | Change |
|---|---|
| `agent.last_turn` | new `finish_reason_missing` field |
| TURN_END | new `finish_reason_missing` key (additive, no `schema_version` bump) |
| `agentao.log` | `Finish Reason:` line qualified when it's agentao's fallback |
| LLM_CALL_COMPLETED | new `finish_reason_reported` key |
| replay `turn_completed` | key written when set (omitted otherwise, like `incomplete_reason`) |
| `agentao run --output json` | new `finish_reason_missing` on `RunResult`; **does not** affect the exit code |

## Review

Ran at **xhigh**. 15 verified findings; **13 fixed here**. Notable ones caught:

- the falsy-vs-`None` producer disagreement above
- the compaction summarizer bypassing detection entirely
- the flag missing from replay, `agentao run`, and `agentao.log`
- the `status == "ok"` gate silently dropping the signal on *errored* turns, a case its own rationale didn't cover
- `_StreamResponse`'s constructor default failing open (now a required argument — `build()` is the sole caller)
- four weak tests of my own, including a positive fixture that reused the `"stop"` fallback so its assertion couldn't fail

**Two left open as contract decisions, not defects of this change:**

1. **Sub-agent boundary** — the flag doesn't cross into the parent turn. The wrapper deliberately holds no parent reference, and the cited `max_iterations` precedent actually flows into the *child's own* classification rather than the parent's flag. Three plausible shapes; worth deciding deliberately.
2. **ACP** — no channel carries it. Widening that surface is a scoping decision.

## Tests

20 in `tests/test_finish_reason_missing.py`. Streaming responses come from the real producers (`client.chat_stream`, `_StreamAccumulator.build()`); one test pins the non-streaming premise — that an omitted `finish_reason` surfaces as `None` — against the **installed SDK** rather than a fixture, so a future openai-python change fails at the source.

Every distinct piece of logic was falsified by reverting it and confirming the intended test reddens. Two of those runs initially passed when they shouldn't have — the falsy fix and the stale-summary reset were unprotected, since my first tests exercised the producer and a non-compacting turn respectively, neither of which reaches the changed line. Both rewritten and re-verified.

Full suite: `3808 passed, 2 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)