### PR TITLE
chore(release): prep 0.4.19 — silent-failure fixes in env, permissions and MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,158 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased]
+## [0.4.19] — 2026-08-04
 
-_Targeting 0.4.19. Add entries under the relevant heading as work lands._
+A **correctness release**. Nothing in it is a new capability anyone asked for;
+every user-facing item is a defect that failed *silently* — a key that was read
+as empty, tools that were never listed, a command that walked past the security
+floor, a stream that ended mid-answer and reported success.
+
+The three worth upgrading for:
+
+- **agentao launched from a Claude Code session could not find its API key.**
+  A present-but-empty ambient variable permanently masked the real value in
+  `.env`. It has shipped since 0.4.8, when the wrapper was added.
+- **The shell hardline floor was bypassable with a run modifier.**
+  `timeout 5 rm -rf /` and eight sibling shapes passed a floor that sits above
+  every mode preset and user rule. The same grammar was exponentially
+  backtrackable on the tool-execution hot path.
+- **MCP tools past page 1 were invisible.** A server paginating a 400-tool
+  catalog presented whatever fit on page 1, with no error, no warning, and
+  nothing in `/mcp list` saying so.
 
 ### Added
 
+- **agentao negotiates the MCP protocol era instead of pinning the handshake.**
+  mcp 2.0 added a second protocol era, and the legacy `initialize` handshake can
+  only ever report the version the *client* proposed or older — so a modern-only
+  server (2026-07-28+) was unreachable by construction and failed the connect
+  outright with `-32022`. `McpClient._negotiate()` now sends `initialize` and
+  escalates to `server/discover` only when the server *rejects* it: definitely
+  (`-32022`, which names the server's own `supportedVersions`) or speculatively
+  (`-32601`, since the modern era has no `initialize` handler at all — a failed
+  speculative probe re-raises the original error rather than renaming the
+  failure after a method the operator never heard of).
+
+  Handshake-first is deliberately the reverse of upstream's `mode='auto'`, and
+  the order was decided by measurement rather than preference. Probe-first was
+  built and then run against a real server per SDK generation over stdio: an
+  mcp 2.0.0 `MCPServer` negotiated silently, but an mcp 1.26.0 `FastMCP`
+  rejected the unknown method with a 31-error pydantic union-validation dump —
+  **258 lines**, and for stdio that stderr *is* agentao's stderr. That is a
+  per-connect cost on the commonest server there is, paid for a capability with
+  no consumer today: tool discovery and tool calls behave identically in both
+  eras, verified against the 2.0.0 peer rather than assumed. The tradeoff is
+  that a dual-era server stays on the handshake era;
+  `test_a_dual_era_server_is_left_on_the_handshake_era` pins it, so the day a
+  modern-only capability is needed the flip is one deliberate edit in
+  `_negotiate`.
+
+  The negotiated version lands on `McpClient.protocol_version`,
+  `get_server_status()["protocol"]` and `/mcp list`. It is a **ceiling, not a
+  constant** — gate on `>=`, never equality. An unresolvable mismatch raises
+  `McpProtocolEraError`, carrying both halves of the failure; its type
+  suppresses the "try `type: sse`" hint, which no transport change could act on.
+
+  Six defects found while reviewing that change ship with it: `_compat.field()`
+  now dispatches on a model's *declared* fields instead of `hasattr` (every wire
+  model is `extra='allow'` on both majors, so a server shipping its own
+  `protocol_version` / `is_error` key made the old probe resolve to the peer's
+  unvalidated value over the SDK-validated camelCase field — this affected every
+  `field()` call site); `/mcp list` escapes server-authored strings (an unmatched
+  `[/b]` in a third-party error message raised `MarkupError` out of the command
+  and took the whole listing with it, healthy servers included); `call_tool`
+  checks that a reconnect actually succeeded, instead of handing the model
+  `'NoneType' object has no attribute 'call_tool'` in place of the reason;
+  `connect()` clears `_session` and `_protocol_version` on its failure path, so
+  a version can no longer hang off an ERROR server; `_can_discover()` probes the
+  live session rather than the imported class; and `call_tool` opts in to
+  `InputRequiredResult`, so an SDK `RuntimeError` telling a *programmer* to pass
+  `allow_input_required=True` no longer arrives as the tool's result.
+
+  Design: `docs/design/mcp-streamable-http.md` §5.8/§5.8.1 (EN + zh).
+
+- **`TurnOutcome.finish_reason_missing` — agentao now reports when a provider
+  never said why generation stopped.** A stream can end with no `finish_reason`
+  at all: a gateway closing the SSE body after its own upstream timeout, or a
+  partially-compatible local server that never emits the field.
+  `_StreamAccumulator` falls back to `"stop"`, so such a turn was
+  indistinguishable from a clean completion — a truncated fragment came back as
+  a finished answer with `is_answer` True.
+
+  **Reported, not classified.** The flag is deliberately *not* a member of
+  `INCOMPLETE_ANSWER_REASONS` and deliberately does not affect `is_answer`:
+  every value in that closed set becomes a CLI error envelope, so joining it
+  would make each turn a hard failure on every provider that omits the field.
+  It rides its own axis, the way `max_iterations` does. A host that wants the
+  strict reading writes `o.is_answer and not o.finish_reason_missing`; one on a
+  known-lenient provider keeps ignoring it. The wire value of `finish_reason`
+  itself keeps its `"stop"` fallback — flipping that to `None` would shift
+  LLM_CALL_COMPLETED payloads and replay renders for every provider that omits
+  it.
+
+  Sticky across every LLM call in the turn, not only the last: an intermediate
+  call that ends without a finish_reason may have had its tool-call arguments
+  cut off with nothing to detect it, since `_is_length_truncation` never fires
+  and the arguments get executed. The compaction summarizer bypasses the chat
+  loop entirely and so records its own observation, which the two compaction
+  call sites fold in — that is the one call whose output permanently rewrites
+  history, and a truncated summary is inherited by every later turn. Suppressed
+  on a cancelled turn, where the cancellation already explains the absence;
+  reported on an errored one, where it does not.
+
+  It reaches every surface that exists to explain a turn after the fact:
+  `agentao.log` qualifies its `Finish Reason:` line, LLM_CALL_COMPLETED carries
+  `finish_reason_reported`, the replay `turn_completed` record carries the flag
+  when set, and `agentao run`'s JSON envelope gains `finish_reason_missing`
+  without it touching the exit code.
+
 ### Changed
+
+- **CI gains a narrow ruff gate — defect rules only, and it is a required
+  check.** `ruff check .` selecting `E9`, `F401`, `F402`, `F405`, `F811`,
+  `F821` and nothing else. The selection is measured, not chosen by taste:
+  against the tree it landed on, `UP` fired 2652 findings and `F401` 255, with
+  zero live bugs between them, while the defect group fired 4 — each read
+  individually, none live. So the claim for this gate is deliberately not "it
+  found bugs"; it is that F821 has already bitten this repo (#141 is titled
+  "declare plugin types for F821"), it measures 0 today, and ~15s of CI keeps
+  it there.
+
+  `F401` is enforced in `tests/` and `examples/` — 184 findings cleaned across
+  92 files — and exempted **wholesale** for `agentao/`. That exemption is not
+  squeamishness: agentao is a published library, so a name re-exported for
+  downstream embedders is imported by nobody in this repo, which is exactly
+  what a public API looks like to a single-file linter. `--fix` over the tree
+  applied 212 fixes and broke 9 test modules at collection, deleting the public
+  surface of `llm/client.py`, `acp_client/client.py` and the `__init__.py`
+  re-export hubs. Making `agentao/` decidable later means giving every
+  re-export hub an explicit `__all__`. Suppress with a reason
+  (`# noqa: F401 — pytest fixture injection`), never bare. See
+  `docs/design/lint-gate.md`.
+
+- **Five pre-pytest test scripts removed, and duplicated test helpers hoisted
+  into `tests/support/`.** Nothing in the published package changes; two of the
+  removals had measured side effects on every default `pytest tests/` run.
+  Three of the five defined no `def test_*` at all — they were module-level
+  scripts that ran during *collection* and printed, with every failure path a
+  `print("✗ ...")` rather than a raise, so none could report a problem even in
+  principle. One of those wrote `OPENAI_API_KEY` and `OPENAI_BASE_URL` into
+  `os.environ` at collection time, outside monkeypatch and so unrollbackable,
+  which left all 3806 other tests inheriting `https://api.example.com/v1` as
+  their base URL, decided by collection order. Another called `agent.chat()`
+  for real on every run — taking a 401 and passing anyway, or sending a
+  developer's genuine exported key to api.openai.com — and constructed
+  `Agentao(working_directory=Path.cwd())`, mutating the developer's own
+  `.agentao/memory.db`.
+
+- **Docs**: the pi-mono v0.80.6→v0.83.0 pull review is recorded
+  (`docs/design/pi-mono-pull-review-2026-08.md`), the `flint-chart-author` skill
+  joins the `examples/skills/` gallery (prose only — no install, no script, no
+  API key), and three places that said skill `references/*.md` are "loaded on
+  activation" are corrected: `activate_skill` *enumerates* them by absolute path
+  and tells the model to `read_file` what it needs, which is the whole point —
+  the always-resident cost stays at name + description.
 
 ### Fixed
 
@@ -26,6 +171,133 @@ _Targeting 0.4.19. Add entries under the relevant heading as work lands._
   still wins, which is the part of no-override callers actually rely on. NUL
   scrubbing — the reason this wrapper exists — is unchanged and now covered by
   a test. See `tests/test_env_dotenv.py`.
+
+- **MCP `tools/list` is paginated instead of silently dropping page 2 and
+  beyond.** `McpClient` issued exactly one `list_tools()` and took `.tools`, so
+  every tool a paginating server exposed past the first page was invisible to
+  the model — with no error, no warning, and nothing in `/mcp list` or
+  `get_server_status()` distinguishing "this server has 12 tools" from "this
+  server has 12 of its 400". `grep next_cursor` returned zero matches
+  repo-wide, tests included.
+
+  `_list_all_tools()` now walks the cursor, bounded against a hostile peer:
+  repeated cursor, 64 KiB cursor (UTF-8 bytes), 1024 accumulated tools (checked
+  *before* `extend`), and 100 pages. Every bound raises `McpCatalogError`,
+  which `connect()` absorbs into `status=ERROR` for that one server —
+  truncation is deliberately not a supported outcome, since a partial catalog
+  is the same silent wrongness this removes. `McpCatalogError` is its own type
+  so it can be excluded from the "try `type: sse`" hint: a bound is reachable
+  only after `initialize` and one `tools/list` have already succeeded, so the
+  transport provably works and pointing the operator at it would hide the real
+  cause.
+
+  Cross-major: `params=` is the one call spelling accepted on all three CI SDK
+  cells including the 1.26.0 floor (positional `cursor=` is 1.x-only, gone in
+  2.x), and the cursor field needs `_compat.field` (`nextCursor` →
+  `next_cursor`). Note there is **no page-size field in the MCP spec** — the
+  server decides. Design, including three regression profiles accepted and
+  recorded rather than fixed: `docs/design/mcp-tool-list-pagination.md` §9.
+
+- **`replace` folds Unicode compatibility forms (NFKC) before fuzzy matching.**
+  The tier-3 match normalized through a codepoint table only (dashes, quotes,
+  spaces), and that table has no entries for compatibility forms — so an edit
+  whose `old_text` differed from the file only by full-width punctuation fell
+  straight through to `_not_found_hint`. In a CJK source file mixing 全角 and
+  半角 that is the common case, not an exotic one: `print（"你好"）；` was
+  unreachable from `print("你好");`.
+
+  Tier 3 now runs NFKC first, then the table. Neither pass subsumes the other —
+  NFKC folds full-width forms, ligatures and every space variant but leaves
+  smart quotes and en/em dashes alone (they have no compatibility
+  decomposition), which is exactly what the table covers. The order is
+  load-bearing: sweeping the Unicode planes finds five characters that NFKC
+  folds *into* a table entry without being in the table themselves (U+207B,
+  U+208B, U+FE31, U+FE32, U+FE58), and table-first strands all five one step
+  short of ASCII. Byte offsets are unaffected — `line_transform` only builds
+  the per-line comparison keys, while the prefix table is built from the
+  original line lengths, so spliced spans still index the original content.
+
+- **Event-listener exceptions are logged instead of swallowed in silence.**
+  `EventBroadcaster.notify` caught every subscriber exception with a bare
+  `except Exception: pass`. Swallowing is correct and stays — a subscriber is a
+  side channel and must never break the emit path — but being *silent* about it
+  is not: the only symptom an embedded host got was "my listener does nothing",
+  with no record anywhere and the swallow three call frames from any code they
+  wrote. WARNING-and-swallow was already the documented convention for the
+  other side-channel sink on this contract (`HostReplaySink`); `broadcast.py`
+  was the one place that did not follow it.
+
+  Logged, not re-emitted as an error event: an event would re-enter `notify`,
+  so a listener that raises on everything would spin forever. `event.type`
+  only, never `event.data` — payloads carry tool arguments, full tool results
+  and LLM text, and agentao's credential redaction is a `Formatter` on its own
+  file handler (deliberately not a `Filter`, so it does not leak into a host's
+  handlers), which means a payload logged here would reach those handlers
+  unredacted. With `exc_info=True`, since a swallowed exception with no stack
+  is barely better than silence.
+
+- **Renaming a skill preserves its `SKILL.md` layout byte-for-byte.**
+  `replace_skill_name` rewrites a file the user wrote, so everything except the
+  `name:` value must survive. It rebuilt the frontmatter from a literal
+  `f"---\n{block}\n---\n"` instead, reformatting every document whose layout
+  differed from that one shape — 6 of 7 measured layouts were corrupted,
+  including the one every skill in this repo uses (the blank line between the
+  closing fence and the body, silently deleted by `/crystallize`). Also
+  affected: a file ending at the fence gained a trailing newline, leading
+  whitespace was dropped, trailing spaces on the fence line were dropped, CRLF
+  documents were rewritten to LF, and a blank line inside the frontmatter was
+  deleted.
+
+  The fix splices the new block into the original string by the frontmatter's
+  own span, so no character outside that block is retyped, and within the block
+  replaces only the *value* span of the `name:` line — replacing the whole match
+  takes the trailing whitespace with it, because `_NAME_LINE_RE` ends in `\s*$`
+  and `\s` swallows a trailing `\r`. +16 tests, all comparing whole strings; the
+  pre-existing test passed against the buggy version precisely because a
+  substring assertion cannot see a deleted blank line.
+
+### Security
+
+- **The shell hardline floor no longer lets a run modifier walk past it.**
+  `permissions.py` documents that `full-access` may omit its sensitive-file
+  rule because "disk-wipe-class attacks already trip the hardline floor". The
+  floor did not uphold that — a run modifier in front of the command was enough:
+
+      timeout 5 rm -rf /        nice -n 5 rm -rf /
+      stdbuf -oL rm -rf /       chrt 10 rm -rf /
+      taskset ff rm -rf /       /usr/bin/timeout 5 rm -rf /
+      exec -a login rm -rf /    nice --adj 5 rm -rf /
+      timeout .5 rm -rf /
+
+  Root cause: the wrapper prefix carried one value-flag set copied from
+  `sudo`/`env`, and had no notion of a wrapper that consumes a positional
+  operand; `timeout` and `stdbuf` were absent entirely. A shared set cannot
+  work — `sudo -n` takes no value while `nice -n 5` does, so any single set
+  breaks one of them. Each family now carries its own set, and
+  `timeout`/`chrt`/`taskset` declare their bare operand.
+
+- **The wrapper grammar is no longer exponentially backtrackable.** It ran on
+  the tool-execution hot path, for every shell call. Two ambiguities, both
+  fixed by making the arms disjoint rather than by bounding input: a separated
+  flag value could also start a fresh wrapper (`sudo -u sudo ...`), so wrapper
+  words are excluded from the value arm; and a bare `-n` matched both the
+  short-flag and the general-flag arm. `"sudo " + "-u sudo "*16 + "X"` — 134
+  characters — took **35 minutes** through `hardline_check`; it now takes
+  0.80 ms, and every ambiguous shape scales linearly to n=128. The ReDoS
+  predates the wrapper additions above (`sudo` was already exponential), so
+  this fixes it rather than merely avoiding widening it.
+
+- **Two false-positive directions closed with it.**
+  `shutdown`/`reboot`/`halt`/`poweroff` matched on `\b`, which also fires
+  before `-` and `.`, so promoting a wrapper operand to command position made
+  `timeout 60 reboot-check.sh` read as `reboot`. Because the floor sits above
+  mode presets and user rules, no `permissions.json` allow and no
+  `/mode full-access` could unblock it. Verified against a 56-command
+  must-block corpus (0 false negatives) and a 14-command must-allow corpus
+  (0 false positives); the new tests fail 4/4 against the previous grammar.
+  Still not recognised as wrappers, all pre-existing: `flock`, `setarch`,
+  `doas`, `unshare`, `runuser` — expanding that inventory is a separate call
+  with its own false-positive cost.
 
 ---
 

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.19.dev0"
+__version__ = "0.4.19"
 
 
 def _ensure_utf8() -> None:

--- a/docs/releases/v0.4.19.md
+++ b/docs/releases/v0.4.19.md
@@ -1,0 +1,216 @@
+# Agentao 0.4.19
+
+A **correctness release**. Nothing in it is a capability anyone asked for; every
+user-facing item is a defect that failed *silently* — a key that was read as
+empty, tools that were never listed, a command that walked past the security
+floor, a stream that ended mid-answer and reported success.
+
+The headline:
+
+- **agentao launched from a Claude Code session could not find its API key.** A
+  present-but-empty ambient variable permanently masked the real value in
+  `.env`. It has shipped since 0.4.8, when the wrapper was added.
+- **The shell hardline floor was bypassable with a run modifier.**
+  `timeout 5 rm -rf /` and eight sibling shapes passed a floor that sits above
+  every mode preset and every user rule. The same grammar was exponentially
+  backtrackable on the tool-execution hot path.
+- **MCP tools past page 1 were invisible.** A server paginating a 400-tool
+  catalog presented whatever fit on page 1, with no error and no warning.
+
+**No breaking changes.** `pip install -U agentao` is the whole upgrade.
+
+## Why this release
+
+0.4.18 was a `web_fetch` release with three breaking changes. This one is its
+opposite: no new surface, no migration, and the reason to take it is that four
+of the six fixes are conditions you cannot detect from the outside. A masked API
+key looks like a missing API key. A truncated tool catalog looks like a server
+with fewer tools. A stream that ends without `finish_reason` looks like an
+answer. Each was found by probing behavior rather than by reading code, which is
+also why none of them had a bug report.
+
+## The API key that was there all along
+
+`safe_load_dotenv` assigned via `os.environ.setdefault`, which treats a key that
+is *present but empty* as already set: no-override declines to write, and every
+downstream `os.getenv` sees `""` — permanently, for the life of the process.
+
+This is not hypothetical. Claude Code injects `ANTHROPIC_API_KEY=""` into child
+processes to neuter their LLM calls, so any agentao invoked from a Claude Code
+session reported "no API key" while a valid key sat unread in `.env`. Measured
+end to end before the fix:
+
+    os.environ["ANTHROPIC_API_KEY"] = ""
+    safe_load_dotenv(".env")            # .env has ANTHROPIC_API_KEY=sk-real
+    os.getenv("ANTHROPIC_API_KEY")      # -> ''      (masked)
+    discover_llm_kwargs()["api_key"]    # -> ''      (propagates)
+
+An empty or whitespace-only value carries no configuration meaning, so letting
+`.env` fill it in loses nothing. A non-empty ambient value still wins — that is
+the part of no-override callers actually rely on, and it stays.
+
+Worth naming for anyone tempted to fix this one layer up: skipping the empty
+value in `discover_llm_kwargs` is **not** sufficient. It would turn `api_key=''`
+into a missing key, but the real key in `.env` still never loads, because the
+mask is applied before discovery runs at all.
+
+## The hardline floor, and what walked past it
+
+`permissions.py` documents that `full-access` may omit its sensitive-file rule
+because "disk-wipe-class attacks already trip the hardline floor". The floor did
+not uphold that. A run modifier in front of the command was enough:
+
+    timeout 5 rm -rf /        nice -n 5 rm -rf /
+    stdbuf -oL rm -rf /       chrt 10 rm -rf /
+    taskset ff rm -rf /       /usr/bin/timeout 5 rm -rf /
+    exec -a login rm -rf /    nice --adj 5 rm -rf /
+    timeout .5 rm -rf /
+
+The wrapper prefix carried a single value-flag set copied from `sudo`/`env`, and
+had no notion of a wrapper that consumes a positional operand; `timeout` and
+`stdbuf` were not in the inventory at all. One shared set cannot work — `sudo -n`
+takes no value while `nice -n 5` does, so any single set breaks one of them.
+Each family now carries its own set, and `timeout`/`chrt`/`taskset` declare
+their bare operand.
+
+The same grammar was also exponentially backtrackable — on the tool-execution
+hot path, for every shell call. Two ambiguities, both fixed by making the arms
+disjoint rather than by bounding input: a separated flag value can also be the
+start of a fresh wrapper (`sudo -u sudo ...`), so wrapper words are excluded
+from the value arm; and a bare `-n` matched both the short-flag and the general
+flag arm. `"sudo " + "-u sudo "*16 + "X"` — 134 characters — took **35 minutes**
+through `hardline_check`. It now takes 0.80 ms, and every ambiguous shape scales
+linearly to n=128. That ReDoS predates the wrapper work (`sudo` was already
+exponential), so this fixes it rather than merely avoiding widening it.
+
+Two false-positive directions closed with it. `shutdown`/`reboot`/`halt`/
+`poweroff` matched on `\b`, which also fires before `-` and `.`, so promoting a
+wrapper operand to command position made `timeout 60 reboot-check.sh` read as
+`reboot` — and because the floor sits above mode presets and user rules, no
+`permissions.json` allow and no `/mode full-access` could unblock it.
+
+Verified against a 56-command must-block corpus (0 false negatives) and a
+14-command must-allow corpus (0 false positives). The new tests fail 4/4 against
+the previous grammar. Still not recognised as wrappers, all pre-existing:
+`flock`, `setarch`, `doas`, `unshare`, `runuser`.
+
+## The MCP catalog you were not seeing
+
+`McpClient` issued exactly one `list_tools()` and took `.tools`. Every tool a
+paginating server exposed past the first page was invisible to the model — with
+no error, no warning, and nothing in `/mcp list` or `get_server_status()`
+distinguishing "this server has 12 tools" from "this server has 12 of its 400".
+`grep next_cursor` returned zero matches repo-wide, tests included.
+
+`_list_all_tools()` now walks the cursor, bounded against a hostile peer:
+repeated cursor, 64 KiB cursor (UTF-8 bytes), 1024 accumulated tools (checked
+before the append), and 100 pages. Every bound raises `McpCatalogError`, which
+`connect()` absorbs into `status=ERROR` for that one server. Truncation is
+deliberately not a supported outcome — a partial catalog is the same silent
+wrongness this change removes.
+
+`McpCatalogError` is its own type so it can be excluded from `connect()`'s "try
+`type: sse`" hint: a bound is only reachable after `initialize` and one
+`tools/list` have already succeeded, so the transport provably works and
+pointing the operator at it would hide the real cause.
+
+Note the MCP spec has **no page-size field** — the server decides how much a
+page holds, so the bounds above are the only lever a client has.
+
+## Also in this release
+
+**MCP protocol-era negotiation.** mcp 2.0 added a second protocol era, and the
+legacy `initialize` handshake can only ever report the version the *client*
+proposed or older — so a modern-only server was unreachable by construction and
+failed the connect with `-32022`. `McpClient._negotiate()` now sends
+`initialize` and escalates to `server/discover` only when the server rejects it.
+Handshake-first is deliberately the reverse of upstream's `mode='auto'`: probing
+first was built and measured, and an mcp 1.26.0 `FastMCP` answers the unknown
+method with a 258-line pydantic union-validation dump — which, over stdio, is
+agentao's own stderr. The negotiated version lands on
+`McpClient.protocol_version`, `get_server_status()["protocol"]` and `/mcp list`,
+and is a **ceiling, not a constant**: gate on `>=`, never equality. Six defects
+found while reviewing that change ship with it, including a `_compat.field()`
+probe that could resolve to a peer's unvalidated value over the SDK-validated
+field, and an unescaped server-authored string that could take down the whole
+`/mcp list` output with a `MarkupError`.
+
+**`TurnOutcome.finish_reason_missing`.** A stream can end with no
+`finish_reason` at all — a gateway closing the SSE body after its own upstream
+timeout, a partially-compatible local server that never emits the field. The
+accumulator falls back to `"stop"`, so a truncated fragment came back
+indistinguishable from a finished answer. The flag is **reported, not
+classified**: it is deliberately not a member of `INCOMPLETE_ANSWER_REASONS` and
+does not affect `is_answer`, because every member of that closed set becomes a
+CLI error envelope. A host that wants the strict reading writes
+`o.is_answer and not o.finish_reason_missing`; one on a known-lenient provider
+keeps ignoring it. It is sticky across every call in the turn, suppressed on a
+cancelled turn, and surfaces in `agentao.log`, on LLM_CALL_COMPLETED, in the
+replay record, and in `agentao run`'s JSON envelope — without touching the exit
+code.
+
+**`replace` folds compatibility forms before fuzzy matching.** Tier-3 matching
+normalized through a codepoint table (dashes, quotes, spaces) that has no
+entries for Unicode compatibility forms, so an edit differing from the file only
+by full-width punctuation fell straight through to the not-found hint. In a CJK
+source file mixing 全角 and 半角 that is the common case: `print（"你好"）；` was
+unreachable from `print("你好");`. NFKC now runs first, then the table — the
+order is load-bearing, since five characters fold *into* a table entry without
+being in the table themselves.
+
+**Event-listener exceptions are logged.** `EventBroadcaster.notify` swallowed
+every subscriber exception with a bare `except Exception: pass`. Swallowing
+stays — a subscriber is a side channel and must never break the emit path — but
+silence does not: the only symptom an embedded host got was "my listener does
+nothing". Logged at WARNING with `exc_info=True`, carrying `event.type` only and
+never `event.data`, since payloads hold tool arguments and LLM text and
+agentao's redaction lives on its own file handler by design.
+
+**Renaming a skill preserves its `SKILL.md` layout.** The rewrite rebuilt the
+frontmatter from a literal fence template, reformatting every document whose
+layout differed from that one shape — 6 of 7 measured layouts were corrupted,
+including the one every skill in this repo uses. The new block is spliced into
+the original string by the frontmatter's own span, and within it only the
+*value* span of the `name:` line is replaced.
+
+## Repo-facing: a lint gate, and a test suite that lies less
+
+Neither changes the published package.
+
+CI gains a **narrow ruff gate — defect rules only** (`E9`, `F401`, `F402`,
+`F405`, `F811`, `F821`), now a required check. The selection is measured, not
+chosen by taste: `UP` fired 2652 findings and `F401` 255 with zero live bugs
+between them, while the defect group fired 4, each read individually and none
+live. So the claim is not "it found bugs" — it is that F821 has already bitten
+this repo, it measures 0 today, and ~15 s of CI keeps it there. `F401` is
+enforced in `tests/` and `examples/` (184 findings cleaned across 92 files) and
+exempted wholesale for `agentao/`, because a name re-exported for downstream
+embedders is indistinguishable from dead code to a single-file linter — `--fix`
+proved it by deleting the public surface of three modules and breaking 9 test
+modules at collection.
+
+Five pre-pytest scripts were **removed**. Three defined no `def test_*` at all —
+module-level scripts that ran during collection and printed, with every failure
+path a `print("✗ ...")` rather than a raise, so none could report a problem even
+in principle. Two had measured side effects on every default `pytest tests/`
+run: one wrote `OPENAI_API_KEY` / `OPENAI_BASE_URL` into `os.environ` at
+collection time, outside monkeypatch, leaving all 3806 other tests inheriting a
+fake base URL decided by collection order; another called `agent.chat()` for
+real (taking a 401 and passing anyway, or sending a developer's genuine exported
+key to api.openai.com) and mutated the developer's own `.agentao/memory.db`.
+
+## Breaking changes
+
+None.
+
+## Upgrade
+
+`pip install -U agentao`.
+
+Worth doing after upgrading, if either applies to you:
+
+- If you run MCP servers, check `/mcp list` — a server whose tool count changes
+  was paginating, and the model was only ever seeing its first page.
+- If you drive `agentao run` in automation and want the strict reading of a
+  turn, gate on `is_answer and not finish_reason_missing`. The default behavior
+  is unchanged.


### PR DESCRIPTION
Version `0.4.19.dev0` → `0.4.19`, `CHANGELOG` `[Unreleased]` cut to `[0.4.19] — 2026-08-04`, and `docs/releases/v0.4.19.md`.

Unlike the 0.4.18 cut, `[Unreleased]` held **one** entry (#157). #158–#169 landed without changelog entries of their own, so this PR writes them from the commit bodies rather than just re-heading a finished section.

## What is in the release

8 behavior-changing PRs plus 6 repo-only ones. **No breaking changes.**

| | |
|---|---|
| **Security** | #169 — the hardline floor was walked past by a run modifier (`timeout 5 rm -rf /`, `nice -n 5 …`, +7 shapes), and its grammar was exponentially backtrackable on the tool-execution hot path (134 chars → 35 min, now 0.80 ms) |
| **Added** | #158 MCP protocol-era negotiation · #161 `TurnOutcome.finish_reason_missing` |
| **Fixed** | #157 empty ambient env var masked `.env` · #168 MCP `tools/list` pagination · #159 NFKC before fuzzy edit matching · #160 listener exceptions logged · #167 `SKILL.md` layout preserved on rename |
| **Changed** (repo-only) | #163/#164/#165/#166 lint gate + test cleanup · #162/#170 docs, one bullet |

The three that carry it: **#157** (agentao launched from a Claude Code session could not find its API key — that session injects `ANTHROPIC_API_KEY=""` into children), **#169**, **#168** (a paginating server's tools past page 1 were invisible, no error, no warning).

## Verified on this tree, not inherited from CI

- full suite after the version bump: **3865 passed, 1 skipped**, 9 deselected
- `ruff check .` (the required lint gate): all checks passed
- `write_replay_schema.py --check` / `write_host_schema.py --check`: both up to date
- `mypy --strict --package agentao.host`: clean, 7 source files
- no test pins the version literal — the one hit under `tests/` is `test_acp_initialize.py` importing `__version__` dynamically
- "shipped since 0.4.8" for #157 is `git tag --contains 843bcee`, not an assumption that it was always there
- every identifier and constant quoted in the two documents was read from source, not transcribed from the commit bodies: `_MAX_TOOL_PAGES` 100 / `_MAX_TOOLS` 1024 / `_MAX_CURSOR_BYTES` 64×1024 (`client.py:191-193`), `McpCatalogError` / `McpProtocolEraError` (`client.py:135/149`), `_NAME_LINE_RE` (`skills/drafts.py:234`), `TurnOutcome.finish_reason_missing` (`outcome.py:61`), `finish_reason_reported` on the LLM_CALL_COMPLETED payload (`runtime/llm_call.py:197`), `finish_reason_missing` in `agentao run`'s envelope (`cli/run.py:732`)
- release note carries **zero relative links** — it is also the `--notes-file` body, and GitHub resolves those against the repo root

## After merge

`gh release create v0.4.19 --notes-file docs/releases/v0.4.19.md`, then open the 0.4.20 dev cycle (`0.4.20.dev0` + empty `[Unreleased]` headings) once PyPI confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
