### PR TITLE
fix(compact): make truncation a fixed point, and stop cutting the same text twice

### DIFF
--- a/agentao/context_manager.py
+++ b/agentao/context_manager.py
@@ -287,25 +287,62 @@ class ContextManager:
     # 20% head (command invoked, initial output) + 80% tail (errors, final results).
     MICROCOMPACT_HEAD_RATIO = 0.2
 
+    # Matches an omission notice this class wrote, so a re-clip can carry the
+    # earlier count forward instead of reporting only its own slice.
+    _OMISSION_NOTICE = re.compile(r"\[… ([\d,]+) chars [^\]]*?…\]")
+
+    @classmethod
+    def _prior_omissions(cls, text: str) -> int:
+        """Total already reported as dropped by an earlier clip of ``text``."""
+        return sum(
+            int(m.group(1).replace(",", ""))
+            for m in cls._OMISSION_NOTICE.finditer(text)
+        )
+
     @classmethod
     def _head_tail_clip(cls, text: str, limit: int, note: str = "omitted") -> str:
         """Keep the head + tail of ``text`` and say how much fell out between.
 
-        One copy, because the two call sites — microcompaction and the summary
+        One copy, because the call sites — microcompaction and the summary
         transcript's failure tier — need the identical shape, and the notice is
         load-bearing at both: without it a reader (or the summarizing model)
         cannot tell a clipped result from a complete one and will quote half a
         command or half a path as fact.
+
+        **The notice is budgeted *inside* ``limit``, which makes this a fixed
+        point.** It used to be appended on top, so the output was
+        ``limit + len(notice)`` characters — strictly longer than the limit
+        that produced it. Everything downstream tests "is this over the limit?",
+        so the clip re-selected its own output forever: a second pass cut the
+        honest ``197,020 chars omitted`` notice out of the middle and wrote
+        ``45 chars omitted`` in its place, and every later pass reported ``40``.
+        That also pinned ``microcompact_would_mutate()`` at True and
+        ``last_microcompact_mutated`` at True for the whole 55-65% band,
+        silently defeating both stand-downs added in #181.
+
+        A re-clip of already-clipped text carries the earlier count forward
+        (:meth:`_prior_omissions`), so the figure the summarizer sees is the
+        total lost, not the last slice.
         """
         if len(text) <= limit:
             return text
-        head = int(limit * cls.MICROCOMPACT_HEAD_RATIO)
-        tail = limit - head
-        omitted = len(text) - limit
+        # ``omitted`` can never exceed ``len(text)``, so a notice sized for that
+        # worst case is an upper bound on the real one — which makes the final
+        # result at most ``limit`` characters without a second pass.
+        reserve = len(f"\n[… {len(text):,} chars {note} …]\n")
+        avail = max(1, limit - reserve)
+        head = int(avail * cls.MICROCOMPACT_HEAD_RATIO)
+        tail = avail - head
+        kept = text[:head] + text[len(text) - tail:] if tail else text[:head]
+        omitted = (
+            len(text) - avail
+            + cls._prior_omissions(text)
+            - cls._prior_omissions(kept)
+        )
         return (
             text[:head]
             + f"\n[… {omitted:,} chars {note} …]\n"
-            + text[len(text) - tail:]
+            + (text[len(text) - tail:] if tail else "")
         )
 
     def _microcompactable_indices(self, messages: List[Dict[str, Any]]) -> set:
@@ -480,9 +517,6 @@ class ContextManager:
         if len(messages) < 5:
             return messages
 
-        # --- Step 1: microcompact (free) ------------------------------------
-        messages = self.microcompact_messages(messages)
-
         # --- Step 2: partial compaction split -------------------------------
         # Keep at most KEEP_RECENT_MESSAGES, but no more than 60% of total
         keep_count = min(
@@ -522,7 +556,13 @@ class ContextManager:
         # ``_find_split_index`` never returns 0, so ``to_summarize`` is
         # non-empty by construction — no second emptiness check needed here.
         to_summarize = messages[:split_index]
-        to_keep = messages[split_index:]
+        # Microcompact only the half that survives — the summarized half is
+        # discarded once the summary exists, so clipping it here is pure loss:
+        # ``_format_for_summary`` applies its own content-aware budget, which
+        # gives a failing command four times what this pass would have left and
+        # keeps the tail where its diagnostic is. Running before the split (as
+        # this did) cut the same text twice for no gain.
+        to_keep = self.microcompact_messages(messages[split_index:])
 
         # --- Step 3: extract pinned messages --------------------------------
         pinned = [
@@ -925,11 +965,19 @@ class ContextManager:
         if not cls._FAILURE_MARKERS.search(text):
             # Head-only: a success's useful part is its opening, and the two
             # disjoint fragments a head+tail split leaves read worse here.
-            omitted = len(text) - cls._TOOL_RESULT_TRUNCATION
-            return (
-                text[: cls._TOOL_RESULT_TRUNCATION]
-                + f"\n[… {omitted:,} chars omitted …]"
+            #
+            # The count carries any earlier clip's forward. This is the second
+            # cut by construction — full compression microcompacts the kept
+            # window first, and the live 55% pass has usually already run — so
+            # reporting only this slice would tell the summarizer a result lost
+            # 2,000 characters when it lost 199,065.
+            kept = text[: cls._TOOL_RESULT_TRUNCATION]
+            omitted = (
+                len(text) - cls._TOOL_RESULT_TRUNCATION
+                + cls._prior_omissions(text)
+                - cls._prior_omissions(kept)
             )
+            return kept + f"\n[… {omitted:,} chars omitted …]"
         return cls._head_tail_clip(text, cls._ERROR_RESULT_TRUNCATION)
 
     def _clip_carry_summary(self, text: str) -> str:

--- a/docs/design/codex-compaction-vs-agentao.zh.md
+++ b/docs/design/codex-compaction-vs-agentao.zh.md
@@ -150,7 +150,34 @@ lines.append(f"[{role.upper()}]: {str(content)[:500]}")               # :651
 4. **普通档的截断不打标记。** 只有失败档标了省略；普通档直接砍到 1000 字符就交出去，摘要模型无从分辨「完整」与「被砍」——这正是同文件 `_clip_args` 已经写明的失败模式（会把半截路径/命令当成事实引用）。现在两档都标。
 5. **两处测试是空转的。** `test_a_single_oversized_message_still_produces_a_transcript` 名义上钉住「装不下也要保住最新一条」，但 ASCII 消息被 `_MESSAGE_TRUNCATION` 卡在 2000 字符 ≈ 500 token，永远够不到 2000 token 的预算下限，那条分支根本没被走到（改用 CJK 才真正触发）；`test_write_file_result_no_longer_gets_a_privileged_budget` 断的是 `not hasattr(...)`，任何拼写错误都能让它通过。两条都改成行为断言。另外预算的 token 计量从直接调 `_heuristic_token_count` 改为走 `count_tokens_in_text`，使它与所占比例的 `max_tokens` **同一单位**（有 tiktoken 用 tiktoken，没有则回落到同一个 CJK 启发式）。
 
-**未做：** 没有动 `MICROCOMPACT_TOOL_LIMIT = 3000`，所以双重截断（§本节上文）仍在——只是第二道从 200 抬到了 1000/4000，且两刀的切点不再重合。
+### 第三轮：双重截断本身（2026-08-23，同日）
+
+**上一轮记的「未做」被查实为更严重的问题：`_head_tail_clip` 不是幂等的，而且第二遍会覆盖掉第一遍诚实的计数。**
+
+它把提示行**追加在 limit 之外**，所以输出长度是 `limit + len(提示)`——**严格大于产生它的那个 limit**。而下游一律用「是否超过 limit」来判定，于是这个裁剪会永远重新选中自己的输出。实测四遍：
+
+```
+原文 200,020 字符
+pass 1: len=3045  mutated=True   [… 197,020 chars omitted by microcompact …]   ← 诚实
+pass 2: len=3040  mutated=True   [… 45 chars omitted by microcompact …]        ← 覆盖掉了
+pass 3: len=3040  mutated=True   [… 40 chars omitted by microcompact …]
+```
+
+**这条 bug 顺带废掉了 PR #181 的两处修复**,而 #181 和 #183 两轮评审都没发现:`microcompact_would_mutate()` 因此**恒为 True**,所以 55–65% 区间里的「无事可做就站下」永远不触发——每轮照样 fork 一次 PreCompact 子进程、emit 一条 `pre == post`;`last_microcompact_mutated` 同样恒为 True,token anchor 每轮照旧失效。**F1 和 F3 在最常见的情形下形同虚设。**
+
+三处修改:
+
+1. **提示行改为占用 limit 之内**,输出恰好 ≤ limit,裁剪成为不动点。第二遍起 `mutated=False`、`would_mutate=False`,诚实计数永久保留。
+2. **重复裁剪时把先前的省略数累加进来**(`_prior_omissions`),所以第二刀报的是**累计损失**而不是自己那一片——否则摘要模型会被告知一条丢了 20 万字符的结果「少了 2,000 字符」。
+3. **`compress_messages` 不再裁剪它即将丢弃的那一半**。原先在切分**之前**跑 microcompact,于是 `to_summarize` 被白切一刀——而 `_format_for_summary` 自己的分级本来就会给失败输出四倍空间并保住尾部。现在只对 `to_keep` 跑。
+
+实测存活率(同一批会话、真实窗口):**15% → 25%(#183) → 29%**。
+
+**仍未做:** `MICROCOMPACT_TOOL_LIMIT = 3000` 这个数值本身没动——它服务的是 55% 那一档对**活历史**的压缩,与摘要保真度是两个目标。真正的双重截断(同一段文本被两把互不知情的刀切)已经消除。
+
+---
+
+**教训(与 [[feedback_eviction_policy_check_the_discarded_end]] 同源):** 一个「裁剪到 N」的函数,其输出必须满足「不需要再裁剪」的判定。我写它的时候只想着「切完是 N 字符加一行说明」,没想到那行说明会让它越过自己的阈值。**任何带谓词的变换都要问一句:它的输出喂回谓词,答案是什么。**
 
 ---
 

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -805,7 +805,10 @@ def test_a_microcompacted_failure_passes_through_the_summary_clip_untouched():
     )
     out = cm._clip_tool_result(microcompacted)
     assert out == microcompacted
-    honest = f"{len(original) - cm.MICROCOMPACT_TOOL_LIMIT:,} chars omitted by microcompact"
+    # Measured against the retained content, since the notice is budgeted
+    # inside the limit rather than appended on top of it.
+    kept = len(microcompacted) - len(cm._OMISSION_NOTICE.search(microcompacted).group(0)) - 2
+    honest = f"{len(original) - kept:,} chars omitted by microcompact"
     assert honest in out, "the real omitted count must survive"
 
 
@@ -975,3 +978,74 @@ def test_a_carried_conversation_summary_is_never_evicted_by_the_budget():
     assert cm.count_tokens_in_text(
         out.split("earlier message(s) omitted")[0]
     ) <= cm._summary_input_budget() // 2 + 100
+
+
+# ---------------------------------------------------------------------------
+# Double truncation: microcompact -> summary clip
+#
+# The live 55% pass rewrites history in place, so a result reaching
+# ``_format_for_summary`` has usually been cut once already. The second cut
+# used to report only its own slice, and ``compress_messages`` added a third
+# by microcompacting the half it was about to discard.
+# ---------------------------------------------------------------------------
+
+def test_second_clip_reports_the_total_lost_not_just_its_own_slice():
+    """A 200KB result clipped twice must not claim it lost 2,000 characters."""
+    from agentao.context_manager import ContextManager
+    cm = _cm()
+    original = "setup\n" * 10 + "y" * 200_000 + "\ndone"
+    once = ContextManager._head_tail_clip(
+        original, cm.MICROCOMPACT_TOOL_LIMIT, note="omitted by microcompact"
+    )
+    twice = cm._clip_tool_result(once)
+    reported = max(
+        int(m.group(1).replace(",", ""))
+        for m in ContextManager._OMISSION_NOTICE.finditer(twice)
+    )
+    assert reported > 190_000, f"reported {reported:,}, the real loss is ~199,000"
+
+
+def test_compress_does_not_microcompact_the_half_it_is_about_to_discard():
+    """Clipping the summarize window before summarizing it is pure loss.
+
+    ``_format_for_summary`` applies its own content-aware budget — four times
+    the room for a failure, and the tail kept where the diagnostic is. Cutting
+    the same text to 3,000 chars first only takes that choice away, and it is
+    the ``MICROCOMPACT_TOOL_LIMIT`` half of the double truncation.
+    """
+    cm = _cm()
+    seen = {}
+    real = cm.microcompact_messages
+
+    def _spy(messages):
+        seen["contents"] = [str(m.get("content", "")) for m in messages]
+        return real(messages)
+
+    old_result = "OLD-RESULT-" + "z" * 50_000
+    msgs = (
+        [{"role": "user", "content": "start"}]
+        + [{"role": "tool", "name": "run_shell_command", "content": old_result}]
+        + [{"role": "assistant", "content": f"step {i}"} for i in range(8)]
+        + [{"role": "user", "content": "go on"}]
+        + [{"role": "assistant", "content": f"more {i}"} for i in range(24)]
+    )
+    summarized = {}
+    cm.microcompact_messages = _spy  # type: ignore[method-assign]
+
+    def _capture(window):
+        summarized["raw"] = "".join(str(x.get("content", "")) for x in window)
+        return ""
+
+    # ``_summarize_messages`` is what calls ``_format_for_summary``; stub it at
+    # that level so the window it receives is observable.
+    cm._summarize_messages = _capture  # type: ignore[method-assign]
+    cm.compress_messages(msgs, is_auto=True)
+
+    assert "contents" in seen, "microcompaction must still run on the kept half"
+    assert not any(c.startswith("OLD-RESULT-") for c in seen["contents"]), (
+        "the summarized half must never reach microcompaction"
+    )
+    assert len(seen["contents"]) < len(msgs)
+    # And the summarizer sees the result at full length, not pre-clipped.
+    assert len(summarized["raw"]) > cm.MICROCOMPACT_TOOL_LIMIT
+    assert "OLD-RESULT-" in summarized["raw"]

--- a/tests/test_microcompaction.py
+++ b/tests/test_microcompaction.py
@@ -40,11 +40,50 @@ def test_old_large_result_is_truncated():
 
 
 def test_omission_marker_contains_char_count():
+    """The count is what actually fell out, and the whole result fits the limit.
+
+    The notice is budgeted *inside* ``MICROCOMPACT_TOOL_LIMIT`` rather than
+    appended on top, so the retained content is ``limit - len(notice)`` and the
+    omitted figure is measured against that. Appending it made the output
+    longer than the limit that produced it, which re-selected the result on
+    every later pass — see ``test_microcompaction_is_a_fixed_point``.
+    """
     large = "B" * (_LIMIT * 2)
     messages = [_tool_msg(large)] + [_tool_msg("s") for _ in range(_PRESERVE)]
     result = _cm().microcompact_messages(messages)
-    omitted = len(large) - _LIMIT
-    assert f"{omitted:,}" in result[0]["content"]
+    body = result[0]["content"]
+    assert len(body) <= _LIMIT
+    kept_b = body.count("B")
+    assert f"{len(large) - kept_b:,}" in body
+
+
+def test_microcompaction_is_a_fixed_point():
+    """A second pass over already-microcompacted content must change nothing.
+
+    It used to change plenty: the output was ``limit + len(notice)`` chars, so
+    it stayed over the limit forever. Pass 2 cut the honest
+    ``197,020 chars omitted`` notice out of the middle and wrote ``45`` in its
+    place; every pass after that reported ``40``. It also pinned
+    ``microcompact_would_mutate()`` at True for the whole 55-65% band, so the
+    no-op stand-down that exists to stop per-iteration PreCompact subprocesses
+    never fired, and the token anchor was invalidated every iteration.
+    """
+    cm = _cm()
+    original = "START\n" + "x" * 200_000 + "\nEND"
+    msgs = [_tool_msg(original)] + [_tool_msg("s") for _ in range(_PRESERVE)]
+    once = cm.microcompact_messages(msgs)
+    assert cm.last_microcompact_mutated is True
+    honest = once[0]["content"]
+    notice = ContextManager._OMISSION_NOTICE.search(honest)
+    retained = len(honest) - len(notice.group(0)) - 2  # the notice's own newlines
+    reported = int(notice.group(1).replace(",", ""))
+    assert reported == len(original) - retained, "the count must be what fell out"
+    assert reported > 190_000, "not the ~45 a re-clip of its own output reported"
+
+    twice = cm.microcompact_messages(once)
+    assert cm.last_microcompact_mutated is False, "second pass must be a no-op"
+    assert cm.microcompact_would_mutate(once) is False
+    assert twice[0]["content"] == honest
 
 
 def test_preserves_last_n_tool_results_at_full_fidelity():
@@ -86,10 +125,13 @@ def test_head_tail_split_ratio():
     messages = [_tool_msg(content)] + [_tool_msg("s") for _ in range(_PRESERVE)]
     result = _cm().microcompact_messages(messages)
     truncated = result[0]["content"]
-    expected_head = int(_LIMIT * ContextManager.MICROCOMPACT_HEAD_RATIO)
+    # The ratio applies to the space left after reserving the notice, not to
+    # the raw limit — the notice lives inside the budget.
+    avail = truncated.count("H") + truncated.count("T")
+    assert len(truncated) <= _LIMIT
+    expected_head = int(avail * ContextManager.MICROCOMPACT_HEAD_RATIO)
     assert truncated.startswith("H" * expected_head)
-    expected_tail = _LIMIT - expected_head
-    assert truncated.endswith("T" * expected_tail)
+    assert truncated.endswith("T" * (avail - expected_head))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the `MICROCOMPACT_TOOL_LIMIT` double truncation that #183 left open. It turned out not to be a tuning question — the clip was not idempotent, and the bug had **silently defeated both stand-downs added in #181**.

## The clip re-selected its own output

`_head_tail_clip` appended its omission notice *outside* the limit, so its output was `limit + len(notice)` characters — strictly longer than the limit that produced it. Everything downstream asks "is this over the limit?", so the clip kept re-selecting what it had just written. Measured over four passes:

```
original 200,020 chars
pass 1: len=3045  mutated=True   [… 197,020 chars omitted by microcompact …]   ← honest
pass 2: len=3040  mutated=True   [… 45 chars omitted by microcompact …]        ← overwritten
pass 3: len=3040  mutated=True   [… 40 chars omitted by microcompact …]
pass 4: len=3040  mutated=True   [… 40 chars omitted by microcompact …]
```

Pass 2 cuts the honest notice out of the middle and writes its own slice in its place. The summarizer — whose output permanently replaces history — is told a result lost 40 characters when it lost 197,020.

## The knock-on is the bigger cost

A microcompacted result stays over `MICROCOMPACT_TOOL_LIMIT` forever, so:

- `microcompact_would_mutate()` **never returns False**. #181's no-op stand-down never fires, and every iteration in the 55–65% band still forks a `PreCompact` hook subprocess and emits a `CONTEXT_COMPRESSED` reporting `pre == post` — the exact churn that fix exists to stop.
- `last_microcompact_mutated` is pinned True for the same reason, so the token anchor is invalidated on every pass — #181's F3, also inert.

Both were reported as landed. Neither review pass on #181 or #183 caught this.

## Three parts

**The notice is budgeted inside the limit.** Output is at most `limit` characters, so the clip is a fixed point: pass 2 is a genuine no-op, `mutated` goes False, and the honest count survives indefinitely. Sized against `len(text)` as the worst-case omitted figure, so it needs no second sizing pass.

**A re-clip carries prior counts forward** (`_prior_omissions`). The summary clip is the second cut by construction — the live 55% pass has usually already run — so reporting only its own slice would claim 2,000 characters lost where 199,000 were.

**`compress_messages` no longer microcompacts the half it discards.** It ran *before* the split, so `to_summarize` was clipped to 3,000 chars for nothing: `_format_for_summary` then applies its own content-aware budget, which gives a failure four times the room and keeps the tail where its diagnostic is. Only `to_keep` is microcompacted now, which is what that pass is for.

## Tests

Three existing tests failed because they encoded the old arithmetic (`limit` where it is now `limit - len(notice)`). Rewritten to assert the **contract** — the result fits the limit, the head/tail ratio applies to the space actually available, the reported figure equals what fell out — rather than re-deriving the formula. Added `test_microcompaction_is_a_fixed_point` and two for the double cut.

Verified over 400 adversarial trials: microcompaction is idempotent, the carried summary always survives, live survivors are a contiguous suffix, and the transcript stays within budget.

## Effect

Retention on the sessions measured in #183, over realistic `to_summarize` windows: **25% → 29%** (15% before #183).

## Not done

`MICROCOMPACT_TOOL_LIMIT = 3000` itself is unchanged — it serves live-history compaction at 55%, a different goal from summary fidelity. What is gone is the same text being cut by two clips that did not know about each other.

Full suite `4032 passed`, `ruff check .` clean. The one local failure is the known home-directory `.env` leak, green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
