### PR TITLE
chore: open 0.4.20 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+_Targeting 0.4.20. Add entries under the relevant heading as work lands._
+
+### Added
+
+### Changed
+
+### Fixed
+
+---
+
 ## [0.4.19] — 2026-08-04
 
 A **correctness release**. Nothing in it is a new capability anyone asked for;

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.19"
+__version__ = "0.4.20.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Version `0.4.19` → `0.4.20.dev0`, and restore the `[Unreleased]` block consumed by the 0.4.19 cut.

## 0.4.19 is published

Recorded before opening the next cycle, since that is what the cycle-open asserts:

- `publish.yml` run `30912343614` — success, 3m31s, all 15 steps including **Validate release tag matches package version** and **Publish distribution to PyPI**
- `pypi.org/pypi/agentao/json` — `info.version` is `0.4.19`, with `agentao-0.4.19-py3-none-any.whl` and `agentao-0.4.19.tar.gz` uploaded at `13:11:44Z`
- `pypi.org/simple/agentao/` — both files listed

One thing worth writing down: `/pypi/agentao/0.4.19/json` **404'd for ~2 minutes after a green publish** — a stale cache from a probe issued before the upload landed, and `200` on re-request with `Cache-Control: no-cache`. The project JSON and the simple index were correct throughout, so a per-version 404 on its own is not evidence that a publish failed.

## Two notes on the diff

**The `[Unreleased]` restore is larger than #156's.** The 0.4.18 cut kept `## [Unreleased]` in place and retargeted its `_Targeting_` line, leaving only the three empty headings to re-add. The 0.4.19 cut removed the whole block, so this restores the header and targeting line too. Net effect on the file is the same two-step convention — only the split between the two PRs differs.

**The literal is the PEP 440 canonical `0.4.20.dev0`**, not the hyphenated `0.4.20-dev` that the 0.4.10 and 0.4.11 cycle-opens drifted to. Both build identically (hatchling normalizes the hyphen), but the hyphen form leaves `agentao.__version__` exposing a string that differs from the distribution version.

## Verified on this tree

- `ruff check .` — all checks passed
- `import agentao` reports `0.4.20.dev0`
- `tests/test_acp_initialize.py` — the one test that reads `__version__`, and it does so dynamically — 20 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
