### PR TITLE
compact: make the PreCompact `trigger` say where the compaction came from (PR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ _Targeting 0.4.20. Add entries under the relevant heading as work lands._
 
 ### Added
 
+- **`PreCompact` hooks can finally match on where a compaction came from.**
+  `build_pre_compact` takes a required `trigger` argument and each of the five
+  compaction entry points states its own provenance, so manual `/compact`
+  reports `manual` and the four automatic sites report `auto`. `trigger` keeps
+  Claude Code's `manual | auto` vocabulary — the finer provenance was already
+  in `compaction_type` and `reason`, which are now typed (`CompactionKind`,
+  `CompactionReason`) in a new standard-library-only `agentao/compaction/`
+  module. `custom_instructions` also becomes a parameter instead of a hardcoded
+  `""`, though nothing passes it yet.
+
+  **This changes which rules fire.** Until now the payload hardcoded
+  `"trigger": "auto"` everywhere, so `{"trigger": "manual"}` was a matcher value
+  with **no reachable producer** — a rule written against it could never fire at
+  any entry point, in any configuration — while `{"trigger": "auto"}` wrongly
+  matched manual `/compact` too. After this change `{"trigger": "manual"}` fires
+  on `/compact` and only on `/compact`, and `{"trigger": "auto"}` stops matching
+  it. A rule written `{"trigger": "manual|auto"}` (Claude Code's own alternation
+  form) matches all five entry points before and after, and is the shape to
+  reach for if you want everything.
+
+  Also fixes the disagreement where manual `/compact`'s hook payload said
+  `auto` while its own `PLUGIN_HOOK_FIRED` replay event said `manual` for the
+  same compaction. `docs/releases/v0.4.4.md` gains an erratum, since its
+  `trigger` row's "no `manual` site exists" was true at 0.4.4 and false since.
+
 ### Changed
 
 - **Full LLM compaction now triggers at 80% of `max_context_tokens`, not 65%**

--- a/agentao/cli/commands/compact.py
+++ b/agentao/cli/commands/compact.py
@@ -59,6 +59,7 @@ def _dispatch_pre_compact(agent) -> None:
         payload = ClaudeHookPayloadAdapter().build_pre_compact(
             session_id=agent._session_id,
             cwd=cwd,
+            trigger="manual",
             compaction_type="full",
             reason="manual_cli",
             permission_mode=agent.active_permissions().mode,

--- a/agentao/compaction/__init__.py
+++ b/agentao/compaction/__init__.py
@@ -1,0 +1,19 @@
+"""Compaction orchestration — vocabulary types, and (later) the coordinator.
+
+Only ``types`` is re-exported here. ``coordinator`` must **not** be, even
+once it exists: ``agentao.host`` re-exports the public subset of this
+package, and dragging ``coordinator`` -> ``context_manager`` -> the LLM
+stack in through this ``__init__`` would trip import-layering rule 5
+(``tests/test_import_layering.py``, "``import agentao.host`` must not drag
+in the runtime or the LLM stack").
+"""
+
+from __future__ import annotations
+
+from .types import CompactionKind, CompactionReason, CompactionTrigger
+
+__all__ = [
+    "CompactionKind",
+    "CompactionReason",
+    "CompactionTrigger",
+]

--- a/agentao/compaction/types.py
+++ b/agentao/compaction/types.py
@@ -1,0 +1,42 @@
+"""Compaction vocabulary and contract types — standard library only.
+
+This module is deliberately **leaf-shaped**: it imports nothing from
+``agentao`` and nothing outside the standard library. ``context_manager.py``
+and the coordinator both need these names, and defining them anywhere else
+would force one of those two modules to import the other — the dependency
+direction ``docs/design/compaction-orchestration-plan.md`` §4.2.1 pins is
+that ``ContextManager`` never learns about the coordinator.
+
+The three aliases below are the **whole** vocabulary. ``trigger`` stays
+``manual | auto`` for Claude Code parity (§3.2): a host rule written
+``{"trigger": "manual|auto"}`` must keep matching every entry point, so the
+finer provenance lives in ``kind`` and ``reason`` instead of subdividing
+``trigger``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+#: Where the compaction came from, as the PreCompact matcher sees it.
+#: Claude Code parity — do not subdivide ``auto``.
+CompactionTrigger = Literal["manual", "auto"]
+
+#: Which transform is about to run. Today's ``compaction_type`` field.
+CompactionKind = Literal["microcompact", "full", "minimal_history"]
+
+#: Which condition asked for it. Today's ``reason`` field; one value per
+#: entry point in §2's table.
+CompactionReason = Literal[
+    "microcompact_threshold",
+    "compression_threshold",
+    "api_overflow",
+    "api_overflow_after_compression",
+    "manual_cli",
+]
+
+__all__ = [
+    "CompactionKind",
+    "CompactionReason",
+    "CompactionTrigger",
+]

--- a/agentao/plugins/hooks/_payload.py
+++ b/agentao/plugins/hooks/_payload.py
@@ -17,6 +17,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from ...compaction.types import (
+    CompactionKind,
+    CompactionReason,
+    CompactionTrigger,
+)
 from ._alias import ToolAliasResolver
 
 
@@ -147,18 +152,29 @@ class ClaudeHookPayloadAdapter:
         *,
         session_id: str | None = None,
         cwd: Path | None = None,
-        compaction_type: str,
-        reason: str,
+        trigger: CompactionTrigger,
+        compaction_type: CompactionKind,
+        reason: CompactionReason,
+        custom_instructions: str = "",
         permission_mode: str | None = None,
     ) -> dict[str, Any]:
+        """Build the flat Claude-shape ``PreCompact`` payload.
+
+        ``trigger`` is **required and has no default**. It used to be
+        hardcoded ``"auto"`` for all five compaction entry points, which
+        made ``{"trigger": "manual"}`` a matcher value with no reachable
+        producer — a rule written against it could never fire anywhere.
+        A default here would let a new entry point silently reacquire that
+        bug, so the provenance is stated at every call site instead.
+        """
         return {
             "hook_event_name": "PreCompact",
             "session_id": session_id or "",
             "transcript_path": None,
             "cwd": str(cwd or Path.cwd()),
             "permission_mode": permission_mode or "workspace-write",
-            "trigger": "auto",
-            "custom_instructions": "",
+            "trigger": trigger,
+            "custom_instructions": custom_instructions,
             "compaction_type": compaction_type,
             "reason": reason,
         }

--- a/agentao/runtime/chat_loop/_compaction.py
+++ b/agentao/runtime/chat_loop/_compaction.py
@@ -39,6 +39,7 @@ class _CompactionMixin:
             # pre == post, on top of two full-history token estimates.
             return messages_with_system, system_prompt
         self._dispatch_pre_compact(
+            trigger="auto",
             compaction_type="microcompact",
             reason="microcompact_threshold",
         )
@@ -92,6 +93,7 @@ class _CompactionMixin:
             )
             return messages_with_system, system_prompt
         self._dispatch_pre_compact(
+            trigger="auto",
             compaction_type="full",
             reason="compression_threshold",
         )

--- a/agentao/runtime/chat_loop/_hook_dispatch.py
+++ b/agentao/runtime/chat_loop/_hook_dispatch.py
@@ -16,6 +16,11 @@ from __future__ import annotations
 
 from typing import Literal
 
+from ...compaction.types import (
+    CompactionKind,
+    CompactionReason,
+    CompactionTrigger,
+)
 from ...plugins.models import StopHookResult
 from ...transport import AgentEvent, EventType
 from ._outcomes import _HookOutcome
@@ -163,12 +168,18 @@ class _HookDispatchMixin:
     def _dispatch_pre_compact(
         self,
         *,
-        compaction_type: str,
-        reason: str,
+        trigger: CompactionTrigger,
+        compaction_type: CompactionKind,
+        reason: CompactionReason,
     ) -> None:
         """PreCompact dispatch — fires before the about-to-mutate
         compaction site; side-effect only with the same no-emit gate as
         ``_dispatch_stop``.
+
+        ``trigger`` carries the provenance the matcher reads. Every site
+        reachable from here is automatic, so all four pass ``"auto"`` —
+        but it is passed rather than assumed, because assuming it is what
+        made manual ``/compact`` report itself as ``auto``.
         """
         agent = self._agent
         if not agent._plugin_hook_rules:
@@ -181,6 +192,7 @@ class _HookDispatchMixin:
         payload = ClaudeHookPayloadAdapter().build_pre_compact(
             session_id=agent._session_id,
             cwd=cwd,
+            trigger=trigger,
             compaction_type=compaction_type,
             reason=reason,
             permission_mode=agent.active_permissions().mode,
@@ -197,7 +209,7 @@ class _HookDispatchMixin:
                 "hook_name": "PreCompact",
                 "outcome": "allow",
                 "compaction_type": compaction_type,
-                "trigger": "auto",
+                "trigger": trigger,
                 "matched_rule_count": len(matched),
             }))
         except Exception:

--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -1159,6 +1159,7 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                 return ChatLoopRunner._LlmOutcome(error_return=err_msg)
             agent.llm.logger.warning(f"Context overflow from API, forcing compression: {e}")
             self._dispatch_pre_compact(
+                trigger="auto",
                 compaction_type="full",
                 reason="api_overflow",
             )
@@ -1197,6 +1198,7 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                         "Context still too long after compression, keeping minimal history"
                     )
                     self._dispatch_pre_compact(
+                        trigger="auto",
                         compaction_type="minimal_history",
                         reason="api_overflow_after_compression",
                     )

--- a/docs/history/implementation/stop-precompact-hooks-plan.md
+++ b/docs/history/implementation/stop-precompact-hooks-plan.md
@@ -22,6 +22,20 @@
 > | A4 emit-site table (from `:480`) | Four emit sites | **Now five**, adding the manual site at `cli/commands/compact.py:44`. |
 > | A5 `PLUGIN_HOOK_FIRED` projection (`:512`) | "`trigger` is always `"auto"` under this plan" | Qualified by "under this plan", so **still accurate as a historical statement**; but the manual site emits `"trigger": "manual"` in its replay event (`compact.py:75`), **contradicting the hook payload (`"auto"`) for the same compaction**. |
 >
+> **Follow-up — 2026-08-24: item 1 below is fixed; item 2 still stands.**
+> `build_pre_compact` now takes a required `trigger` argument and every
+> one of the five entry points states its own provenance
+> (`agentao/plugins/hooks/_payload.py`), so manual `/compact` reports
+> `manual` in both its hook payload and its `PLUGIN_HOOK_FIRED` event.
+> The contract change this banner warned about is real and shipped: a
+> rule written `{"trigger": "auto"}` no longer matches manual
+> `/compact`, while `{"trigger": "manual|auto"}` still matches all five.
+> The test-coverage gap named in item 1 is closed twice over — the
+> enumerated site list now carries five entries including `manual_cli`,
+> and `tests/test_hooks_pre_compact_trigger_provenance.py` drives all
+> five **production** call sites and reads the payload off the hook's
+> stdin rather than building it by hand.
+>
 > **Two items this banner does not resolve (they need a separate decision, not a doc edit):**
 > 1. **Code defect** — `build_pre_compact` takes no `trigger` argument, so a manual compaction's hook payload and its replay event report different `trigger` values for the same compaction. Fixing it **changes the hook contract** (the match set of agentao's post-translation matcher objects shifts), and `tests/test_hooks_pre_compact_payload_claude_shape.py:60-74` enumerates only the four sites, without `manual_cli` — **the existing tests cannot catch it**.
 > 2. **The contract recorded here has no living document** — the `PreCompact` payload/matcher contract exists only inside this superseded plan (`grep -rl PreCompact docs/ --include=*.md` hits nothing outside `docs/history/` except design reviews and release notes).

--- a/docs/history/implementation/stop-precompact-hooks-plan.zh.md
+++ b/docs/history/implementation/stop-precompact-hooks-plan.zh.md
@@ -21,6 +21,15 @@
 > | A4 emit 位置表（`:480` 起） | 四个 emit 位置 | **现为五个**，新增 `cli/commands/compact.py:44` 的手动位置。 |
 > | A5 `PLUGIN_HOOK_FIRED` 投影（`:512`） | 「`trigger` 在本计划下恒为 `"auto"`」 | 该句以「本计划下」限定，**作为历史陈述仍准确**；但手动位置的 replay 事件发的是 `"trigger": "manual"`（`compact.py:75`），**与它同一次压缩的 hook payload（`"auto"`）自相矛盾**。 |
 >
+> **后续 —— 2026-08-24：下方第 1 项已修复，第 2 项仍然成立。**
+> `build_pre_compact` 现在有一个必填的 `trigger` 参数，五个入口各自声明自己的来源
+> （`agentao/plugins/hooks/_payload.py`），因此手动 `/compact` 在 hook payload 与
+> `PLUGIN_HOOK_FIRED` 事件里都报 `manual`。本横幅预警的契约变化确实发生了：
+> `{"trigger": "auto"}` 规则**不再**命中手动 `/compact`，而 `{"trigger": "manual|auto"}`
+> 仍命中全部五个入口。第 1 项点名的测试盲区被两重堵上——站点清单已扩到五条、含
+> `manual_cli`，且 `tests/test_hooks_pre_compact_trigger_provenance.py` 驱动五个
+> **生产**调用点、从 hook 的 stdin 读回载荷，而不是手工构造。
+>
 > **未由本横幅解决的两项（需另行决策，不属于「修文档」范围）：**
 > 1. **代码缺陷** —— `build_pre_compact` 无 `trigger` 参数，手动压缩的 hook payload 与 replay 事件对同一次压缩给出不同的 `trigger`。修复会**改变 hook 契约**（agentao 翻译后 matcher 对象的命中集合随之变化），且 `tests/test_hooks_pre_compact_payload_claude_shape.py:60-74` 的站点清单只列了四个位置、不含 `manual_cli`，**现有测试抓不到它**。
 > 2. **本文所载契约没有在世文档** —— `PreCompact` 的 payload / matcher 契约目前只存在于这份已废止计划里（`grep -rl PreCompact docs/ --include=*.md` 在 `docs/history` 之外只命中 design 评审与 release notes）。

--- a/docs/releases/v0.4.4.md
+++ b/docs/releases/v0.4.4.md
@@ -128,7 +128,18 @@ preserved; Phase B's Stop emit extends it:
 | `added_context_count` | Stop only: `len(stop_result.additional_contexts)` |
 | `suppress_output` | Stop only: from JSON `suppressOutput` |
 | `compaction_type` | PreCompact only: `microcompact` / `full` / `minimal_history` |
-| `trigger` | PreCompact only: `auto` (no `manual` site exists) |
+| `trigger` | PreCompact only: `auto` (no `manual` site exists) — see the erratum below |
+
+> **Erratum — 2026-08-24.** The `trigger` row's parenthetical
+> ("no `manual` site exists") was true when 0.4.4 shipped and is false
+> now. Manual `/compact` (`agentao/cli/commands/compact.py`) landed
+> afterwards, and until 0.4.20 `build_pre_compact` hardcoded
+> `"trigger": "auto"` for **every** entry point — so the manual site
+> reported itself as `auto` while its own `PLUGIN_HOOK_FIRED` event said
+> `manual`, and a rule written `{"trigger": "manual"}` could not fire
+> anywhere. From 0.4.20 `trigger` reports the site that produced it:
+> `manual` for `/compact`, `auto` for the four automatic sites. The
+> historical statement above is left as written.
 
 `matched_rule_count` is a **selection count, not an execution
 count**. It is computed via `select_matching_rules("Stop", ...)`

--- a/tests/test_hook_dispatcher_stop.py
+++ b/tests/test_hook_dispatcher_stop.py
@@ -57,6 +57,7 @@ def test_dispatch_pre_compact_returns_hook_success_attachment(tmp_path):
     payload = ClaudeHookPayloadAdapter().build_pre_compact(
         session_id="s1",
         cwd=tmp_path,
+        trigger="auto",
         compaction_type="microcompact",
         reason="microcompact_threshold",
         permission_mode="workspace-write",

--- a/tests/test_hooks_pre_compact_matcher_non_dict_guard.py
+++ b/tests/test_hooks_pre_compact_matcher_non_dict_guard.py
@@ -64,6 +64,7 @@ def test_runtime_non_dict_matcher_returns_false_no_match(tmp_path):
     )
     payload = ClaudeHookPayloadAdapter().build_pre_compact(
         cwd=tmp_path,
+        trigger="auto",
         compaction_type="full",
         reason="compression_threshold",
     )

--- a/tests/test_hooks_pre_compact_matcher_trigger.py
+++ b/tests/test_hooks_pre_compact_matcher_trigger.py
@@ -14,11 +14,12 @@ from agentao.plugins.hooks import (
 from agentao.plugins.models import ParsedHookRule
 
 
-def _payload(tmp_path):
+def _payload(tmp_path, trigger="auto"):
     return ClaudeHookPayloadAdapter().build_pre_compact(
         cwd=tmp_path,
+        trigger=trigger,
         compaction_type="full",
-        reason="compression_threshold",
+        reason="compression_threshold" if trigger == "auto" else "manual_cli",
     )
 
 
@@ -44,11 +45,40 @@ def test_auto_matcher_fires(tmp_path):
     assert dispatcher._matches(rule, _payload(tmp_path))
 
 
+def test_manual_matcher_fires_on_manual_payload(tmp_path):
+    """The producer half of the pair above.
+
+    Before the trigger contract was fixed, ``build_pre_compact`` hardcoded
+    ``"auto"`` at all five entry points, so ``{"trigger": "manual"}`` was a
+    configuration value **no site could ever produce** — the rule above
+    passed while describing a dead matcher. This is the assertion that
+    makes it a real pair.
+    """
+    dispatcher = PluginHookDispatcher(cwd=tmp_path)
+    rule = _make_rule({"trigger": "manual"})
+    assert dispatcher._matches(rule, _payload(tmp_path, trigger="manual"))
+
+
+def test_auto_matcher_does_not_fire_on_manual_payload(tmp_path):
+    """The behaviour change PR-1 makes visible: an ``{"trigger": "auto"}``
+    rule used to match manual ``/compact`` too, because every payload said
+    ``auto``. It must not any more."""
+    dispatcher = PluginHookDispatcher(cwd=tmp_path)
+    rule = _make_rule({"trigger": "auto"})
+    assert not dispatcher._matches(rule, _payload(tmp_path, trigger="manual"))
+
+
 def test_alternation_pattern_fires_claude_parity(tmp_path):
-    """`manual|auto` must fire on `"auto"` payload — Claude Code parity."""
+    """`manual|auto` must fire on **both** payloads — Claude Code parity.
+
+    This is the regression guard for the trigger change: an existing host
+    rule written ``{"trigger": "manual|auto"}`` matched everything before
+    and must keep matching everything after.
+    """
     dispatcher = PluginHookDispatcher(cwd=tmp_path)
     rule = _make_rule({"trigger": "manual|auto"})
-    assert dispatcher._matches(rule, _payload(tmp_path))
+    assert dispatcher._matches(rule, _payload(tmp_path, trigger="auto"))
+    assert dispatcher._matches(rule, _payload(tmp_path, trigger="manual"))
 
 
 def test_wildcard_regex_fires(tmp_path):

--- a/tests/test_hooks_pre_compact_no_emit_when_no_rules.py
+++ b/tests/test_hooks_pre_compact_no_emit_when_no_rules.py
@@ -17,6 +17,7 @@ from tests.support.stop_precompact import make_runner_with_rules
 def test_no_plugin_rules_emits_nothing(tmp_path):
     runner, transport = make_runner_with_rules(tmp_path, rules=[])
     runner._dispatch_pre_compact(
+        trigger="auto",
         compaction_type="microcompact",
         reason="microcompact_threshold",
     )
@@ -29,6 +30,7 @@ def test_rules_exist_but_none_target_pre_compact(tmp_path):
     )
     runner, transport = make_runner_with_rules(tmp_path, rules=[stop_rule])
     runner._dispatch_pre_compact(
+        trigger="auto",
         compaction_type="microcompact",
         reason="microcompact_threshold",
     )
@@ -44,6 +46,7 @@ def test_positive_control_emits_with_correct_payload(tmp_path):
     )
     runner, transport = make_runner_with_rules(tmp_path, rules=[rule])
     runner._dispatch_pre_compact(
+        trigger="auto",
         compaction_type="microcompact",
         reason="microcompact_threshold",
     )
@@ -73,7 +76,7 @@ def test_compaction_type_round_trips_for_every_emit_site(tmp_path):
     for compaction_type, reason in sites:
         runner, transport = make_runner_with_rules(tmp_path, rules=[rule])
         runner._dispatch_pre_compact(
-            compaction_type=compaction_type, reason=reason,
+            trigger="auto", compaction_type=compaction_type, reason=reason,
         )
         fired = transport.hook_fired_events("PreCompact")
         assert len(fired) == 1, (compaction_type, reason)

--- a/tests/test_hooks_pre_compact_payload_claude_shape.py
+++ b/tests/test_hooks_pre_compact_payload_claude_shape.py
@@ -1,7 +1,9 @@
 """PreCompact payload wire-shape contract — sibling of the Stop test.
 
 Asserts top-level keys exactly match Claude Code's flat snake_case
-schema and that ``trigger`` is always ``"auto"`` under this plan.
+schema and that ``trigger`` reports the provenance of the site that
+built the payload — ``"manual"`` for ``/compact``, ``"auto"`` for the
+four automatic sites.
 """
 
 from __future__ import annotations
@@ -30,8 +32,12 @@ PRECOMPACT_TOP_LEVEL_KEYS = {
 }
 
 
-def _capture(tmp_path, *, compaction_type: str, reason: str) -> dict:
-    script, capture = write_capture_script(tmp_path, name=f"capture_{compaction_type}.sh")
+def _capture(
+    tmp_path, *, trigger: str = "auto", compaction_type: str, reason: str,
+) -> dict:
+    script, capture = write_capture_script(
+        tmp_path, name=f"capture_{trigger}_{compaction_type}_{reason}.sh",
+    )
     rule = ParsedHookRule(
         event="PreCompact",
         hook_type="command",
@@ -41,6 +47,7 @@ def _capture(tmp_path, *, compaction_type: str, reason: str) -> dict:
     payload = ClaudeHookPayloadAdapter().build_pre_compact(
         session_id="s",
         cwd=tmp_path,
+        trigger=trigger,
         compaction_type=compaction_type,
         reason=reason,
         permission_mode="workspace-write",
@@ -57,17 +64,50 @@ def test_pre_compact_payload_top_level_keys_match_claude(tmp_path):
     assert received["hook_event_name"] == "PreCompact"
 
 
-def test_pre_compact_trigger_always_auto_for_every_emit_site(tmp_path):
-    """Every PreCompact emit site keeps trigger=='auto' (no manual surface)."""
+def test_pre_compact_trigger_matches_its_emit_site(tmp_path):
+    """Every PreCompact emit site reports its own provenance.
+
+    The list is **five** sites, not four: manual ``/compact``
+    (``cli/commands/compact.py``) shipped after this test was written, and
+    while ``trigger`` was hardcoded ``"auto"`` its omission here was
+    invisible. That omission is the reason the defect survived — the test
+    enumerated exactly the sites that happened to be right.
+    """
     sites = [
-        ("microcompact", "microcompact_threshold"),
-        ("full", "compression_threshold"),
-        ("full", "api_overflow"),
-        ("minimal_history", "api_overflow_after_compression"),
+        ("auto", "microcompact", "microcompact_threshold"),
+        ("auto", "full", "compression_threshold"),
+        ("auto", "full", "api_overflow"),
+        ("auto", "minimal_history", "api_overflow_after_compression"),
+        ("manual", "full", "manual_cli"),
     ]
-    for compaction_type, reason in sites:
-        received = _capture(tmp_path, compaction_type=compaction_type, reason=reason)
-        assert received["trigger"] == "auto", (compaction_type, reason)
+    for trigger, compaction_type, reason in sites:
+        received = _capture(
+            tmp_path, trigger=trigger, compaction_type=compaction_type, reason=reason,
+        )
+        assert received["trigger"] == trigger, (compaction_type, reason)
         assert received["custom_instructions"] == ""
         assert received["compaction_type"] == compaction_type
         assert received["reason"] == reason
+
+
+def test_custom_instructions_round_trips(tmp_path):
+    """``custom_instructions`` is a parameter now, not a hardcoded ``""``.
+
+    Nothing passes it yet — ``handle_compact_command`` still ignores the
+    ``args`` it receives — so this pins the payload half only, so that
+    wiring ``/compact <instructions>`` later needs no schema change.
+    """
+    received = _capture(
+        tmp_path, trigger="manual", compaction_type="full", reason="manual_cli",
+    )
+    assert received["custom_instructions"] == ""
+
+    payload = ClaudeHookPayloadAdapter().build_pre_compact(
+        cwd=tmp_path,
+        trigger="manual",
+        compaction_type="full",
+        reason="manual_cli",
+        custom_instructions="focus on the failing test",
+    )
+    assert payload["custom_instructions"] == "focus on the failing test"
+    assert set(payload.keys()) == PRECOMPACT_TOP_LEVEL_KEYS

--- a/tests/test_hooks_pre_compact_trigger_provenance.py
+++ b/tests/test_hooks_pre_compact_trigger_provenance.py
@@ -1,0 +1,222 @@
+"""``trigger`` provenance, driven through the **five real entry points**.
+
+The sibling wire-shape test builds payloads by hand, so it can only
+assert what ``build_pre_compact`` does with the arguments a test chooses.
+This one drives the actual compaction sites — ``_maybe_microcompact``,
+``_maybe_full_compress``, both rungs of ``_call_llm_with_overflow_recovery``,
+and ``/compact``'s ``_dispatch_pre_compact`` — and reads the payload the
+hook subprocess actually received on stdin.
+
+That distinction is the whole point of this file. ``trigger`` was
+hardcoded ``"auto"`` inside the payload builder for every entry point,
+and a hand-built payload passing ``trigger="manual"`` would have looked
+correct while no site on earth produced it. Only the real call sites can
+falsify that.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+
+from agentao.cancellation import CancellationToken
+from agentao.cli.commands.compact import _dispatch_pre_compact as dispatch_manual
+from agentao.plugins.models import ParsedHookRule
+from agentao.runtime.chat_loop import ChatLoopRunner
+
+from tests.support.host_events import CapturingTransport
+from tests.support.stop_precompact import make_bare_agent
+
+# An error string the real classifier accepts as an overflow, taken from
+# tests/test_context_overflow_detection.py's Anthropic row.
+_OVERFLOW = "prompt is too long: 213462 tokens > 200000 maximum"
+
+_HISTORY = [
+    {"role": "user", "content": "one"},
+    {"role": "assistant", "content": "two"},
+    {"role": "user", "content": "three"},
+    {"role": "assistant", "content": "four"},
+    {"role": "user", "content": "five"},
+]
+
+
+def _rule(tmp_path, name, matcher=None):
+    """A PreCompact rule whose command **appends** each payload it is given.
+
+    The shared ``write_capture_script`` truncates, which loses the first
+    of the two overflow rungs — both dispatch into the same file within
+    one driver call.
+    """
+    script = tmp_path / f"{name}.sh"
+    capture = tmp_path / f"{name}.jsonl"
+    script.write_text(
+        "#!/bin/sh\ncat >> '" + str(capture) + "'\nprintf '\\n' >> '"
+        + str(capture) + "'\nexit 0\n",
+        encoding="utf-8",
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IRUSR | stat.S_IWUSR)
+    rule = ParsedHookRule(
+        event="PreCompact",
+        hook_type="command",
+        command=f"sh '{script}'",
+        matcher=matcher,
+        plugin_name="t",
+    )
+    return rule, capture
+
+
+def _payloads(capture):
+    if not capture.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in capture.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _agent(tmp_path, rules):
+    transport = CapturingTransport()
+    agent = make_bare_agent(tmp_path, transport=transport)
+    agent._plugin_hook_rules = rules
+    agent.messages = list(_HISTORY)
+    # ``runtime/turn.py:111`` sets this at the start of every turn; these
+    # drivers call the compaction sites directly, below that layer.
+    agent._last_session_summary_id = None
+    return agent, transport
+
+
+def _neutralize(agent, monkeypatch):
+    """Stub the parts of a compaction that need an LLM or a real prompt.
+
+    Everything up to and including the hook dispatch stays real — that is
+    what is under test. ``compress_messages`` is the summarizing call and
+    is replaced with the identity, which is also exactly what it returns
+    today on every failure path.
+    """
+    monkeypatch.setattr(agent, "_build_system_prompt", lambda: "")
+    monkeypatch.setattr(agent, "_emit_session_summary_if_new", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        agent.context_manager, "compress_messages", lambda msgs, is_auto=True: msgs,
+    )
+
+
+# --------------------------------------------------------------------------
+# The five drivers — each runs the production code path end to end.
+# --------------------------------------------------------------------------
+
+def _drive_microcompact(tmp_path, monkeypatch, rules):
+    agent, transport = _agent(tmp_path, rules)
+    _neutralize(agent, monkeypatch)
+    cm = agent.context_manager
+    monkeypatch.setattr(cm, "needs_microcompaction", lambda *_a, **_k: True)
+    monkeypatch.setattr(cm, "microcompact_would_mutate", lambda *_a, **_k: True)
+    runner = ChatLoopRunner(agent)
+    runner._maybe_microcompact([{"role": "system", "content": ""}] + agent.messages, "")
+    return transport
+
+
+def _drive_threshold_full(tmp_path, monkeypatch, rules):
+    agent, transport = _agent(tmp_path, rules)
+    _neutralize(agent, monkeypatch)
+    cm = agent.context_manager
+    monkeypatch.setattr(cm, "needs_compression", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        type(cm), "compaction_circuit_open", property(lambda _s: False),
+    )
+    runner = ChatLoopRunner(agent)
+    runner._maybe_full_compress([{"role": "system", "content": ""}] + agent.messages, "")
+    return transport
+
+
+def _drive_overflow(tmp_path, monkeypatch, rules):
+    """Both ladder rungs: ``_llm_call`` raises overflow every time."""
+    agent, transport = _agent(tmp_path, rules)
+    _neutralize(agent, monkeypatch)
+
+    def _always_overflow(*_a, **_k):
+        raise RuntimeError(_OVERFLOW)
+
+    monkeypatch.setattr(agent, "_llm_call", _always_overflow)
+    runner = ChatLoopRunner(agent)
+    runner._call_llm_with_overflow_recovery(
+        [{"role": "system", "content": ""}] + agent.messages,
+        "",
+        [],
+        CancellationToken(),
+    )
+    return transport
+
+
+def _drive_manual(tmp_path, monkeypatch, rules):
+    agent, transport = _agent(tmp_path, rules)
+    dispatch_manual(agent)
+    return transport
+
+
+def test_each_entry_point_reports_its_own_trigger(tmp_path, monkeypatch):
+    """The provenance table, read off the wire.
+
+    Four automatic sites say ``auto``; manual ``/compact`` says
+    ``manual``. Before the fix all five said ``auto``.
+    """
+    expected = {
+        "microcompact_threshold": "auto",
+        "compression_threshold": "auto",
+        "api_overflow": "auto",
+        "api_overflow_after_compression": "auto",
+        "manual_cli": "manual",
+    }
+
+    rule, capture = _rule(tmp_path, "capture_all")
+    for driver in (
+        _drive_microcompact,
+        _drive_threshold_full,
+        _drive_overflow,
+        _drive_manual,
+    ):
+        driver(tmp_path, monkeypatch, [rule])
+
+    seen = {p["reason"]: p["trigger"] for p in _payloads(capture)}
+    assert seen == expected, seen
+
+
+def test_manual_matcher_selects_only_the_manual_entry(tmp_path, monkeypatch):
+    """PR-1's acceptance: ``{"trigger": "manual"}`` fires on ``/compact``
+    and on nothing else.
+
+    Selection is asserted through ``PLUGIN_HOOK_FIRED``, which is emitted
+    only when ``select_matching_rules`` returned something — so a count of
+    zero means the rule was genuinely not selected, not that the script
+    failed.
+    """
+    rule, _ = _rule(tmp_path, "manual_only", matcher={"trigger": "manual"})
+
+    for driver in (_drive_microcompact, _drive_threshold_full, _drive_overflow):
+        transport = driver(tmp_path, monkeypatch, [rule])
+        assert transport.hook_fired_events("PreCompact") == [], driver.__name__
+
+    transport = _drive_manual(tmp_path, monkeypatch, [rule])
+    fired = transport.hook_fired_events("PreCompact")
+    assert len(fired) == 1
+    assert fired[0].data["trigger"] == "manual"
+
+
+def test_alternation_rule_still_fires_at_every_entry_point(tmp_path, monkeypatch):
+    """The regression guard named in the plan: a host rule written
+    ``{"trigger": "manual|auto"}`` matched all five sites before the
+    change and must match all five after it."""
+    rule, _ = _rule(tmp_path, "alternation", matcher={"trigger": "manual|auto"})
+
+    counts = []
+    for driver in (
+        _drive_microcompact,
+        _drive_threshold_full,
+        _drive_overflow,
+        _drive_manual,
+    ):
+        transport = driver(tmp_path, monkeypatch, [rule])
+        counts.append(len(transport.hook_fired_events("PreCompact")))
+
+    # microcompact 1, threshold 1, overflow 2 (both rungs), manual 1.
+    assert counts == [1, 1, 2, 1]


### PR DESCRIPTION
Implements **PR-1** of `docs/design/compaction-orchestration-plan.md` (§4.1) — the first of the four batch-1 PRs, in the plan's dependency order **PR-1 → PR-3 → PR-2 → PR-4**.

## The defect

`ClaudeHookPayloadAdapter.build_pre_compact` hardcoded `"trigger": "auto"` for **all five** compaction entry points. The consequence is bigger than a wrong field:

> A hook registered with `matcher: {"trigger": "manual"}` could never fire, at any entry point, in any configuration. It was not a mislabelled payload — it was a configuration value with no reachable producer.

And the inverse: `{"trigger": "auto"}` **wrongly matched** manual `/compact`, whose own `PLUGIN_HOOK_FIRED` replay event said `manual` for the same compaction.

## What changed

- `build_pre_compact(..., trigger, custom_instructions="")` — `trigger` is **required, no default**, so a future entry point cannot silently reacquire the bug.
- All five sites state their provenance: `auto` for microcompaction / threshold / both overflow rungs, `manual` for `/compact`.
- **Vocabulary stays `manual | auto`.** Splitting `auto` into `threshold|overflow` would silently stop an existing `{"trigger": "manual|auto"}` rule from matching threshold compaction — the exact failure class this plan exists to remove. The finer provenance already lives in `compaction_type` / `reason`, now typed as `CompactionKind` / `CompactionReason`.
- New `agentao/compaction/` package: `types.py` is **standard-library-only** and holds the vocabulary. It is where the rest of the orchestration contract lands in PR-3, and `__init__.py` deliberately re-exports only `types` so that `agentao.host` can later re-export the public subset without dragging `coordinator → context_manager →` the LLM stack through import-layering rule 5.

## Behaviour change (stated out loud)

`{"trigger": "auto"}` **no longer matches manual `/compact`**. `{"trigger": "manual|auto"}` — Claude Code's own alternation form — matches all five sites before and after, and is the shape to reach for if you want everything.

## Not in scope, recorded as a consequence

`_matches` still compares exactly one key for PreCompact. Typing `kind` / `reason` does **not** make them matchable; Claude Code's PreCompact matcher is trigger-only, so extending it is an agentao-only extension needing its own item and its own docs.

## Tests

The old site list had four entries, and the test asserting it was named `test_pre_compact_trigger_always_auto_for_every_emit_site` with a docstring reading "no manual surface" — **the stale premise was encoded in the test's own name**, which is why the defect survived a shipped `/compact`. Renamed, extended to five sites, and joined by `tests/test_hooks_pre_compact_trigger_provenance.py`, which drives all five **production** call sites (`_maybe_microcompact`, `_maybe_full_compress`, both rungs of `_call_llm_with_overflow_recovery`, `/compact`) and reads the payload off the hook subprocess's stdin rather than building it by hand.

Covered: each site's own trigger; `{"trigger": "manual"}` fires on `/compact` **and nothing else**; `{"trigger": "manual|auto"}` still fires everywhere; `{"trigger": "auto"}` no longer matches manual.

## Docs

- `docs/releases/v0.4.4.md` gains an **erratum** — its `trigger` row said "no `manual` site exists", true at 0.4.4 and false since `/compact` shipped. Annotated, not rewritten.
- The `stop-precompact-hooks-plan` errata banners (en + zh twins) record that their item 1 — the code defect they could not resolve — is now fixed. Their item 2 (the PreCompact contract has no living document) still stands.

## Gates

`uv run ruff check .` clean. `uv run python -m pytest tests/` — 4038 passed, 1 skipped; the single failure is the pre-existing `test_model_switching_flow`, which reaches a live endpoint from a home-directory `.env` and is green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
