### PR TITLE
docs(design): record the pi-mono v0.80.6→v0.83.0 pull review

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -61,6 +61,7 @@ Retrospective analyses — competitive/borrow reviews, conformance gap reviews, 
 - **core-boundary-review** — core vs host package-boundary audit (codex parallel, 2026-05).
 - **codex-reverse-review** *(en only)* — reverse-review discipline record (2026-05-12).
 - **pi-mono-borrow-review** — pi-mono v0.66→v0.73 borrow analysis; demand-gated precedent anchor.
+- **pi-mono-pull-review-2026-08** — pi-mono v0.80.6→v0.83.0 (434 commits). 3 landed (#159 NFKC edit matching, #160 listener-error logging, #161 `finish_reason_missing` — the last **adopted inverted** from pi's error-by-default). 2 deferred as contract decisions (sub-agent boundary, ACP channel). `watch()` snapshot/subscribe recorded as the one real architectural gap, but its assumed trigger `agentao serve` is ✗-listed in the roadmap, so read §"Recorded, demand-gated" before assuming it is scheduled. 8 not-applicable, each with the query that settled it — **do not re-raise those without new evidence** (2026-08-02).
 - **pi-mono-tools-review** — pi-mono tools-level companion review.
 - **pi-mono-openai-stream-fix** — pi-mono OpenAI-compat stream fix + agentao-side gap analysis.
 - **system-prompt-profile** — host-injectable collaboration posture (review record; impl deferred).

--- a/docs/design/pi-mono-pull-review-2026-08.md
+++ b/docs/design/pi-mono-pull-review-2026-08.md
@@ -1,0 +1,121 @@
+# pi-mono Pull Review (v0.80.6 → v0.83.0)
+
+**Status:** Decision record. Drafted 2026-08-02 after surveying 434 commits / 730 files in `../pi-mono` (`34582ef34..aa0ec808b`, the delta since the 2026-07-10 pull) and fact-checking every candidate against agentao's current tree.
+**Audience:** Agentao maintainers deciding what to port from pi-mono.
+**Companion:** `pi-mono-pull-review-2026-08.zh.md`.
+**Prior art:** `pi-mono-borrow-review.md` (v0.66 → v0.73), `pi-mono-tools-review.md`, `pi-mono-openai-stream-fix.md`.
+**Method:** Categorise the delta → shortlist by the harness-vs-product boundary → grep-verify each candidate against agentao before recommending → land, defer with a stated reason, or record as not-applicable with the query that proved it.
+
+## TL;DR
+
+Three landed, two deferred as contract decisions, one architectural gap recorded but demand-gated, eight verified not-applicable.
+
+| Disposition | Item |
+|---|---|
+| **Landed** | NFKC in the edit fuzzy matcher (PR #159) |
+| **Landed** | Listener-exception logging in `EventBroadcaster` (PR #160) |
+| **Landed** | `TurnOutcome.finish_reason_missing` (PR #161) |
+| **Deferred — contract decision** | Sub-agent boundary for `finish_reason_missing` |
+| **Deferred — contract decision** | ACP channel for `finish_reason_missing` |
+| **Recorded, demand-gated** | `watch()` — atomic snapshot + gap-free subscription |
+| **Decision, not recommendation** | Lanes / conversation tree; durable operations with crash recovery |
+| **Not applicable (8)** | See the table at the bottom — each with the query that settled it |
+
+The bulk of the 434 commits is pi's own product surface: a TUI alt-screen rewrite, a session-storage move to SQLite with a repository facade, and three new packages (`protocol`, `server`, `client`) implementing a remote-session wire protocol. None of that crosses into agentao's harness.
+
+## Landed
+
+### NFKC before the codepoint table — PR #159
+
+**Source:** `packages/agent/src/harness/tools/edit-diff.ts::normalizeForFuzzyMatch`.
+
+`EditTool`'s tier-3 match normalised through a codepoint table only (dashes, quotes, spaces — copied from codex-rs `seek_sequence.rs`). The table has no entries for Unicode *compatibility forms*, so an edit whose `old_text` differed from the file only by full-width punctuation fell straight through to `_not_found_hint`. In a CJK source file mixing 全角 and 半角 that is the common case: `print（"你好"）；` was unreachable from `print("你好");`.
+
+Both passes are needed and neither subsumes the other — NFKC folds full-width forms, ligatures and every space variant, but leaves smart quotes and en/em dashes alone (no compatibility decomposition), which is exactly what the table covers.
+
+Ordering is load-bearing, not stylistic. Sweeping the Unicode planes finds exactly five characters that NFKC folds *into* a table entry without being in the table themselves — `U+207B ⁻`, `U+208B ₋`, `U+FE31 ︱`, `U+FE32 ︲`, `U+FE58 ﹘`, the last three CJK compatibility dashes. Table-first strands all five one step short of ASCII.
+
+agentao needs none of pi's `applyReplacementsPreservingUnchangedLines` machinery: `line_transform` only builds per-line comparison keys, while the prefix table comes from the original `content_lines` lengths, so spliced spans still index the original content.
+
+### Listener-exception logging — PR #160
+
+**Source:** pi's `handler_error` event (`packages/agent/docs/harness-v2.md` §10). Note it is **design-only there** — zero hits in `packages/agent/src` or `packages/coding-agent/src`; what ships today is the narrower extensions-only `ExtensionError`.
+
+`EventBroadcaster.notify` caught every subscriber exception with a bare `except Exception: pass` — no log, no counter. Swallowing is correct and stays; being silent about it was not. WARNING-and-swallow was already the documented convention for the other side-channel sink on this contract (`HostReplaySink`, `docs/reference/host-api.md`); `broadcast.py` was the one place that did not follow it.
+
+Three choices worth preserving:
+
+- **Logged, not re-emitted as an event.** An event would re-enter `notify`, so a listener that raises on everything would spin forever — which is why pi's `handler_error` needs an explicit recursion guard. A log call has no such edge, so agentao needs none of that machinery.
+- **`event.type` only, never `event.data`.** The credential redaction is a `Formatter` on agentao's own file handler, deliberately not a `Filter`, precisely so it does not leak into an embedded host's handlers — which means a payload logged here would reach those handlers *unredacted*.
+- **`exc_info=True`.** A swallowed exception with no stack is barely better than silence.
+
+The hook half of pi's design already had an agentao equivalent and was left alone: plugin hooks are subprocesses, so timeout / spawn-failure / non-zero-exit are each already logged in `agentao/plugins/hooks/_dispatcher.py`.
+
+### `TurnOutcome.finish_reason_missing` — PR #161
+
+**Source:** `2c3041242 fix(ai): support streams without finish reasons` — **adopted inverted.**
+
+pi makes a stream that ends without `finish_reason` a hard error by default, with a per-model `supportsFinishReason: false` opt-out. agentao does the opposite: it reports the fact and classifies nothing. The reason is that every value in `INCOMPLETE_ANSWER_REASONS` becomes a CLI error envelope, so joining that set would turn each turn into a hard failure on every provider that never sends the field. The flag rides its own axis, the way `max_iterations` does, and does **not** affect `is_answer`. A host that wants the strict reading writes `o.is_answer and not o.finish_reason_missing`.
+
+Design points worth not re-litigating:
+
+- The wire value of `finish_reason` keeps its `"stop"` fallback. Flipping it to `None` would shift LLM_CALL_COMPLETED payloads and replay renders for every provider that omits the field.
+- Detection tests *falsy*, not `is None`, because the streaming recorder gates on truthiness. Testing `is None` would let the same `""` answer differently depending on whether the turn took the streaming or the Gemini/fallback bypass — a transport detail no host can see.
+- Sticky across every LLM call in the turn. An intermediate call that ends without a finish_reason may have had its tool-call arguments cut off with nothing to detect it: `_is_length_truncation` never fires and the arguments get executed.
+- The compaction summariser bypasses the chat loop entirely, so it records its own observation on the context manager and the two compaction call sites fold it in. That is the one call whose output *permanently rewrites history*.
+- Suppressed on a cancelled turn (the cancellation already explains the absence); reported on an errored one, where it does not.
+
+An xhigh review of the change produced 15 verified findings, 13 fixed before merge — most of them coverage gaps where the new fact failed to reach `agentao.log`, LLM_CALL_COMPLETED, the replay `turn_completed` record, or the `agentao run` JSON envelope.
+
+## Deferred — contract decisions, not defects
+
+Both came out of the xhigh review of PR #161. Both are real; neither is a defect *of that change*, and each needs a shape decision first.
+
+**1. Sub-agent boundary.** A sub-agent's `finish_reason_missing` dies with the child and never reaches the parent turn. `AgentToolWrapper` deliberately holds no parent-agent reference (`agentao/agents/tools/_wrapper.py` takes getters only), so propagating it means opening a new channel through that seam. Note the `max_iterations` precedent is *not* exact: it flows into the child's own `_classify_subagent_outcome`, making the sub-agent's result render as incomplete to the parent LLM — it does not write the parent's turn flag. Three plausible shapes: parent `TurnOutcome`, a note in the rendered sub-agent result, or `SubagentLifecycleEvent`.
+
+**2. ACP channel.** `handle_session_prompt` returns only `{"stopReason": …}` and `acp/transport.py::_build_update` has no TURN_END branch, so no `session/update` carries the flag either. Adding one widens the ACP surface, which the project's ACP scoping deliberately keeps narrow (`acp-target-client` decisions; fs/terminal proxy is already a documented non-goal).
+
+## Recorded, demand-gated: `watch()`
+
+The one genuinely architectural gap. pi's `watch()` (`harness-v2.md` §9) captures a snapshot and starts buffering in **one step**; `start(listener)` then flushes the buffer in order and switches to live. Their own words: *"No sequence numbers, no registration race."* The motivation is explicitly the proxy case — a server must deliver the snapshot to its client before any event reaches the wire.
+
+agentao has no snapshot primitive. `agentao/host/events.py` documents the gap as a contract property: *"Subscriber starts after events were emitted: no replay; only future events are delivered."* Grepping `snapshot` across `host/`, `transport/` and `acp/` returns only permission snapshots, schema snapshots and list-copy comments.
+
+A host **cannot** build this on top of a plain `subscribe()`: read-state-then-subscribe drops the events in between, subscribe-then-read-state double-counts. It has to be a harness primitive.
+
+agentao has already hit this race once and solved it point-wise — `agentao/acp/session_load.py` registers the session *after* replay finishes, precisely so a pipelined prompt cannot interleave live updates with replayed ones. One instance, ad hoc, no general primitive.
+
+**Gate:** it only bites when a host attaches to a *running* turn. Today's CLI and ACP flows construct before running and never hit it.
+
+The obvious trigger would be `agentao serve` — but note that is **not** merely unstarted: `path-a-roadmap.md` lists it under "deferred to P2 or moved to separate projects" with `✗ agentao serve daemon — clashes with "in-process harness" positioning`. So this is not a primitive waiting on a scheduled feature; on current strategy that feature is not coming.
+
+The realistic trigger is narrower and independent of `serve`: an **embedded host** that attaches an observer to an `Agentao` mid-turn — a web UI reconnecting while a `/goal` loop or an `agentao run` is executing. That is squarely inside the stated positioning, so it can arrive without `serve` ever existing. If it does, build the primitive rather than a second point fix like `session_load.py`'s.
+
+## Decisions, not recommendations
+
+**Lanes / conversation tree.** pi restructured the harness around an append-only entry tree plus *lanes* — named tree positions, one operation each, running in parallel, keyed by external identity (a Slack thread id). It buys shared history prefixes and per-lane model config. agentao's implicit answer is N harness instances: `examples/slack-bot/src/bot.py` constructs a fresh `Agentao` per message. Both are coherent; pi's costs a single-writer discipline and buys token reuse. Only worth revisiting if agentao targets a multi-thread host.
+
+**Durable operations with crash recovery.** pi's accepted prompt is a durable operation with "no partial outcomes" — a crash leaves either "did not happen" or "recovery can finish it" — backed by an operation log kept strictly out of the conversation tree. agentao's replay is explicitly out-of-core observability and sessions are save/load snapshots; a mid-turn crash loses the turn. Relevant to `/goal` loops and `agentao run`, but it is pi's entire Part II (record catalog, provisioned ids, recovery reduction) holding it up — not a slice you can take.
+
+## Not applicable — verified
+
+| pi change | agentao status | Query |
+|---|---|---|
+| `7af8533c6` abortable provider retries | Already done, before pi | SDK `max_retries=0` (`llm/client.py`) + own `_retry.py::_interruptible_sleep` |
+| 6× `preserve raw stop reasons` | Never normalised; raw string passes through | `_LENGTH_FINISH_REASONS` is already a multi-vendor set |
+| `f4e9ca746` date out of the system prompt | agentao is ahead — pi *deleted* it; agentao moved it to a per-turn `<system-reminder>` on the user message | `tests/test_date_in_prompt.py` |
+| `cced6a21d` AGENTS.md loaded twice in nested worktrees | Structurally impossible | `prompts/helpers.py` reads `working_directory / "AGENTAO.md"` only; no ancestor walk |
+| `5d548ae96` rpc bash bypassing the permission gate | No second entry point | `grep LocalShellExecutor` → `tools/shell.py` + `tools/base.py` lazy accessor only; ACP has no terminal/exec method |
+| `bd2cfabc5` reject cyclic values | CBOR-specific | Python `json.dumps` raises `Circular reference detected` by default |
+| `74caa2649` validate package manifests | Already thorough | `embedding/plugins/manifest.py` validates each field with `isinstance` |
+| Append-only context invariant | Already holds | `grep 'messages.insert\|messages\[:0\]'` → no match; only wholesale compaction, pi's own named exception |
+
+**Deliberate divergence worth holding:** pi added `protocol` + `server` + `client` — its own CBOR wire protocol and Unix-socket transport — and now runs two remote surfaces. agentao has one (ACP), scoped narrowly on purpose — see `acp-server-conformance-review.md` §4, where the non-IDE / chat-automation target decision is what makes the narrow surface correct rather than incomplete. Not a borrow; a line to hold.
+
+**Observation, not a candidate:** `3d8f74357 message-anchored tool loading` anchors newly-added tools to a tool-result position instead of the cached prompt prefix, so adding a tool mid-session does not wipe the cache. agentao has the same shape (`/goal`'s `add_tool` injection, skill activation), but the mechanism depends on Anthropic / OpenAI-Responses cache anchors and agentao is chat.completions-shaped. Not portable.
+
+## Process note
+
+The xhigh review of PR #161 caught four weak tests I had written, including a positive fixture that reused the accumulator's own `"stop"` fallback so its assertion could not fail. Separately, two of my counterfactual checks initially *passed* when they should have failed — the falsy-vs-`None` fix and the stale-summary reset were both unprotected, because my first tests exercised the producer and a non-compacting turn respectively, neither of which reaches the changed line.
+
+The lesson generalises past this PR: writing the test is not the check. Reverting the fix and confirming the test reddens is the check, and it has to be done per distinct piece of logic, one at a time — two of these counterfactuals masked each other when applied together.

--- a/docs/design/pi-mono-pull-review-2026-08.zh.md
+++ b/docs/design/pi-mono-pull-review-2026-08.zh.md
@@ -1,0 +1,121 @@
+# pi-mono Pull 评审（v0.80.6 → v0.83.0）
+
+**状态：** 决策记录。2026-08-02 起草，基于对 `../pi-mono` 中 434 个 commit / 730 个文件（`34582ef34..aa0ec808b`，即 2026-07-10 那次 pull 之后的增量）的梳理，每个候选项都对照 agentao 当前代码核实过。
+**读者：** 决定从 pi-mono 借鉴什么的 Agentao 维护者。
+**对应文档：** `pi-mono-pull-review-2026-08.md`。
+**先前记录：** `pi-mono-borrow-review.md`（v0.66 → v0.73）、`pi-mono-tools-review.md`、`pi-mono-openai-stream-fix.md`。
+**方法：** 先给增量分类 → 按 harness/product 边界筛出候选 → 每条在推荐前先 grep 核实 agentao 现状 → 要么落地，要么写明理由推迟，要么记为不适用并附上判定它的查询。
+
+## TL;DR
+
+三条已落地，两条作为契约决策推迟，一条架构缺口已记录但按需求门控，八条核实为不适用。
+
+| 处置 | 条目 |
+|---|---|
+| **已落地** | edit 模糊匹配加 NFKC（PR #159） |
+| **已落地** | `EventBroadcaster` 记录监听器异常（PR #160） |
+| **已落地** | `TurnOutcome.finish_reason_missing`（PR #161） |
+| **推迟——契约决策** | `finish_reason_missing` 的子 agent 边界 |
+| **推迟——契约决策** | `finish_reason_missing` 的 ACP 通道 |
+| **已记录，需求门控** | `watch()`——原子快照 + 无缝订阅 |
+| **是决策，不是推荐** | Lanes / 对话树；带崩溃恢复的持久化操作 |
+| **不适用（8 条）** | 见文末表格，每条附判定查询 |
+
+这 434 个 commit 的主体是 pi 自己的产品面：TUI alt-screen 重写、session 存储迁到 SQLite 并加 repository 门面、以及三个实现远程 session 线协议的新包（`protocol`、`server`、`client`）。这些都没有越过 agentao 的 harness 边界。
+
+## 已落地
+
+### NFKC 前置于码点表 —— PR #159
+
+**来源：** `packages/agent/src/harness/tools/edit-diff.ts::normalizeForFuzzyMatch`。
+
+`EditTool` 的 tier-3 匹配此前只走一张码点表（破折号、引号、空格，抄自 codex-rs `seek_sequence.rs`）。这张表没有 Unicode**兼容形式**的条目，所以当 `old_text` 与文件只差在全角标点时，会直接落到 `_not_found_hint`。在全角半角混排的中文代码库里这是常态而非特例：`print（"你好"）；` 从 `print("你好");` 匹配不到。
+
+两遍都需要，互不包含——NFKC 折叠全角形式、连字和所有空格变体，但完全不动智能引号和 en/em dash（它们没有兼容分解），而后者正是码点表覆盖的。
+
+顺序是承重的，不是风格问题。扫过整个 Unicode 平面后，恰好有五个字符 NFKC 之后才落进表里、而自身不在表中——`U+207B ⁻`、`U+208B ₋`、`U+FE31 ︱`、`U+FE32 ︲`、`U+FE58 ﹘`，后三个是 CJK 兼容破折号。表在前会让这五个都停在离 ASCII 一步之遥的地方。
+
+agentao 不需要 pi 那套 `applyReplacementsPreservingUnchangedLines`：`line_transform` 只用来构造逐行比较键，而前缀表是从原始 `content_lines` 长度建的，所以 splice 的 span 仍然索引原文。
+
+### 监听器异常记录 —— PR #160
+
+**来源：** pi 的 `handler_error` 事件（`packages/agent/docs/harness-v2.md` §10）。注意它在 pi 那边**只存在于设计稿**——`packages/agent/src` 和 `packages/coding-agent/src` 都是零命中；今天真正跑着的是更窄的、仅面向扩展的 `ExtensionError`。
+
+`EventBroadcaster.notify` 此前用裸 `except Exception: pass` 吞掉每个订阅者异常——没有日志，没有计数。吞掉是对的，保留；对此保持静默不对。WARNING-and-swallow 本来就是这份契约上另一个旁路 sink 的既定约定（`HostReplaySink`，见 `docs/reference/host-api.md`），`broadcast.py` 只是唯一没照做的地方。
+
+三个值得保留的决定：
+
+- **记日志，而不是再发一个事件。** 事件会重入 `notify`，于是一个对所有事件都抛的监听器会无限循环——这正是 pi 的 `handler_error` 需要显式递归守卫的原因。日志调用没有这条边，所以 agentao 不需要那套机制。
+- **只记 `event.type`，绝不记 `event.data`。** 凭据脱敏是挂在 agentao 自己 file handler 上的 `Formatter`，刻意不是 `Filter`，正是为了不渗进嵌入宿主的 handler——反过来说，这里若记了 payload，宿主的 handler 收到的就是**未脱敏**的原文。
+- **`exc_info=True`。** 一个被吞掉的异常如果没有栈，比静默好不了多少。
+
+pi 那套设计的 hook 一半，agentao 早已有对应物，未作改动：插件 hook 是子进程，超时 / 起不来 / 非零退出各自已在 `agentao/plugins/hooks/_dispatcher.py` 记录。
+
+### `TurnOutcome.finish_reason_missing` —— PR #161
+
+**来源：** `2c3041242 fix(ai): support streams without finish reasons`——**反向采纳**。
+
+pi 的默认行为是：流结束而没有 `finish_reason` 就直接报错，并提供 per-model 的 `supportsFinishReason: false` 逃生阀。agentao 反过来：只上报事实，不做任何分类。理由是 `INCOMPLETE_ANSWER_REASONS` 里的每个值都会变成 CLI 的 error envelope，所以加进那个集合就等于让每个不发该字段的 provider 的每个 turn 都硬失败。这个标记走自己的轴，跟 `max_iterations` 一样，且**不影响** `is_answer`。想要严格语义的宿主自己写 `o.is_answer and not o.finish_reason_missing`。
+
+不必重新讨论的设计点：
+
+- `finish_reason` 的线上值保留 `"stop"` 兜底。改成 `None` 会让所有省略该字段的 provider 的 LLM_CALL_COMPLETED 载荷和 replay 渲染都发生位移。
+- 检测判的是 **falsy**，不是 `is None`，因为流式记录侧是按真值门控的。判 `is None` 会让同一个 `""` 因为这次 turn 走的是流式还是 Gemini/回退旁路而给出不同答案——而这是宿主看不见的传输细节。
+- 在一个 turn 内跨所有 LLM 调用粘性。中间那次调用如果没有 finish_reason，它的工具调用参数可能被截断而完全无从检测：`_is_length_truncation` 不会触发，参数照样执行。
+- compaction 摘要调用完全绕过 chat loop，所以它把自己的观察记在 context manager 上，由两个 compaction 调用点折进来。那是唯一一次输出会**永久改写历史**的调用。
+- 被取消的 turn 上抑制（取消本身已解释了缺失）；出错的 turn 上照常上报，因为错误并不解释它。
+
+对这个改动做的 xhigh 评审产出 15 条经验证的发现，合并前修掉 13 条——多数是覆盖缺口：这个新事实没能到达 `agentao.log`、LLM_CALL_COMPLETED、replay 的 `turn_completed` 记录，以及 `agentao run` 的 JSON 信封。
+
+## 推迟——是契约决策，不是缺陷
+
+两条都来自 PR #161 的 xhigh 评审。两条都是真问题；都不是**那次改动**的缺陷，且都需要先定形状。
+
+**1. 子 agent 边界。** 子 agent 的 `finish_reason_missing` 随子进程消失，不进父 turn。`AgentToolWrapper` 刻意不持有父 agent 引用（`agentao/agents/tools/_wrapper.py` 只接收 getter），所以传播它意味着在那个接缝上开一条新通道。注意 `max_iterations` 这个先例**并不精确**：它流进的是子 agent 自己的 `_classify_subagent_outcome`，让子 agent 的结果对父 LLM 显示为未完成——它不写父 turn 的标记。三个候选形状：父 `TurnOutcome`、子 agent 渲染结果里的提示、或 `SubagentLifecycleEvent`。
+
+**2. ACP 通道。** `handle_session_prompt` 只返回 `{"stopReason": …}`，`acp/transport.py::_build_update` 也没有 TURN_END 分支，所以没有任何 `session/update` 携带这个标记。加一条会扩大 ACP 面，而项目对 ACP 的划界刻意保持收窄（fs/terminal proxy 已明确列为 non-goal）。
+
+## 已记录，需求门控：`watch()`
+
+唯一一条真正属于架构层面的缺口。pi 的 `watch()`（`harness-v2.md` §9）在**一步之内**抓取快照并开始缓冲；随后 `start(listener)` 按序冲刷缓冲并切到实时。他们的原话：*"No sequence numbers, no registration race."* 动机明写了是代理场景——服务端必须在任何事件上线之前把快照交给客户端。
+
+agentao 没有快照原语。`agentao/host/events.py` 把这个缺口作为契约属性写着：*"Subscriber starts after events were emitted: no replay; only future events are delivered."* 在 `host/`、`transport/`、`acp/` 里 grep `snapshot` 只命中权限快照、schema 快照和 list 拷贝注释。
+
+宿主**无法**在一个普通 `subscribe()` 之上自建这个能力：先读状态再订阅会丢掉中间的事件，先订阅再读状态会重复计数。它只能是 harness 的原语。
+
+agentao 其实已经撞过这个竞态一次并点状解决了——`agentao/acp/session_load.py` 把 session 注册放在 replay 完成**之后**，正是为了防止流水线过来的 prompt 让实时更新与重放历史交错。一个实例，临时处理，没有通用原语。
+
+**门控：** 只有当宿主挂到**正在运行的** turn 上时才会咬人。今天的 CLI 与 ACP 流程都是先构造后运行，碰不到。
+
+最直观的触发条件是 `agentao serve`——但要注意它**并非**只是"还没开始做"：`path-a-roadmap.md` 把它列在"推迟到 P2 或移入独立项目"那一档，写的是 `✗ agentao serve daemon — clashes with "in-process harness" positioning`。所以这不是一个等着某个排期功能的原语；按现行策略，那个功能不会来。
+
+现实的触发条件更窄，且与 `serve` 无关：某个**嵌入宿主**在 turn 进行中给 `Agentao` 挂上观察者——比如 `/goal` 循环或 `agentao run` 正在跑时，一个 Web UI 重连上来。这完全落在既定定位之内，所以它可以在 `serve` 永不存在的情况下发生。真发生时，应该建这个原语，而不是再来一个像 `session_load.py` 那样的点状修补。
+
+## 是决策，不是推荐
+
+**Lanes / 对话树。** pi 把 harness 重构成一棵 append-only 的 entry 树加上 *lane*——树上的具名位置，各自串行一个操作，彼此并行，以外部身份（如 Slack thread id）为键。它买到的是共享历史前缀和 per-lane 模型配置。agentao 隐含的答案是 N 个 harness 实例：`examples/slack-bot/src/bot.py` 每条消息新建一个 `Agentao`。两者都自洽；pi 的代价是单写者纪律，收益是 token 复用。只有当 agentao 要面向多线程宿主时才值得重新考虑。
+
+**带崩溃恢复的持久化操作。** pi 中被接受的 prompt 就是一个持久操作，且"不存在部分结果"——崩溃后要么"没发生过"，要么"恢复能把它做完"——背后是一份严格排除在对话树之外的操作日志。agentao 的 replay 明确是 core 之外的观测通道，session 是存档快照；turn 中途崩溃就丢了这个 turn。这对 `/goal` 循环和 `agentao run` 有实际意义，但支撑它的是 pi 的整个 Part II（记录目录、provisioned id、恢复归约）——不是能切一小块拿走的东西。
+
+## 不适用——已核实
+
+| pi 的改动 | agentao 现状 | 判定查询 |
+|---|---|---|
+| `7af8533c6` 可中断的 provider 重试 | 早已实现，先于 pi | SDK `max_retries=0`（`llm/client.py`）+ 自有 `_retry.py::_interruptible_sleep` |
+| 6 个 `preserve raw stop reasons` | 从不归一化，原样透传 | `_LENGTH_FINISH_REASONS` 本就是多厂商拼写集合 |
+| `f4e9ca746` 把日期移出 system prompt | agentao 更靠前——pi 是**直接删掉**；agentao 移到 user message 的 per-turn `<system-reminder>` | `tests/test_date_in_prompt.py` |
+| `cced6a21d` nested worktree 重复加载 AGENTS.md | 构造上不可能 | `prompts/helpers.py` 只读 `working_directory / "AGENTAO.md"`，无祖先遍历 |
+| `5d548ae96` rpc bash 绕过权限门 | 没有第二入口 | `grep LocalShellExecutor` → 只有 `tools/shell.py` 与 `tools/base.py` 的 lazy accessor；ACP 无 terminal/exec 方法 |
+| `bd2cfabc5` 拒绝循环引用 | CBOR 特有 | Python `json.dumps` 默认就抛 `Circular reference detected` |
+| `74caa2649` 校验 package manifest | 已足够严 | `embedding/plugins/manifest.py` 逐字段 `isinstance` 校验 |
+| Append-only context 不变量 | 已成立 | `grep 'messages.insert\|messages\[:0\]'` → 无命中；只有整体替换（compaction），正是 pi 自己点名的例外 |
+
+**值得守住的刻意分道：** pi 新增了 `protocol` + `server` + `client`——自研 CBOR 线协议与 Unix socket 传输——现在跑两套远程面。agentao 只有一条（ACP），且是刻意收窄的——见 `acp-server-conformance-review.md` §4，那里的非 IDE / chat-automation 目标客户端裁定，正是「窄」之所以是正确而非残缺的依据。这不是可借鉴项，是一条要守的分界。
+
+**一条观察，不是候选：** `3d8f74357 message-anchored tool loading` 把新增工具锚定到 tool result 的位置而非缓存前缀，从而避免中途加工具冲掉整段缓存。agentao 有同样的形态（`/goal` 的 `add_tool` 注入、skill 激活），但该机制依赖 Anthropic / OpenAI-Responses 的缓存锚点能力，而 agentao 是 chat.completions 形状。搬不过来。
+
+## 过程记录
+
+PR #161 的 xhigh 评审抓出四条我自己写的弱测试，其中包括一个正向 fixture 复用了累加器自身的 `"stop"` 兜底值，导致它的断言根本不可能失败。另外，我有两次反事实检查一开始**通过**了，而它们本该失败——falsy-vs-`None` 那条修复和陈旧摘要标记的重置都处于无保护状态，因为我最初的测试分别只走了 producer 和一个不做 compaction 的 turn，两者都碰不到被改动的那一行。
+
+这条教训超出这个 PR：写出测试不等于做了检查。把修复改回去、确认测试变红，才是检查；而且必须按每一处独立逻辑逐条做——这里就有两个反事实在同时施加时互相掩盖了对方。


### PR DESCRIPTION
Decision record for the 2026-08-02 pi-mono pull — 434 commits / 730 files (`34582ef34..aa0ec808b`), every candidate grep-verified against agentao before being recommended. Bilingual pair plus a `docs/design/README.md` index entry, matching the `pi-mono-borrow-review` / `refactor-audit-2026-07` convention.

## Disposition

| | Item |
|---|---|
| **Landed** | #159 NFKC edit matching · #160 listener-error logging · #161 `finish_reason_missing` |
| **Deferred — contract decision** | Sub-agent boundary · ACP channel |
| **Recorded, gated** | `watch()` atomic snapshot + gap-free subscription |
| **Decision, not recommendation** | Lanes / conversation tree · durable operations with crash recovery |
| **Not applicable** | 8, each with the query that settled it |

## What the doc is actually for

The **not-applicable table is the substantive half**, same as `pi-mono-borrow-review.md` — each row carries the query that settled it, so the same eight proposals are not re-raised without new evidence. Two of those rows are places agentao is *ahead* rather than behind: pi **deleted** the date from its system prompt where agentao moved it to a per-turn reminder, and pi only now made provider retries abortable, which agentao has done since it took the SDK off its own retry path.

`finish_reason_missing` is recorded as **adopted inverted** — the part most likely to be misread later. pi errors by default with a per-model opt-out; agentao reports without classifying, because every member of `INCOMPLETE_ANSWER_REASONS` becomes a CLI error envelope.

## Two corrections made while fact-checking my own draft

Both would have misled a later reader, so they're worth calling out rather than burying:

- The `watch()` section originally described `agentao serve` as merely parked. The roadmap actually **✗-lists** it as clashing with the in-process-harness positioning — so that primitive is *not* waiting on a scheduled feature. Rewritten to name the real trigger: an embedded host attaching an observer mid-turn, which needs no `serve` to happen.
- A citation to a goose ACP-consolidation review was **dangling** — no such document exists in this repo (it was in my working notes, not the tree). Repointed at `acp-server-conformance-review.md` §4, where the narrow-ACP-surface decision actually lives.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)