### PR TITLE
test: make the memory recency test depend on recency, not on SQLite's tie-break

### DIFF
--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -352,13 +352,31 @@ def test_stable_entries_caps_incidental_types(tmp_path):
     assert len(note_entries) == 3
 
 
-def test_stable_entries_incidental_takes_most_recent(tmp_path):
-    """When capping incidental entries, the most-recently-updated ones are kept."""
-    import time
+def test_stable_entries_incidental_takes_most_recent(tmp_path, monkeypatch):
+    """When capping incidental entries, the most-recently-updated ones are kept.
+
+    Timestamps are driven explicitly rather than by a sleep. ``storage._now_iso``
+    formats to whole seconds, so the ``time.sleep(0.01)`` this used to rely on
+    produced *identical* ``created_at`` and ``updated_at`` for both rows in
+    ~99% of runs. With every sort key tied, the outcome fell through to
+    SQLite's unspecified ordering for equal ``ORDER BY created_at`` keys — it
+    happened to return the newest row first on most builds and the oldest on
+    others, so the test asserted nothing and still went red on CI's Python 3.10.
+    """
+    from agentao.memory import storage
+
+    stamps = iter(["2026-01-01T00:00:00", "2026-01-02T00:00:00"])
+    monkeypatch.setattr(storage, "_now_iso", lambda: next(stamps))
+
     mgr = _make_manager(tmp_path)
     mgr.save_from_tool("old_note", "old", [])
-    time.sleep(0.01)  # ensure distinct updated_at
     mgr.save_from_tool("new_note", "new", [])
+
+    # Guard the premise: if these ever tie again the assertions below go back
+    # to riding on SQLite's tie-break instead of on the recency rule.
+    by_title = {e.title: e.updated_at for e in mgr.get_all_entries()}
+    assert by_title["old_note"] < by_title["new_note"]
+
     stable = mgr.get_stable_entries(recent_project_limit=1)
     stable_titles = {e.title for e in stable}
     assert "new_note" in stable_titles


### PR DESCRIPTION
`tests/test_memory_manager.py::test_stable_entries_incidental_takes_most_recent` went red on `main` after #181 landed, then **green on a rerun of the identical commit** (run [32623656697](https://github.com/jin-bo/agentao/actions/runs/32623656697)). It is a pre-existing flake — #181 touches no memory code — but it had never been diagnosed, so here it is.

## What the test believed

```python
mgr.save_from_tool("old_note", "old", [])
time.sleep(0.01)  # ensure distinct updated_at
mgr.save_from_tool("new_note", "new", [])
```

## What actually happens

Both `manager._now()` and `storage._now_iso()` are `strftime("%Y-%m-%dT%H:%M:%S")` — **whole seconds**. A 10ms sleep yields distinct timestamps only when the two saves straddle a second tick. Measured: **0 out of 20 runs**.

So every sort key ties, and the assertion falls through two layers of unspecified behaviour:

1. `incidental.sort(key=lambda r: r.updated_at, reverse=True)` — Python's sort is stable, and `reverse=True` does **not** reverse equal elements, so tied keys preserve input order.
2. That input order comes from `ORDER BY created_at ASC` (`storage.py:242`), and `created_at` is tied too — SQLite leaves the order of equal keys unspecified.

The test therefore asserted nothing about recency. It passed because the SQLite build on most runners happens to return the newest row first; CI's Python 3.10 image returned the oldest and it failed.

## The fix

Drive the two timestamps explicitly through `storage._now_iso` rather than hoping the clock cooperates, and add a premise guard:

```python
assert by_title["old_note"] < by_title["new_note"]
```

so that if these ever tie again the test fails on its *setup* — loudly, naming the real cause — instead of silently handing the outcome back to SQLite.

## Verification

Confirmed the test can now fail for the right reason: swapping the two stamps trips the guard (`assert '2026-01-02...' < '2026-01-01...'`). Otherwise green 3/3 runs of the file, and the full suite is `4016 passed`, `ruff check .` clean.

Not touched: the whole-second timestamp format itself. Widening it would change what is already stored in every `memory.db` as TEXT, and nothing else in the suite depends on sub-second resolution — that is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
