### PR TITLE
test: hoist duplicated helpers into tests/support and drop stale shim imports

### DIFF
--- a/tests/support/README.md
+++ b/tests/support/README.md
@@ -11,8 +11,24 @@ only one caller, anything that requires a flag to behave differently per call
 site. If an abstraction needs more than two optional knobs, it is probably
 better left inline.
 
-**Import style:** Use relative imports (`from .support.acp_client import X`)
-from inside `tests/`. Helpers here are **plain functions / classes**, not
-pytest fixtures — construction is explicit at the call site.
+**Import style:** Both forms are in use and either is fine, but match the
+file you are editing — the ACP suites use relative
+(`from .support.acp_server import X`), the rest use absolute
+(`from tests.support.memory import X`). Helpers here are **plain functions /
+classes**, not pytest fixtures — construction is explicit at the call site.
 
-See `plans/agentao-fixture-helper-abstract-rossum.md` for the migration plan.
+## Modules
+
+| Module | Holds |
+|---|---|
+| `acp_agents.py` | `FakeAgent` and friends — duck-typed `Agentao` replacements for ACP handler tests. |
+| `acp_client.py` | Fake ACP subprocess servers (`JSONRPC_MOCK_SCRIPT`, `INTERACTION_SERVER_SCRIPT`) + manager/handle builders. |
+| `acp_server.py` | In-memory `AcpServer` builders, plus the `BlockingStdin` / `CapturingStdout` / `RecordingServer` stream doubles. |
+| `host_events.py` | Host event-stream capture. |
+| `mcp.py` | MCP client/tool doubles. |
+| `memory.py` | Memory-store builders. |
+| `permissions.py` | Permission-rule builders. |
+| `stop_precompact.py` | Runner + capture-script setup for the Stop / PreCompact hook suites. |
+| `tool_calls.py` | The OpenAI SDK *wire* `tool_call` shape. |
+| `tools.py` | Registrable tool doubles (`NamedTool`) and `make_dummy_agent`. |
+| `wheel.py` | Built-wheel discovery for the `slow` clean-install tests. |

--- a/tests/support/acp_server.py
+++ b/tests/support/acp_server.py
@@ -13,12 +13,19 @@ or similar pytest-injected values.
 The ``client_capabilities`` default mirrors the "minimal client" shape
 used by the prompt / load / cancel tests. Multi-session and session_new
 tests pass the full ``{"fs": ..., "terminal": True}`` shape explicitly.
+
+Also here: the three stream doubles the end-to-end ACP tests drive
+``AcpServer.run`` with — :class:`BlockingStdin`, :class:`CapturingStdout`
+and :class:`RecordingServer`.
 """
 
 from __future__ import annotations
 
 import io
-from typing import Any, Dict, Optional
+import json
+import queue
+import threading
+from typing import Any, Dict, List, Optional, Tuple
 
 from agentao.acp import initialize as acp_initialize
 from agentao.acp.protocol import ACP_PROTOCOL_VERSION
@@ -74,3 +81,77 @@ def make_initialized_server(
         ),
     )
     return server
+
+
+class BlockingStdin:
+    """File-like stdin that blocks on ``readline`` until a line is pushed.
+
+    ``StringIO`` cannot drive the end-to-end tests: its ``readline``
+    returns ``''`` the moment EOF is reached, so ``AcpServer.run`` bails
+    out and cancels every pending outbound request before an injector
+    thread has a chance to route a response — and it races the worker
+    pool on the cancel tests. A queue-backed stdin lets the test decide
+    exactly when EOF lands: push the response lines, then ``push_eof()``.
+    """
+
+    def __init__(self) -> None:
+        self._q: "queue.Queue[Optional[str]]" = queue.Queue()
+        self._closed = False
+
+    def push_line(self, line: str) -> None:
+        if not line.endswith("\n"):
+            line += "\n"
+        self._q.put(line)
+
+    def push_eof(self) -> None:
+        self._q.put(None)
+
+    def readline(self) -> str:
+        if self._closed:
+            return ""
+        item = self._q.get()
+        if item is None:
+            self._closed = True
+            return ""
+        return item
+
+
+class CapturingStdout:
+    """Stdout double that lets a driver thread poll for completed lines."""
+
+    def __init__(self) -> None:
+        self._buf = io.StringIO()
+        self._lock = threading.Lock()
+
+    def write(self, data: str) -> int:
+        with self._lock:
+            return self._buf.write(data)
+
+    def flush(self) -> None:
+        with self._lock:
+            self._buf.flush()
+
+    def getvalue(self) -> str:
+        with self._lock:
+            return self._buf.getvalue()
+
+
+class RecordingServer:
+    """Stand-in for :class:`AcpServer` that captures notifications.
+
+    Used by the ``ACPTransport`` unit tests so notifications can be
+    inspected without spinning up a real server. Params are round-tripped
+    through JSON on the way in, so a payload carrying a non-serializable
+    value fails loudly here rather than at the wire.
+
+    Note ``test_acp_request_permission`` defines its own, unrelated class
+    of the same name — that one records ``call()`` and returns a
+    ``_PendingRequest``. Different surface, deliberately not merged.
+    """
+
+    def __init__(self) -> None:
+        self.notifications: List[Tuple[str, Dict[str, Any]]] = []
+
+    def write_notification(self, method: str, params: Dict[str, Any]) -> None:
+        encoded = json.dumps(params, separators=(",", ":"))
+        self.notifications.append((method, json.loads(encoded)))

--- a/tests/support/tools.py
+++ b/tests/support/tools.py
@@ -1,0 +1,57 @@
+"""Shared doubles for tool-registration tests.
+
+The three tool-wiring suites (``test_host_tool_injection``,
+``test_host_tool_allowlist``, ``test_runtime_tool_injection``) each need
+the same two things: a concrete :class:`Tool` whose name is decided at
+construction, and an ``Agentao`` built with throwaway LLM config so
+construction touches no network.
+
+Distinct from ``support/tool_calls.py``, which fabricates the OpenAI SDK's
+*wire* ``tool_call`` shape. This module is about registrable tool objects.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from agentao import Agentao
+from agentao.host import Tool
+
+
+class NamedTool(Tool):
+    """Minimal concrete Tool with a configurable name + marker description."""
+
+    def __init__(self, name: str, description: str = "marker") -> None:
+        self._name = name
+        self._description = description
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    def execute(self, **kwargs: Any) -> str:
+        return "ran"
+
+
+def make_dummy_agent(tmp_path: Any, **kwargs: Any) -> Agentao:
+    """Construct an Agentao with dummy LLM config (no network at init).
+
+    ``base_url`` points at port 0 deliberately: if anything in
+    construction were to actually dial the provider, it fails immediately
+    and loudly rather than hanging or reaching a real endpoint.
+    """
+    return Agentao(
+        working_directory=tmp_path,
+        api_key="x",
+        base_url="http://localhost:0",
+        model="dummy",
+        **kwargs,
+    )

--- a/tests/test_acp_mcp_injection.py
+++ b/tests/test_acp_mcp_injection.py
@@ -39,7 +39,6 @@ from agentao.acp.mcp_translate import (
 )
 from agentao.acp.protocol import ACP_PROTOCOL_VERSION
 from agentao.acp.server import AcpServer
-from agentao.session import save_session
 
 
 # ===========================================================================

--- a/tests/test_acp_multi_session.py
+++ b/tests/test_acp_multi_session.py
@@ -44,10 +44,8 @@ history independence (see :class:`TestMessageHistoryIsolation`).
 
 from __future__ import annotations
 
-import io
 import json
 import os
-import queue
 import subprocess
 import sys
 import threading
@@ -77,7 +75,7 @@ from agentao.acp.transport import (
     PERMISSION_REJECT_ALWAYS,
 )
 from agentao.cancellation import CancellationToken
-from agentao.session import save_session
+from agentao.embedding.sessions import save_session
 
 from .support.acp_agents import (
     StallingFakeAgent,
@@ -85,7 +83,12 @@ from .support.acp_agents import (
     make_round_robin_factory,
 )
 from .support.acp_agents import FakeAgent as _FakeAgent
-from .support.acp_server import make_initialized_server, make_server
+from .support.acp_server import (
+    BlockingStdin,
+    CapturingStdout,
+    make_initialized_server,
+    make_server,
+)
 
 
 # ===========================================================================
@@ -115,56 +118,6 @@ class FakeAgent(_FakeAgent):
             side_effect=side_effect,
             track_messages=track_messages,
         )
-
-
-# ===========================================================================
-# I/O test doubles (shared with the prompt/cancel/load test files)
-# ===========================================================================
-
-
-class BlockingStdin:
-    """Queue-backed stdin so a driver thread can control EOF timing."""
-
-    def __init__(self) -> None:
-        self._q: "queue.Queue[Optional[str]]" = queue.Queue()
-        self._closed = False
-
-    def push_line(self, line: str) -> None:
-        if not line.endswith("\n"):
-            line += "\n"
-        self._q.put(line)
-
-    def push_eof(self) -> None:
-        self._q.put(None)
-
-    def readline(self) -> str:
-        if self._closed:
-            return ""
-        item = self._q.get()
-        if item is None:
-            self._closed = True
-            return ""
-        return item
-
-
-class CapturingStdout:
-    """Stdout double that lets a driver thread poll for completed lines."""
-
-    def __init__(self) -> None:
-        self._buf = io.StringIO()
-        self._lock = threading.Lock()
-
-    def write(self, data: str) -> int:
-        with self._lock:
-            return self._buf.write(data)
-
-    def flush(self) -> None:
-        with self._lock:
-            self._buf.flush()
-
-    def getvalue(self) -> str:
-        with self._lock:
-            return self._buf.getvalue()
 
 
 # ===========================================================================

--- a/tests/test_acp_request_permission.py
+++ b/tests/test_acp_request_permission.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import io
 import json
-import queue
 import threading
 import time
 from typing import Any, Callable, Dict, List, Optional
@@ -57,6 +56,8 @@ from agentao.acp.transport import (
     _build_permission_options,
 )
 from agentao.cancellation import CancellationToken
+
+from .support.acp_server import BlockingStdin
 
 
 # ---------------------------------------------------------------------------
@@ -119,40 +120,6 @@ def _register_session(server: Any, session_id: str = "sess_test") -> AcpSessionS
     state = AcpSessionState(session_id=session_id)
     server.sessions.create(state)
     return state
-
-
-class BlockingStdin:
-    """File-like stdin that blocks on readline until a line is pushed.
-
-    ``StringIO`` won't work for the end-to-end permission tests because
-    ``StringIO.readline()`` returns ``''`` immediately once EOF is
-    reached, so ``AcpServer.run`` bails out and cancels every pending
-    outbound request before any injector thread has a chance to route a
-    response. A queue-backed stdin lets the test control when EOF lands
-    — we push the permission response line and then push a sentinel
-    ``None`` to signal EOF explicitly.
-    """
-
-    def __init__(self) -> None:
-        self._queue: "queue.Queue[Optional[str]]" = queue.Queue()
-        self._closed = False
-
-    def push_line(self, line: str) -> None:
-        if not line.endswith("\n"):
-            line = line + "\n"
-        self._queue.put(line)
-
-    def push_eof(self) -> None:
-        self._queue.put(None)
-
-    def readline(self) -> str:
-        if self._closed:
-            return ""
-        item = self._queue.get()
-        if item is None:
-            self._closed = True
-            return ""
-        return item
 
 
 # ===========================================================================

--- a/tests/test_acp_session_cancel.py
+++ b/tests/test_acp_session_cancel.py
@@ -21,10 +21,9 @@ from __future__ import annotations
 
 import io
 import json
-import queue
 import threading
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 import pytest
 
@@ -45,7 +44,11 @@ from agentao.acp.server import AcpServer, JsonRpcHandlerError
 from agentao.cancellation import CancellationToken
 
 from .support.acp_agents import StallingFakeAgent
-from .support.acp_server import make_initialized_server, make_server
+from .support.acp_server import (
+    BlockingStdin,
+    make_initialized_server,
+    make_server,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -395,36 +398,6 @@ def test_register_populates_handler_dict(initialized_server):
 # ===========================================================================
 # End-to-end: cancel a turn that is mid-flight
 # ===========================================================================
-
-
-class BlockingStdin:
-    """Queue-backed stdin for end-to-end tests.
-
-    StringIO returns ``''`` immediately on EOF, which races the worker
-    pool. A queue lets the test control exactly when EOF lands so we
-    can guarantee the cancel arrives before run() exits.
-    """
-
-    def __init__(self) -> None:
-        self._q: "queue.Queue[Optional[str]]" = queue.Queue()
-        self._closed = False
-
-    def push_line(self, line: str) -> None:
-        if not line.endswith("\n"):
-            line += "\n"
-        self._q.put(line)
-
-    def push_eof(self) -> None:
-        self._q.put(None)
-
-    def readline(self) -> str:
-        if self._closed:
-            return ""
-        item = self._q.get()
-        if item is None:
-            self._closed = True
-            return ""
-        return item
 
 
 class TestEndToEndCancel:

--- a/tests/test_acp_session_load.py
+++ b/tests/test_acp_session_load.py
@@ -23,11 +23,10 @@ from __future__ import annotations
 
 import io
 import json
-import queue
 import threading
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 import pytest
 
@@ -52,31 +51,16 @@ from agentao.acp.transport import (
     _strip_system_reminder_blocks,
 )
 from agentao.cancellation import CancellationToken
-from agentao.session import save_session
+from agentao.embedding.sessions import save_session
 
 from .support.acp_agents import FakeAgent, make_factory
-from .support.acp_server import make_initialized_server, make_server
-
-
-# ---------------------------------------------------------------------------
-# Test doubles
-# ---------------------------------------------------------------------------
-
-
-class RecordingServer:
-    """Stand-in for :class:`AcpServer` that captures notifications.
-
-    Used by the unit tests for ``ACPTransport.replay_history`` so we can
-    inspect the produced notifications without spinning up a real server.
-    """
-
-    def __init__(self) -> None:
-        self.notifications: List[Tuple[str, Dict[str, Any]]] = []
-
-    def write_notification(self, method: str, params: Dict[str, Any]) -> None:
-        # Round-trip through JSON to assert payloads are serializable.
-        encoded = json.dumps(params, separators=(",", ":"))
-        self.notifications.append((method, json.loads(encoded)))
+from .support.acp_server import (
+    BlockingStdin,
+    CapturingStdout,
+    RecordingServer,
+    make_initialized_server,
+    make_server,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -113,51 +97,6 @@ def _load_params(cwd: Path, session_id: str) -> Dict[str, Any]:
         "cwd": str(cwd),
         "mcpServers": [],
     }
-
-
-class BlockingStdin:
-    """Queue-backed stdin so a test can interleave reads with run()."""
-
-    def __init__(self) -> None:
-        self._q: "queue.Queue[Optional[str]]" = queue.Queue()
-        self._closed = False
-
-    def push_line(self, line: str) -> None:
-        if not line.endswith("\n"):
-            line += "\n"
-        self._q.put(line)
-
-    def push_eof(self) -> None:
-        self._q.put(None)
-
-    def readline(self) -> str:
-        if self._closed:
-            return ""
-        item = self._q.get()
-        if item is None:
-            self._closed = True
-            return ""
-        return item
-
-
-class CapturingStdout:
-    """Stdout double that lets a test poll for completed responses."""
-
-    def __init__(self) -> None:
-        self._buf = io.StringIO()
-        self._lock = threading.Lock()
-
-    def write(self, data: str) -> int:
-        with self._lock:
-            return self._buf.write(data)
-
-    def flush(self) -> None:
-        with self._lock:
-            self._buf.flush()
-
-    def getvalue(self) -> str:
-        with self._lock:
-            return self._buf.getvalue()
 
 
 # ===========================================================================

--- a/tests/test_acp_transport.py
+++ b/tests/test_acp_transport.py
@@ -12,7 +12,7 @@ import io
 import json
 import threading
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict
 
 import pytest
 
@@ -21,22 +21,7 @@ from agentao.acp.server import AcpServer
 from agentao.acp.transport import ACPTransport, _json_safe, _todo_write_plan, _tool_kind
 from agentao.transport.events import AgentEvent, EventType
 
-
-# ---------------------------------------------------------------------------
-# Test doubles
-# ---------------------------------------------------------------------------
-
-class RecordingServer:
-    """Stand-in for :class:`AcpServer` that captures notification calls."""
-
-    def __init__(self) -> None:
-        self.notifications: List[Tuple[str, Dict[str, Any]]] = []
-
-    def write_notification(self, method: str, params: Dict[str, Any]) -> None:
-        # Round-trip through json to guarantee JSON-safety of payloads —
-        # if any value is not serializable the test fails loudly.
-        encoded = json.dumps(params, separators=(",", ":"))
-        self.notifications.append((method, json.loads(encoded)))
+from .support.acp_server import RecordingServer
 
 
 @pytest.fixture

--- a/tests/test_host_tool_allowlist.py
+++ b/tests/test_host_tool_allowlist.py
@@ -18,43 +18,9 @@ from __future__ import annotations
 
 import pytest
 
-from agentao import Agentao
-from agentao.host import Tool
 from agentao.tooling import BUILTIN_TOOL_NAMES
 
-
-def _make_agent(tmp_path, **kwargs) -> Agentao:
-    """Construct an Agentao with a dummy LLM config (no network at init)."""
-    return Agentao(
-        working_directory=tmp_path,
-        api_key="x",
-        base_url="http://localhost:0",
-        model="dummy",
-        **kwargs,
-    )
-
-
-class _NamedTool(Tool):
-    """Minimal concrete Tool with a configurable name."""
-
-    def __init__(self, name: str, description: str = "marker") -> None:
-        self._name = name
-        self._description = description
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @property
-    def description(self) -> str:
-        return self._description
-
-    @property
-    def parameters(self):
-        return {"type": "object", "properties": {}}
-
-    def execute(self, **kwargs) -> str:
-        return "ran"
+from tests.support.tools import NamedTool, make_dummy_agent
 
 
 # A small set of unconditional built-ins (no [web]/bg_store dependency).
@@ -67,7 +33,7 @@ _CORE = {"read_file", "write_file", "replace",
 
 def test_enabled_none_is_status_quo(tmp_path):
     """``enabled_tools=None`` registers built-ins as before."""
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
         # Sanity: unconditional built-ins all present without an allowlist.
         assert _CORE <= set(agent.tools.tools)
@@ -80,7 +46,7 @@ def test_enabled_none_is_status_quo(tmp_path):
 
 def test_allowlist_keeps_only_named_builtins(tmp_path):
     keep = {"read_file", "run_shell_command"}
-    agent = _make_agent(tmp_path, enabled_tools=keep)
+    agent = make_dummy_agent(tmp_path, enabled_tools=keep)
     try:
         present = set(agent.tools.tools)
         assert keep <= present
@@ -93,7 +59,7 @@ def test_allowlist_keeps_only_named_builtins(tmp_path):
 
 def test_allowlist_prunes_optional_builtins(tmp_path):
     """A built-in left out of the allowlist is gone even if normally present."""
-    agent = _make_agent(tmp_path, enabled_tools={"read_file"})
+    agent = make_dummy_agent(tmp_path, enabled_tools={"read_file"})
     try:
         present = set(agent.tools.tools)
         for name in ("todo_write", "save_memory", "activate_skill", "ask_user"):
@@ -107,7 +73,7 @@ def test_allowlist_prunes_optional_builtins(tmp_path):
 
 def test_empty_set_prunes_all_builtins(tmp_path):
     """``enabled_tools=set()`` removes every built-in / agent tool."""
-    agent = _make_agent(tmp_path, enabled_tools=set())
+    agent = make_dummy_agent(tmp_path, enabled_tools=set())
     try:
         present = set(agent.tools.tools)
         # No built-in survives an empty allowlist.
@@ -121,9 +87,9 @@ def test_empty_set_prunes_all_builtins(tmp_path):
 
 def test_extra_tools_kept_despite_allowlist(tmp_path):
     """An injected extra survives even when not named in the allowlist."""
-    agent = _make_agent(
+    agent = make_dummy_agent(
         tmp_path,
-        extra_tools=[_NamedTool("my_retrieval")],
+        extra_tools=[NamedTool("my_retrieval")],
         enabled_tools={"read_file"},
     )
     try:
@@ -137,9 +103,9 @@ def test_extra_tools_kept_despite_allowlist(tmp_path):
 
 def test_extra_name_in_allowlist_is_not_required_but_harmless(tmp_path):
     """Naming the extra in the allowlist too is allowed (no typo error)."""
-    agent = _make_agent(
+    agent = make_dummy_agent(
         tmp_path,
-        extra_tools=[_NamedTool("my_retrieval")],
+        extra_tools=[NamedTool("my_retrieval")],
         enabled_tools={"read_file", "my_retrieval"},
     )
     try:
@@ -153,7 +119,7 @@ def test_extra_name_in_allowlist_is_not_required_but_harmless(tmp_path):
 
 def test_enabled_and_disable_mutually_exclusive(tmp_path):
     with pytest.raises(ValueError, match="mutually exclusive"):
-        _make_agent(
+        make_dummy_agent(
             tmp_path,
             enabled_tools={"read_file"},
             disable_tools={"web_search"},
@@ -163,7 +129,7 @@ def test_enabled_and_disable_mutually_exclusive(tmp_path):
 def test_empty_allowlist_still_excludes_disable(tmp_path):
     """Even an empty allowlist is 'enabled', so it clashes with disable_tools."""
     with pytest.raises(ValueError, match="mutually exclusive"):
-        _make_agent(tmp_path, enabled_tools=set(), disable_tools={"read_file"})
+        make_dummy_agent(tmp_path, enabled_tools=set(), disable_tools={"read_file"})
 
 
 # ── Reserved names raise at construction ──────────────────────────────────
@@ -171,12 +137,12 @@ def test_empty_allowlist_still_excludes_disable(tmp_path):
 
 def test_allowlist_mcp_prefix_rejected(tmp_path):
     with pytest.raises(ValueError, match="reserved 'mcp_' prefix"):
-        _make_agent(tmp_path, enabled_tools={"read_file", "mcp_alpha_ping"})
+        make_dummy_agent(tmp_path, enabled_tools={"read_file", "mcp_alpha_ping"})
 
 
 def test_allowlist_plan_only_rejected(tmp_path):
     with pytest.raises(ValueError, match="reserved for plan mode"):
-        _make_agent(tmp_path, enabled_tools={"plan_save"})
+        make_dummy_agent(tmp_path, enabled_tools={"plan_save"})
 
 
 # ── Unknown name typo guard (apply-time, against live registry) ────────────
@@ -184,7 +150,7 @@ def test_allowlist_plan_only_rejected(tmp_path):
 
 def test_allowlist_unknown_name_rejected(tmp_path):
     with pytest.raises(ValueError, match="unknown tool name"):
-        _make_agent(tmp_path, enabled_tools={"read_fil"})
+        make_dummy_agent(tmp_path, enabled_tools={"read_fil"})
 
 
 def test_allowlist_known_builtin_without_extra_is_legal(tmp_path):
@@ -193,7 +159,7 @@ def test_allowlist_known_builtin_without_extra_is_legal(tmp_path):
     ``web_search`` only registers with the ``[web]`` extra, but it's a legal
     built-in name, so allowlisting it must not be flagged as a typo.
     """
-    agent = _make_agent(tmp_path, enabled_tools={"read_file", "web_search"})
+    agent = make_dummy_agent(tmp_path, enabled_tools={"read_file", "web_search"})
     try:
         assert "read_file" in agent.tools.tools
     finally:

--- a/tests/test_host_tool_injection.py
+++ b/tests/test_host_tool_injection.py
@@ -17,51 +17,18 @@ from __future__ import annotations
 
 import pytest
 
-from agentao import Agentao
 from agentao.host import AsyncToolBase, RegistrableTool, Tool
 from agentao.tooling import BUILTIN_TOOL_NAMES
 from agentao.tools.web import WebSearchTool
 
-
-def _make_agent(tmp_path, **kwargs) -> Agentao:
-    """Construct an Agentao with a dummy LLM config (no network at init)."""
-    return Agentao(
-        working_directory=tmp_path,
-        api_key="x",
-        base_url="http://localhost:0",
-        model="dummy",
-        **kwargs,
-    )
-
-
-class _NamedTool(Tool):
-    """Minimal concrete Tool with a configurable name + marker description."""
-
-    def __init__(self, name: str, description: str = "marker") -> None:
-        self._name = name
-        self._description = description
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @property
-    def description(self) -> str:
-        return self._description
-
-    @property
-    def parameters(self):
-        return {"type": "object", "properties": {}}
-
-    def execute(self, **kwargs) -> str:
-        return "ran"
+from tests.support.tools import NamedTool, make_dummy_agent
 
 
 # ── Contract 1: extra_tools register last & override ──────────────────────
 
 
 def test_extra_tools_add_new_tool(tmp_path):
-    agent = _make_agent(tmp_path, extra_tools=[_NamedTool("my_retrieval")])
+    agent = make_dummy_agent(tmp_path, extra_tools=[NamedTool("my_retrieval")])
     try:
         assert "my_retrieval" in agent.tools.tools
     finally:
@@ -76,8 +43,8 @@ def test_extra_tools_override_builtin(tmp_path):
     conditional tool like ``web_search`` would silently degrade to an "add"
     when ``bs4`` is absent.
     """
-    custom = _NamedTool("read_file", description="custom-override")
-    agent = _make_agent(tmp_path, extra_tools=[custom])
+    custom = NamedTool("read_file", description="custom-override")
+    agent = make_dummy_agent(tmp_path, extra_tools=[custom])
     try:
         assert agent.tools.tools["read_file"] is custom
         assert agent.tools.tools["read_file"].description == "custom-override"
@@ -87,8 +54,8 @@ def test_extra_tools_override_builtin(tmp_path):
 
 def test_extra_tools_inherit_capability_binding(tmp_path):
     """Injected tools get the same wd/filesystem/shell binding as built-ins."""
-    tool = _NamedTool("my_retrieval")
-    agent = _make_agent(tmp_path, extra_tools=[tool])
+    tool = NamedTool("my_retrieval")
+    agent = make_dummy_agent(tmp_path, extra_tools=[tool])
     try:
         registered = agent.tools.tools["my_retrieval"]
         assert registered.working_directory == agent._working_directory
@@ -106,14 +73,14 @@ def test_extra_tools_inherit_capability_binding(tmp_path):
 
 def test_extra_tools_mcp_prefix_rejected(tmp_path):
     with pytest.raises(ValueError, match="reserved 'mcp_' prefix"):
-        _make_agent(tmp_path, extra_tools=[_NamedTool("mcp_alpha_ping")])
+        make_dummy_agent(tmp_path, extra_tools=[NamedTool("mcp_alpha_ping")])
 
 
 def test_extra_tools_duplicate_name_rejected(tmp_path):
     with pytest.raises(ValueError, match="duplicate tool name"):
-        _make_agent(
+        make_dummy_agent(
             tmp_path,
-            extra_tools=[_NamedTool("dup"), _NamedTool("dup")],
+            extra_tools=[NamedTool("dup"), NamedTool("dup")],
         )
 
 
@@ -122,11 +89,11 @@ def test_extra_tools_duplicate_name_rejected(tmp_path):
 
 def test_disable_unknown_tool_raises(tmp_path):
     with pytest.raises(ValueError, match="unknown built-in tool name"):
-        _make_agent(tmp_path, disable_tools={"web_serach"})
+        make_dummy_agent(tmp_path, disable_tools={"web_serach"})
 
 
 def test_disable_known_tool_skips_registration(tmp_path):
-    agent = _make_agent(tmp_path, disable_tools={"read_file"})
+    agent = make_dummy_agent(tmp_path, disable_tools={"read_file"})
     try:
         assert "read_file" not in agent.tools.tools
         # Other built-ins remain.
@@ -142,7 +109,7 @@ def test_disable_tool_without_extra_dep_is_noop_not_error(tmp_path):
     not live availability — so ``web_search`` is always a valid name even
     when ``[web]`` isn't installed; disabling it is simply a no-op then.
     """
-    agent = _make_agent(tmp_path, disable_tools={"web_search", "web_fetch"})
+    agent = make_dummy_agent(tmp_path, disable_tools={"web_search", "web_fetch"})
     try:
         assert "web_search" not in agent.tools.tools
         assert "web_fetch" not in agent.tools.tools
@@ -156,8 +123,8 @@ def test_disable_plus_extra_replacement(tmp_path):
     Uses ``read_file`` (unconditional) so the disable+replace path is
     exercised on any install, not only when ``[web]`` is present.
     """
-    custom = _NamedTool("read_file", description="host-owned")
-    agent = _make_agent(
+    custom = NamedTool("read_file", description="host-owned")
+    agent = make_dummy_agent(
         tmp_path, disable_tools={"read_file"}, extra_tools=[custom]
     )
     try:
@@ -218,7 +185,7 @@ def test_web_search_bocha_backend_without_key_raises(monkeypatch):
 
 def test_extra_tools_empty_name_rejected(tmp_path):
     with pytest.raises(ValueError, match="non-empty string"):
-        _make_agent(tmp_path, extra_tools=[_NamedTool("")])
+        make_dummy_agent(tmp_path, extra_tools=[NamedTool("")])
 
 
 def test_extra_tools_override_is_logged_and_unwarned(tmp_path, caplog):
@@ -233,9 +200,9 @@ def test_extra_tools_override_is_logged_and_unwarned(tmp_path, caplog):
     # ``read_file`` is unconditional — without it (e.g. overriding the
     # bs4-gated web_search on a bare install) replace would be False and the
     # asserted INFO line would never fire.
-    custom = _NamedTool("read_file", description="host-owned")
+    custom = NamedTool("read_file", description="host-owned")
     with caplog.at_level(logging.INFO):
-        agent = _make_agent(tmp_path, extra_tools=[custom])
+        agent = make_dummy_agent(tmp_path, extra_tools=[custom])
     try:
         infos = [r for r in caplog.records if r.levelno == logging.INFO
                  and "overrides an already-registered tool" in r.getMessage()]
@@ -275,8 +242,8 @@ def test_builtin_tool_names_constant_in_sync(tmp_path):
     fake._disable_tools = frozenset()
     fake.bg_store = Mock()  # truthy → bg tools register
     fake.skill_manager = Mock()
-    fake.todo_tool = _NamedTool("todo_write")
-    fake.memory_tool = _NamedTool("save_memory")
+    fake.todo_tool = NamedTool("todo_write")
+    fake.memory_tool = NamedTool("save_memory")
     fake.transport = Mock()
 
     from agentao.tools.base import ToolRegistry

--- a/tests/test_runtime_tool_injection.py
+++ b/tests/test_runtime_tool_injection.py
@@ -18,42 +18,9 @@ import logging
 
 import pytest
 
-from agentao import Agentao
-from agentao.host import Tool
 from agentao.tools.base import ToolRegistry
 
-
-def _make_agent(tmp_path, **kwargs) -> Agentao:
-    return Agentao(
-        working_directory=tmp_path,
-        api_key="x",
-        base_url="http://localhost:0",
-        model="dummy",
-        **kwargs,
-    )
-
-
-class _NamedTool(Tool):
-    """Minimal concrete Tool with a configurable name + marker description."""
-
-    def __init__(self, name: str, description: str = "marker") -> None:
-        self._name = name
-        self._description = description
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @property
-    def description(self) -> str:
-        return self._description
-
-    @property
-    def parameters(self):
-        return {"type": "object", "properties": {}}
-
-    def execute(self, **kwargs) -> str:
-        return "ran"
+from tests.support.tools import NamedTool, make_dummy_agent
 
 
 # ── ToolRegistry.unregister (the base primitive) ──────────────────────────
@@ -61,7 +28,7 @@ class _NamedTool(Tool):
 
 def test_registry_unregister_present_and_absent():
     reg = ToolRegistry()
-    reg.register(_NamedTool("alpha"))
+    reg.register(NamedTool("alpha"))
     assert reg.unregister("alpha") is True
     assert "alpha" not in reg.tools
     # Second removal / unknown name → False, never raises.
@@ -73,9 +40,9 @@ def test_registry_unregister_present_and_absent():
 
 
 def test_add_tool_registers_new(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
-        agent.add_tool(_NamedTool("my_retrieval"))
+        agent.add_tool(NamedTool("my_retrieval"))
         assert "my_retrieval" in agent.tools.tools
     finally:
         agent.close()
@@ -89,9 +56,9 @@ def test_add_tool_binds_capabilities(tmp_path):
     ``None is None`` and pass even if ``_bind_and_register`` never ran.
     """
     fs_sentinel, shell_sentinel = object(), object()
-    agent = _make_agent(tmp_path, filesystem=fs_sentinel, shell=shell_sentinel)
+    agent = make_dummy_agent(tmp_path, filesystem=fs_sentinel, shell=shell_sentinel)
     try:
-        tool = _NamedTool("my_retrieval")
+        tool = NamedTool("my_retrieval")
         agent.add_tool(tool)
         registered = agent.tools.tools["my_retrieval"]
         assert registered.working_directory == agent._working_directory
@@ -105,19 +72,19 @@ def test_add_tool_binds_capabilities(tmp_path):
 
 
 def test_add_tool_existing_name_requires_replace(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
         with pytest.raises(ValueError, match="already.*registered"):
-            agent.add_tool(_NamedTool("read_file"))
+            agent.add_tool(NamedTool("read_file"))
     finally:
         agent.close()
 
 
 def test_add_tool_replace_overrides_and_logs(tmp_path, caplog):
     """``replace=True`` overrides a built-in, silent save for an INFO audit line."""
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
-        custom = _NamedTool("read_file", description="host-owned")
+        custom = NamedTool("read_file", description="host-owned")
         with caplog.at_level(logging.INFO):
             agent.add_tool(custom, replace=True)
         assert agent.tools.tools["read_file"] is custom
@@ -133,10 +100,10 @@ def test_add_tool_replace_overrides_and_logs(tmp_path, caplog):
 
 def test_add_tool_replace_on_absent_name_is_plain_add(tmp_path, caplog):
     """``replace=True`` for a fresh name just adds — no override log, no warning."""
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
         with caplog.at_level(logging.INFO):
-            agent.add_tool(_NamedTool("brand_new"), replace=True)
+            agent.add_tool(NamedTool("brand_new"), replace=True)
         assert "brand_new" in agent.tools.tools
         assert not [r for r in caplog.records
                     if "overrides an already-registered tool" in r.getMessage()]
@@ -148,10 +115,10 @@ def test_add_tool_replace_on_absent_name_is_plain_add(tmp_path, caplog):
 
 
 def test_add_tool_mcp_prefix_rejected(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
         with pytest.raises(ValueError, match="reserved 'mcp_' prefix"):
-            agent.add_tool(_NamedTool("mcp_alpha_ping"))
+            agent.add_tool(NamedTool("mcp_alpha_ping"))
     finally:
         agent.close()
 
@@ -159,19 +126,19 @@ def test_add_tool_mcp_prefix_rejected(tmp_path):
 @pytest.mark.parametrize("replace", [False, True])
 def test_add_tool_plan_name_rejected(tmp_path, replace):
     """Closes the ``add_tool(name='plan_save', replace=True)`` loophole."""
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
         with pytest.raises(ValueError, match="reserved for plan mode"):
-            agent.add_tool(_NamedTool("plan_save"), replace=replace)
+            agent.add_tool(NamedTool("plan_save"), replace=replace)
     finally:
         agent.close()
 
 
 def test_add_tool_empty_name_rejected(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
         with pytest.raises(ValueError, match="non-empty string"):
-            agent.add_tool(_NamedTool(""))
+            agent.add_tool(NamedTool(""))
     finally:
         agent.close()
 
@@ -180,7 +147,7 @@ def test_add_tool_empty_name_rejected(tmp_path):
 
 
 def test_remove_tool_existing_returns_true(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
         assert "read_file" in agent.tools.tools
         assert agent.remove_tool("read_file") is True
@@ -190,7 +157,7 @@ def test_remove_tool_existing_returns_true(tmp_path):
 
 
 def test_remove_tool_unknown_returns_false(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
         assert agent.remove_tool("never_existed") is False
     finally:
@@ -198,7 +165,7 @@ def test_remove_tool_unknown_returns_false(tmp_path):
 
 
 def test_remove_tool_mcp_prefix_rejected(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
         with pytest.raises(ValueError, match="reserved 'mcp_' prefix"):
             agent.remove_tool("mcp_alpha_ping")
@@ -207,7 +174,7 @@ def test_remove_tool_mcp_prefix_rejected(tmp_path):
 
 
 def test_remove_tool_plan_name_rejected(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
         with pytest.raises(ValueError, match="reserved for plan mode"):
             agent.remove_tool("plan_finalize")
@@ -217,7 +184,7 @@ def test_remove_tool_plan_name_rejected(tmp_path):
 
 def test_remove_tool_non_string_raises_clean_error(tmp_path):
     """A non-string name fails with a clear ValueError, not an AttributeError."""
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
         with pytest.raises(ValueError, match="must be a string"):
             agent.remove_tool(123)  # type: ignore[arg-type]
@@ -226,9 +193,9 @@ def test_remove_tool_non_string_raises_clean_error(tmp_path):
 
 
 def test_add_then_remove_round_trip(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
-        agent.add_tool(_NamedTool("ephemeral"))
+        agent.add_tool(NamedTool("ephemeral"))
         assert "ephemeral" in agent.tools.tools
         assert agent.remove_tool("ephemeral") is True
         assert "ephemeral" not in agent.tools.tools
@@ -242,7 +209,7 @@ def test_add_then_remove_round_trip(tmp_path):
 def test_extra_tools_plan_name_rejected_at_construction(tmp_path):
     """Reserving plan names also closes 'extra_tools named plan_save'."""
     with pytest.raises(ValueError, match="reserved for plan mode"):
-        _make_agent(tmp_path, extra_tools=[_NamedTool("plan_save")])
+        make_dummy_agent(tmp_path, extra_tools=[NamedTool("plan_save")])
 
 
 # ── Visibility: changes reach the per-call schema snapshot ────────────────
@@ -250,13 +217,13 @@ def test_extra_tools_plan_name_rejected_at_construction(tmp_path):
 
 def test_add_remove_reflected_in_schema_snapshot(tmp_path):
     """``to_openai_format`` is what ``chat()``/``arun()`` snapshots per call."""
-    agent = _make_agent(tmp_path)
+    agent = make_dummy_agent(tmp_path)
     try:
         def names():
             return {t["function"]["name"] for t in agent.tools.to_openai_format()}
 
         assert "my_retrieval" not in names()
-        agent.add_tool(_NamedTool("my_retrieval"))
+        agent.add_tool(NamedTool("my_retrieval"))
         assert "my_retrieval" in names()
         agent.remove_tool("my_retrieval")
         assert "my_retrieval" not in names()


### PR DESCRIPTION
Tiers 2 and 3 of the test-suite redundancy audit (Tier 1 is #163 — independent, no file overlap, either can merge first).

**`12 files changed, 247 insertions(+), 377 deletions(-)`**

## Tier 2 — helper deduplication

`tests/support/README.md` already states the rule: *"Helpers that are (or would be) duplicated across 2+ test files"* belong in `tests/support/`. These predate it.

| Helper | Copies | Status | New home |
|---|---|---|---|
| `NamedTool` + `make_dummy_agent` | 3 | byte-identical (`md5 08375cee` / `bd12aeda` ×3) | `tests/support/tools.py` *(new)* |
| `BlockingStdin` | 4 | identical but for docstrings and a `_q`/`_queue` rename | `tests/support/acp_server.py` |
| `CapturingStdout` | 2 | byte-identical (`md5 35d962fe` ×2) | `tests/support/acp_server.py` |
| `RecordingServer` | 2 of 3 | `session_load` + `transport` are the same class | `tests/support/acp_server.py` |

The audit initially counted only `_NamedTool`; the `_make_agent` factory sitting beside it in all three files was equally duplicated and came along.

### Two candidates rejected rather than merged

- **`test_acp_multi_session.FakeAgent` is not a duplicate.** It's `class FakeAgent(_FakeAgent)` — an intentional subclass flipping `track_messages` to True. The support-side docstring already records why the default must stay False (the `session_load` tests hydrate `messages` externally, then assert `chat` doesn't mutate it). Left alone.
- **`_FakeAgent`/`_FakeLLM` in `test_acp_session_set_model` vs `test_acp_set_config_option` have genuinely diverged** — one exposes `list_available_models` + a context manager, the other `set_provider` + `base_url`. Unifying needs more optional knobs than the support README's own *"probably better left inline"* threshold allows.

`test_acp_request_permission` keeps its own `RecordingServer` — same name, unrelated class (records `call()`, returns a `_PendingRequest`). The shared one's docstring flags the collision so the next reader doesn't try to merge them.

## Tier 3 — stale shim imports

`agentao.session` is deprecated and scheduled for removal in 0.5.0.

- **`test_acp_mcp_injection`** imported `save_session` and **never called it**. This was the module-scope import printing a `DeprecationWarning` on *every collection of the whole suite*. Deleted.
- **`test_acp_session_load` / `test_acp_multi_session`** → `agentao.embedding.sessions`.

That second one is safe as a pure import swap only because every call site already passes `project_root=` explicitly. It matters: the shim's job is supplying a `Path.cwd()` fallback that the new path **stops offering after 0.5.0**, so swapping a call site that relied on the fallback would compile now and break at removal. Checked all four call sites first.

`test_session` keeps its `agentao.session` import — it is the test *of* the shim.

`tests/support/README.md` pointed at `plans/agentao-fixture-helper-abstract-rossum.md`; that directory doesn't exist in the repo. Replaced with a module table, and the import-style note now describes what the tree actually does (ACP suites relative, everything else absolute) rather than mandating one form.

## Verification

- **3808 passed, 2 skipped, 9 deselected** — identical to the base commit, no test lost
- The `agentao.session` `DeprecationWarning` is **gone from the collection warnings summary**; only the intentional legacy-callback one remains
- No linter is configured in this repo, so unused imports were checked with a throwaway AST pass diffed against the HEAD baseline: the six imports stranded by the removals (`queue` ×3, `io`, `Optional`, `List`/`Tuple`) are cleaned, and the pre-existing dead imports were left untouched so they don't muddy this diff

Those pre-existing ones are a real if minor finding — ~8 dead imports across the ACP suites at HEAD (`Callable`/`Dict`/`List` in `session_cancel`, `INTERNAL_ERROR`/`METHOD_SESSION_NEW` in `request_permission`, `acp_initialize`/`make_round_robin_factory` in `multi_session`, and 7 in `session_load`). Deliberately out of scope here; worth a separate sweep, ideally with a linter added so they stop accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)