### PR TITLE
ci: add a narrow ruff gate for defect rules only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,27 @@ jobs:
       - name: mypy --strict --package agentao.host
         run: uv run --python 3.12 mypy --strict --package agentao.host
 
+  lint-gate:
+    name: Lint gate (ruff, defect rules only)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python 3.12
+        run: uv python install 3.12
+
+      - name: Install dependencies (incl. dev group for ruff)
+        run: uv sync --python 3.12 --group dev
+
+      # Rule selection lives in pyproject.toml :: [tool.ruff.lint]. It is
+      # deliberately narrow (E9/F402/F811/F821) — see docs/design/lint-gate.md.
+      - name: ruff check
+        run: uv run --python 3.12 ruff check agentao/ tests/ examples/
+
   # ─────────────────────────────────────────────────────────────
   # Job 1 · Unit tests across Python 3.10 / 3.11 / 3.12
   # ─────────────────────────────────────────────────────────────

--- a/agentao/cli/_utils.py
+++ b/agentao/cli/_utils.py
@@ -151,8 +151,14 @@ class _SlashCompleter(Completer):
             )
 
 
-def _display_layered_entries(entries, header: str, console) -> None:
-    """Display MemoryRecord list in a readable format."""
+def _display_layered_entries(entries, header: str) -> None:
+    """Display MemoryRecord list in a readable format.
+
+    Prints via the module-level ``console`` singleton. This used to take
+    ``console`` as a third parameter, but both call sites passed the same
+    ``._globals.console`` this module already imports — the parameter only
+    shadowed it.
+    """
     if not entries:
         console.print(f"\n[warning]{header}: no entries.[/warning]\n")
         return

--- a/agentao/cli/app.py
+++ b/agentao/cli/app.py
@@ -269,7 +269,7 @@ class AgentaoCLI:
         # Images staged via /image, attached to (and consumed by) the next
         # chat turn. Each entry is {"data": <base64>, "mimeType": ...}.
         self._staged_images: list = []
-        from ..plan import PlanSession, PlanController
+        from ..plan import PlanSession
         self._plan_session = PlanSession()
         self._plan_controller: Optional[object] = None
         provider = resolve_provider_name()

--- a/agentao/cli/commands_ext/memory.py
+++ b/agentao/cli/commands_ext/memory.py
@@ -112,11 +112,11 @@ def show_memories(cli: AgentaoCLI, subcommand: str = "", arg: str = "") -> None:
 
     elif subcommand == "user":
         entries = mgr.get_all_entries(scope="user")
-        _display_layered_entries(entries, "[Profile Memory]", console)
+        _display_layered_entries(entries, "[Profile Memory]")
 
     elif subcommand == "project":
         entries = mgr.get_all_entries(scope="project")
-        _display_layered_entries(entries, "[Project Memory]", console)
+        _display_layered_entries(entries, "[Project Memory]")
 
     elif subcommand == "session":
         summaries = mgr.get_recent_session_summaries(limit=10)

--- a/agentao/sandbox/policy.py
+++ b/agentao/sandbox/policy.py
@@ -210,16 +210,16 @@ def _validate_field_types(cfg: Dict[str, Any], source: Path) -> List[str]:
     parse failures so the whole stack fails-closed uniformly.
     """
     errors: List[str] = []
-    for field, allowed in _FIELD_TYPES.items():
-        if field not in cfg:
+    for field_name, allowed in _FIELD_TYPES.items():
+        if field_name not in cfg:
             continue
-        value = cfg[field]
+        value = cfg[field_name]
         if not isinstance(value, allowed):
             expected = "/".join(
                 t.__name__ if t is not type(None) else "null" for t in allowed
             )
             errors.append(
-                f"{source}: field '{field}' must be {expected} "
+                f"{source}: field '{field_name}' must be {expected} "
                 f"but got {type(value).__name__}"
             )
     return errors

--- a/docs/design/lint-gate.md
+++ b/docs/design/lint-gate.md
@@ -1,0 +1,94 @@
+# Lint gate
+
+**Status:** landed. CI job `lint-gate`, config in `pyproject.toml :: [tool.ruff.lint]`.
+
+## What it is
+
+`ruff check agentao/ tests/ examples/` with exactly four rule groups:
+
+| Rule | Catches |
+|---|---|
+| `E9` | Syntax / IO errors — code that cannot run at all |
+| `F402` | Import shadowed by a loop variable — latent `UnboundLocalError` |
+| `F811` | Redefinition of an unused name — one of the two is dead |
+| `F821` | Undefined name — guaranteed `NameError` at runtime |
+
+Nothing else. No style, no formatting, no import sorting, no modernization.
+
+## Why this narrow
+
+The selection came from measuring, not from taste. Run against the tree at
+`7eb762e`:
+
+| Ruleset | Findings | Live bugs found |
+|---|---|---|
+| `UP` (pyupgrade) | 2652 | — not a defect class |
+| `F401` (unused-import) | 255 (169 `tests/`, 68 `agentao/`) | 0 |
+| `E9,F402,F811,F821` | 4 | **0** |
+
+All four gate findings were read individually before being fixed; none was a
+live bug. So the honest claim for this gate is **not** "it found bugs" — it is
+"it costs ~15s of CI and pins a class that has already bitten this repo once."
+
+That once is `eef5b70` (PR #141), whose title is *"declare plugin types for
+F821"*. F821 measured 0 when this gate landed; the gate is what keeps it there.
+
+The opinionated sets were rejected on evidence. `UP`'s 2652 findings would
+rewrite working code across the tree and bury real changes in review. This
+repo has already declined a comparable ratchet on the same grounds — see
+`docs/design/refactor-audit-2026-07.md`, where 27 of 89 mypy findings were
+mixin false positives.
+
+## Why F401 is not in the gate
+
+`F401` (unused-import) is the largest single category and looks like the
+obvious win. It is not enforceable on `agentao/` as-is, because **a re-export
+reads as unused inside the module that defines it.**
+
+Measured, not assumed: running `ruff check --select F401 --fix` over
+`agentao/` + `tests/` applied 212 fixes and then broke **9 test modules at
+collection**:
+
+```
+E ImportError: cannot import name 'AcpInteractionRequiredError' from 'agentao.acp_client.client'
+E ImportError: cannot import name '_parse_retry_after' from 'agentao.llm.client'
+E ImportError: cannot import name 'acp_client' from 'agentao'
+```
+
+Every failure was in `agentao/`, none in `tests/`. The deleted names were the
+public surface of `agentao/llm/client.py`, `agentao/acp_client/client.py` and
+the `__init__.py` re-export hubs (`agentao/cli/__init__.py` alone accounts for
+20 of the 68).
+
+Enforcing F401 therefore needs `per-file-ignores` for the re-export modules
+first. That is tracked as separate work: clean the 169 in `tests/` (no
+re-export semantics there), exempt the re-export modules in `agentao/`, then
+add `F401` to `select`.
+
+## The four findings this gate fixed on landing
+
+| Location | Finding | Fix |
+|---|---|---|
+| `agentao/sandbox/policy.py:213` | `for field, ...` shadowed `dataclasses.field` | Renamed to `field_name`, matching `_absolutize_path_fields` in the same file. The function never called `dataclasses.field`, so this was a latent trap rather than a live bug — adding such a call later would have failed with a confusing `UnboundLocalError`. |
+| `agentao/cli/app.py:272` | `PlanController` imported twice, first copy unused | Dropped it from the first import. |
+| `agentao/cli/_utils.py:154` | `console` parameter shadowed the module-level import | Removed the parameter. Both call sites passed the same `._globals.console` this module already imports, so the parameter only shadowed it. |
+| `tests/test_host_typing.py:227` | `import sys` inside a function already importing it at module scope | Dropped the local re-import. |
+
+Note the third was fixed by deleting the redundant parameter rather than by
+adding `# noqa`. A suppression would have preserved exactly the confusion the
+rule exists to flag.
+
+## Running locally
+
+```bash
+uv run ruff check agentao/ tests/ examples/
+```
+
+Rule selection is in `pyproject.toml`, so the local and CI invocations cannot
+drift apart.
+
+## Raising the bar later
+
+Add rules one at a time, and only after measuring what each would fire on and
+reading a sample of the hits. The precedent this document sets is that a
+ruleset earns its place by finding defects, not by being a recognised standard.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,33 @@ dev = [
     "twine>=6.1.0",
     "mypy>=1.13.0",
     "packaging>=25.0",
+    "ruff>=0.14.0",
 ]
+
+[tool.ruff]
+# Lint gate — deliberately narrow. See docs/design/lint-gate.md for the
+# measurement behind the selection.
+target-version = "py310"
+
+[tool.ruff.lint]
+# Only rules that flag a genuine defect, never style. Measured against the
+# tree at 7eb762e: the opinionated sets would have fired 2652 times (UP) and
+# 255 times (F401) without identifying a single live bug, so they are out.
+#
+#   E9   syntax / IO errors — code that cannot run
+#   F402 import shadowed by a loop variable — latent UnboundLocalError
+#   F811 redefinition of an unused name — one of the two is dead
+#   F821 undefined name — guaranteed NameError at runtime
+#
+# F821 is the reason this gate exists: it was 0 when the gate landed, but
+# PR #141 had to fix one, so the class is reachable here.
+#
+# NOT selected: F401 (unused-import). It cannot be enforced on `agentao/`
+# without per-file exemptions, because a re-export reads as unused inside
+# the module that defines it — `ruff --fix` on the full tree deleted the
+# re-exports in `llm/client.py`, `acp_client/client.py` and `cli/__init__.py`
+# and broke 9 test modules at collection. Tracked separately.
+select = ["E9", "F402", "F811", "F821"]
 
 [tool.mypy]
 # P0.4 typing gate — strict only on the public host boundary; the rest of

--- a/tests/test_host_typing.py
+++ b/tests/test_host_typing.py
@@ -224,7 +224,6 @@ def test_harness_alias_emits_deprecation_warning_and_re_exports():
     ``agentao/harness/`` shim package) together.
     """
     import importlib
-    import sys
     import warnings
 
     # Force a fresh import so the warning fires deterministically.

--- a/uv.lock
+++ b/uv.lock
@@ -65,6 +65,7 @@ dev = [
     { name = "mypy" },
     { name = "packaging" },
     { name = "pytest" },
+    { name = "ruff" },
     { name = "twine" },
 ]
 
@@ -104,6 +105,7 @@ dev = [
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "packaging", specifier = ">=25.0" },
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.14.0" },
     { name = "twine", specifier = ">=6.1.0" },
 ]
 
@@ -1925,6 +1927,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a lint gate that only enforces rules flagging a genuine defect. Style, formatting, import sorting and modernization are all explicitly out.

```toml
select = ["E9", "F402", "F811", "F821"]
```

| Rule | Catches |
|---|---|
| `E9` | Syntax / IO errors — code that cannot run |
| `F402` | Import shadowed by a loop variable — latent `UnboundLocalError` |
| `F811` | Redefinition of an unused name — one of the two is dead |
| `F821` | Undefined name — guaranteed `NameError` |

## Why this narrow — measured, not taste

Against the tree at `7eb762e`:

| Ruleset | Findings | Live bugs |
|---|---|---|
| `UP` (pyupgrade) | 2652 | not a defect class |
| `F401` (unused-import) | 255 (169 `tests/`, 68 `agentao/`) | 0 |
| `E9,F402,F811,F821` | **4** | **0** |

**The honest claim for this gate is not "it found bugs."** All four findings were read individually; none was live. It earns ~15s of CI because it pins a class that has already bitten this repo — `eef5b70` (#141) is literally titled *"declare plugin types for F821"*. F821 measures 0 today; the gate is what keeps it there.

`UP`'s 2652 findings would rewrite working code tree-wide and bury real changes in review — the same objection that killed a comparable mypy ratchet in `docs/design/refactor-audit-2026-07.md` (27 of 89 findings were mixin false positives).

## Why F401 is excluded

Not squeamishness — it breaks the build. **A re-export reads as unused inside the module that defines it.** Running `ruff check --select F401 --fix` over the tree applied 212 fixes and then broke **9 test modules at collection**:

```
E ImportError: cannot import name 'AcpInteractionRequiredError' from 'agentao.acp_client.client'
E ImportError: cannot import name '_parse_retry_after' from 'agentao.llm.client'
E ImportError: cannot import name 'acp_client' from 'agentao'
```

Every failure was in `agentao/` — the public surface of `llm/client.py`, `acp_client/client.py` and the `__init__.py` re-export hubs (`agentao/cli/__init__.py` alone is 20 of `agentao/`'s 68). `tests/` has no re-export semantics and took the fix cleanly. Enforcing F401 needs `per-file-ignores` first; tracked as follow-up work.

## The four findings, fixed

| Location | Finding | Fix |
|---|---|---|
| `agentao/sandbox/policy.py:213` | `for field, ...` shadowed `dataclasses.field` | Renamed to `field_name`, matching `_absolutize_path_fields` in the same file. Latent trap, not a live bug — the function never calls `dataclasses.field`, but a later call would have failed as a confusing `UnboundLocalError`. |
| `agentao/cli/app.py:272` | `PlanController` imported unused, then imported again at 328 | Dropped from the first import. |
| `agentao/cli/_utils.py:154` | `console` parameter shadowed the module-level import | **Removed the parameter.** Both call sites passed the same `._globals.console` this module already imports. A `# noqa` would have preserved exactly the confusion the rule exists to flag. |
| `tests/test_host_typing.py:227` | `import sys` inside a function that has it at module scope | Dropped the local re-import. |

## Notes

- Rule selection lives in `pyproject.toml :: [tool.ruff.lint]`, so local and CI invocations cannot drift. Run it yourself with `uv run ruff check agentao/ tests/ examples/`.
- The job syncs only `--group dev` — ruff is a static analyser and never imports the code under test, so it needs no runtime extras.
- Rationale + measurement table: `docs/design/lint-gate.md`.
- Suite unchanged: **3806 passed, 2 skipped, 9 deselected**.

Follow-up (separate PR): clean the 169 `F401` in `tests/`, add `per-file-ignores` for the `agentao/` re-export modules, then add `F401` to `select`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)