### PR TITLE
compact: one coordinator, one outcome, honest events (PR-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,54 @@ _Targeting 0.4.20. Add entries under the relevant heading as work lands._
 
 ### Changed
 
+- **All five compaction entry points now go through one `CompactionCoordinator`,
+  and every attempt returns one `CompactionOutcome`.** Microcompaction, the
+  threshold tier, both rungs of the API-overflow ladder and manual `/compact`
+  used to orchestrate compaction independently, and they disagreed about the
+  two things that matter: whether a failure counts, and whether "compacted"
+  means history actually changed.
+
+  **The observable fix: `CONTEXT_COMPRESSED` is emitted only when the
+  compaction succeeded.** The API-overflow path emitted it unconditionally, so
+  with the circuit breaker open it reported a compaction that returned the
+  message list untouched — `pre_msgs == post_msgs`, no summary, nothing
+  written. The threshold tier got this treatment in 0.4.19; the overflow path
+  was missed. **`CONTEXT_COMPRESSED`'s payload does not change by a single
+  key**, and both its token fields keep their system-*inclusive* unit.
+
+  A new `COMPACTION_SETTLED` event (replay schema **1.3**) is the terminal
+  event for one attempt whatever the outcome — `success | cancelled | failed`,
+  with `trigger` / `kind` / `reason` / `detail`. `skipped` emits **nothing**,
+  deliberately: three of its four cases re-trigger on every loop iteration, so
+  one event each would be an event storm rather than a signal. Its
+  `pre_tokens_history` / `post_tokens_history` are named apart from the old
+  event's pair because they **exclude** the system prompt — two units, two
+  names, so they cannot be wired to each other by accident. Both stay `null`
+  on the overflow rungs and on microcompaction, since filling them in means
+  full-history estimates exactly where they cost most.
+
+  **Second deliberate behaviour change: a failed summarization no longer
+  writes to the memory store.** `crystallize_user_messages` ran *before*
+  summarization, so a summarization that then returned nothing had already
+  crystallized. `compress_messages` splits into `prepare_compaction` /
+  `commit_compaction`, and both SQLite writes moved to commit — which does not
+  run unless a summary exists.
+
+  Also: the API-overflow rung finally passes its real `reason`
+  (`api_overflow`) instead of riding `compress_messages(is_auto=True)`'s
+  default and reporting itself as a threshold compaction, contradicting the
+  hook payload it had just emitted; `/compact` stops guessing success by
+  sniffing `messages[0]` for a `[Compact Boundary]` marker and reports the
+  actual reason it made no change; and the duplicated `PreCompact` dispatch in
+  the CLI is gone — one implementation serves all five entries.
+
+  `ContextManager.compress_messages()` keeps its signature, its return type
+  and its breaker gate, and is now a thin wrapper over the split. It cannot
+  say *why* nothing changed, so new code should go through the coordinator;
+  a direct call bypasses the host control plane and the breaker's probe
+  policy.
+
+
 - **Full LLM compaction now triggers at 80% of `max_context_tokens`, not 65%**
   (`ContextManager.COMPRESSION_THRESHOLD` 0.65 → 0.80). agentao was the most
   conservative of its peers by 25–27 points (pi-mono compacts at

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Agentao is an **embedded agent harness**: the same runtime drives the interactiv
 |---|---|
 | `agentao/agent.py` | `Agentao` class — sync `chat()` and async `arun()`. Construction wires LLM, tools, skills, plugins, permissions, replay. |
 | `agentao/runtime/` | Per-turn machinery extracted from `Agentao` — `ChatLoopRunner` (loop body), `ToolRunner` (4-phase tool pipeline: plan / execute / format / sanitize), `run_llm_call`, model/provider switching. |
+| `agentao/compaction/` | Compaction orchestration. `types.py` is the contract (`CompactionOutcome`, `CompactionDecisionContext`, `CompactionDecision`, `CompactionController`, and the `trigger`/`kind`/`reason` vocabulary) and **imports nothing but the standard library**; `coordinator.py` holds `CompactionCoordinator`. `__init__.py` must never re-export `coordinator` — see Common gotchas. |
 | `agentao/host/` | **Public host contract.** `HostEvent`, `ToolLifecycleEvent`, `SubagentLifecycleEvent`, `PermissionDecisionEvent`, `EventStream`, `ActivePermissions`. Stability boundary for embedded hosts. |
 | `agentao/harness/` | **Deprecated alias for `agentao.host`** (renamed in 0.4.2). Re-exports with old names + `DeprecationWarning`; scheduled for removal in 0.5.0. |
 | `agentao/embedding/` | Host-side construction: `build_from_environment()` (env / dotenv / `.agentao/*.json` reads routed through explicit kwargs), `permission_loader`, `sessions`, `plugins/` (manifest loader, validators, MCP merge, resolvers). |
@@ -111,6 +112,50 @@ Agentao.chat() / Agentao.arun()
 ```
 
 `arun()` is the async path; the sync `chat()` wraps it. AsyncTools dispatch on `runtime_loop` so cancellation works inside the LLM-driven turn.
+
+### Compaction
+
+Five entry points detect their own condition and hand off to one
+`CompactionCoordinator` (`agentao/compaction/coordinator.py`), reached as
+`agent.compaction_coordinator`:
+
+| # | Entry point | `kind` | `reason` |
+|---|---|---|---|
+| 1 | Microcompaction (`runtime/chat_loop/_compaction.py`) | `microcompact` | `microcompact_threshold` |
+| 2 | Threshold full (same file) | `full` | `compression_threshold` |
+| 3 | API overflow, rung 1 (`runtime/chat_loop/_runner.py`) | `full` | `api_overflow` |
+| 4 | API overflow, rung 2 (same file) | `minimal_history` | `api_overflow_after_compression` |
+| 5 | Manual `/compact` (`cli/commands/compact.py`) | `full` | `manual_cli` |
+
+The coordinator owns *whether to run, whose summary to take, and what to
+emit*: the circuit-breaker gate, the `PreCompact` hook dispatch, history
+assignment, and both events. `ContextManager` owns every content transform —
+and **the dependency points one way only: `ContextManager` neither imports
+nor holds a coordinator**. That is why the shared types live in the neutral
+`types.py`.
+
+`compress_messages` is split at the summarization call:
+`prepare_compaction` (pure computation, **no SQLite write, no touch of
+`agent.messages`**) → decide → summarize → `commit_compaction` (the two
+SQLite writes and the new list). `_run_compaction` strings those together and
+owns all three failure-counting points — they cannot live in commit, which
+never runs when summarization returns nothing.
+
+**`skipped` emits no event.** Three of its four cases re-trigger on every loop
+iteration; one event each would be a storm. `CONTEXT_COMPRESSED` fires only on
+`success`; `COMPACTION_SETTLED` fires for `success | cancelled | failed`.
+
+**Two token units, deliberately named apart.** `CONTEXT_COMPRESSED`'s
+`pre_est_tokens` / `post_est_tokens` **include** the system prompt;
+`COMPACTION_SETTLED`'s `pre_tokens_history` / `post_tokens_history` exclude
+it. Never wire one into the other.
+
+`ContextManager.compress_messages()` survives as the legacy wrapper (its
+signature is documented and pinned by tests that call it directly). It returns
+a bare list and so cannot say *why* nothing changed; it also bypasses the
+host control plane and the breaker's probe policy.
+
+Design: `docs/design/compaction-orchestration-plan.md`.
 
 ### Skills
 
@@ -189,6 +234,8 @@ Adding a built-in tool or a skill to this repo: see [docs/guides/adding-componen
 - **Don't intuition-audit architecture.** Before recommending borrowed patterns or claiming a gap exists, grep agentao to verify; subpackage `__init__.py` docstrings document intentional shims and rename trails.
 - **`/goal --turns` is NOT `max_iterations`.** `--turns` caps the *outer* continuation count (how many `chat()` calls the goal loop drives); `max_iterations` caps the *inner* tool-call loop within a single `chat()`. They are orthogonal — both stay in force. The goal loop is host-owned (`cli/input_loop.py`), deliberately not the plugin `Stop`/`force_continue` path. Design: `docs/design/codex-goal-mechanism-review.md` §11.
 - **Never move `arun` back onto the loop's default executor, and don't reach for `asyncio.to_thread` from an async tool.** `agent.py::arun` runs `chat()` on agentao's own `_get_arun_pool()`. This looks like pointless ceremony over `run_in_executor(None, ...)` and is not: a turn holds its worker for the *whole turn*, and partway through it blocks in `tool_executor._run_async_tool` waiting on a tool coroutine running on the host loop. Once concurrent turns reach the pool's worker count, anything on that loop needing a default-executor worker can never get one — and the turns are waiting on precisely that work. That includes code agentao does not control: `loop.getaddrinfo` submits to the default executor, so **every `httpx.AsyncClient` connect to a hostname** goes through it (measured with `trust_env=False`; with proxy env vars set httpx never resolves at all, which is how two earlier attempts at this measurement "proved" the opposite). Same reason `web.py` parses HTML on its own `_get_cpu_pool()`. Three pools, no contention: `agentao-arun-*` (turns), `agentao-web-html-*` (parsing), loop default (left free for httpx). Tests: `tests/test_web_fetch_async_tool.py` starves a one-worker default executor and asserts both still complete.
+
+- **`agentao/compaction/__init__.py` must not re-export `coordinator`.** `agentao.host` re-exports the public compaction types from that package; pulling `coordinator` in through the `__init__` would drag `context_manager` → the LLM stack behind it and trip import-layering rule 5 (`tests/test_import_layering.py`, "`import agentao.host` must not drag in the runtime or the LLM stack"). Same reason `types.py` imports only the standard library: `context_manager.py` and `coordinator.py` both import from it, so both edges point down.
 
 - **Unicode tag stripping is structural, not a range filter — don't "simplify" it.** `security/unicode_tags.py::strip_unicode_tags` removes invisible U+E0000–E007F characters (ASCII smuggling: they render as nothing, tokenize losslessly, and let a web page or MCP result carry instructions only the model sees). Applied at three boundaries: the model-bound copy of every tool result (`runtime/tool_result_formatter.py::_format_one`, *after* the replay emit so the audit record keeps the original bytes), model output re-entering the runtime (`runtime/sanitize.py::sanitize_text_field`), and the terminal display (`acp_client/render.py::_sanitize_terminal_text`, alongside the bidi controls). It is a transform applied at named boundaries — **not** an ambient guarantee; skill/MCP descriptions inlined into the system prompt do not pass through it.
   - The block's one legitimate use is RGI emoji tag sequences, so a blind range filter destroys every subdivision flag — 🏴󠁧󠁢󠁳󠁣󠁴󠁿/🏴󠁧󠁢󠁷󠁬󠁳󠁿/🏴󠁧󠁢󠁥󠁮󠁧󠁿 all collapse to 🏴 (a live defect in goose's own fix, #10745). A run survives only as `U+1F3F4` + ≤5 lowercase-alnum tag chars + `U+E007F`. **Both bounds are load-bearing**: the per-sequence cap alone bounds nothing, since chaining N valid sequences yields N×5 hidden characters — hence `_MAX_TAG_SEQUENCES` caps how many survive per string.

--- a/agentao/agent.py
+++ b/agentao/agent.py
@@ -310,6 +310,10 @@ class Agentao:
             max_tokens=max_context_tokens,
             memory_manager=self._memory_manager,
         )
+        # Built on first use — see :attr:`compaction_coordinator`. Held
+        # rather than rebuilt per call because it is where per-turn
+        # compaction state lives.
+        self._compaction_coordinator = None
 
         # Session-scoped state (session id, host event stream, conversation
         # history, plan session, project instructions) must land before
@@ -1107,6 +1111,26 @@ class Agentao:
     def _latest_session_summary_id(self) -> Optional[str]:
         from .replay.observability import latest_session_summary_id
         return latest_session_summary_id(self)
+
+    @property
+    def compaction_coordinator(self):
+        """The single orchestrator every compaction entry point goes through.
+
+        Lazily built and then held: the coordinator is where compaction state
+        that outlives one call belongs, so a fresh instance per call would
+        quietly drop it.
+
+        Imported here rather than at module scope so that
+        ``agentao/compaction/__init__.py`` stays free of the coordinator —
+        ``agentao.host`` re-exports the public compaction types from that
+        package, and dragging ``coordinator -> context_manager ->`` the LLM
+        stack through it would break the host contract's standalone
+        importability.
+        """
+        if self._compaction_coordinator is None:
+            from .compaction.coordinator import CompactionCoordinator
+            self._compaction_coordinator = CompactionCoordinator(self)
+        return self._compaction_coordinator
 
     def _emit_context_compressed(
         self,

--- a/agentao/cli/commands/compact.py
+++ b/agentao/cli/commands/compact.py
@@ -1,138 +1,86 @@
 """``/compact`` — manually trigger full conversation-history compaction.
 
-Mirrors the threshold-driven path in
-``runtime/chat_loop/_compaction.py::_maybe_full_compress`` but runs on
-demand: it calls ``ContextManager.compress_messages(..., is_auto=False)``,
-swaps in the summarized history, fires the same ``CONTEXT_COMPRESSED`` /
-session-summary observability events, and refreshes the cached context
-percentage shown in the prompt.
+Runs the same path as the threshold-driven tier, on demand: it goes through
+``CompactionCoordinator`` with ``trigger="manual"`` / ``reason="manual_cli"``,
+which fires the ``PreCompact`` hook, applies the circuit-breaker gate, swaps
+in the summarized history, and emits both compaction events. All this file
+adds is the console report.
+
+It used to carry its own copy of the hook dispatch and its own success
+heuristic — sniffing ``messages[0]`` for a freshly prepended
+``[Compact Boundary]`` marker, because ``compress_messages`` returned a bare
+list and could not say whether anything happened. Both are gone: the
+coordinator returns a ``CompactionOutcome`` with a ``status``.
 """
 
 from __future__ import annotations
 
-import time
 from typing import TYPE_CHECKING
 
+from ...compaction.coordinator import CompactionRequest
 from .._globals import console
 
 if TYPE_CHECKING:
     from ..app import AgentaoCLI
 
 # Below this many messages there is nothing worth summarizing — matches the
-# guard inside ``ContextManager.compress_messages``.
+# ``history_too_short`` guard inside ``ContextManager.prepare_compaction``.
+# Checked here as well so the user gets a sentence rather than a silent
+# no-op; the guard downstream is what actually enforces it.
 _MIN_MESSAGES_TO_COMPACT = 5
 
-
-def _produced_fresh_compaction(before: list, after: list) -> bool:
-    """True if ``compress_messages`` actually built a new compact block.
-
-    A successful compaction returns ``[boundary_marker, summary, …]`` — a
-    brand-new first message. Every failure path (circuit breaker open, no
-    safe split, summarization error) instead returns the original list or
-    a microcompacted copy that leaves the first message untouched. Probing
-    for *any* ``[Conversation Summary]`` would misfire when an older summary
-    from a previous compaction is still in history, so key off the freshly
-    prepended ``[Compact Boundary]`` marker instead.
-    """
-    if not after or after[0] is (before[0] if before else None):
-        return False
-    head = after[0].get("content")
-    return isinstance(head, str) and head.startswith("[Compact Boundary")
-
-
-def _dispatch_pre_compact(agent) -> None:
-    """Best-effort ``PreCompact`` plugin-hook dispatch (side-effect only).
-
-    Mirrors ``ChatLoopRunner._dispatch_pre_compact`` — dispatch matching
-    rules *and* emit the ``PLUGIN_HOOK_FIRED`` replay event so manual
-    ``/compact`` runs keep the same observability contract as the
-    threshold-driven path.
-    """
-    rules = getattr(agent, "_plugin_hook_rules", None)
-    if not rules:
-        return
-    try:
-        from ...plugins.hooks import ClaudeHookPayloadAdapter, PluginHookDispatcher
-        from ...transport import AgentEvent, EventType
-
-        cwd = agent.working_directory
-        payload = ClaudeHookPayloadAdapter().build_pre_compact(
-            session_id=agent._session_id,
-            cwd=cwd,
-            trigger="manual",
-            compaction_type="full",
-            reason="manual_cli",
-            permission_mode=agent.active_permissions().mode,
-        )
-        dispatcher = PluginHookDispatcher(cwd=cwd)
-        matched = dispatcher.select_matching_rules("PreCompact", payload, rules)
-        if not matched:
-            return
-        dispatcher.dispatch_pre_compact(payload=payload, rules=matched)
-        agent.transport.emit(AgentEvent(EventType.PLUGIN_HOOK_FIRED, {
-            "hook_name": "PreCompact",
-            "outcome": "allow",
-            "compaction_type": "full",
-            "trigger": "manual",
-            "matched_rule_count": len(matched),
-        }))
-    except Exception:
-        pass
+# Why nothing happened, in the user's terms. ``detail`` values come from
+# ``CompactionOutcome``; anything unlisted falls back to the log pointer.
+_FAILURE_HINTS = {
+    "circuit_open": (
+        "auto-compaction is disabled after repeated failures "
+        "(circuit breaker open)"
+    ),
+    "history_too_short": "there is not enough history to summarize yet",
+    "no_safe_split": (
+        "no safe split point — every candidate boundary would orphan a tool "
+        "result"
+    ),
+    "summary_empty": "the summarization call returned nothing",
+}
 
 
 def handle_compact_command(cli: AgentaoCLI, args: str) -> None:
     """Handle ``/compact`` — summarize old history into a compact block."""
     agent = cli.agent
     cm = agent.context_manager
-    messages = agent.messages
 
-    if len(messages) < _MIN_MESSAGES_TO_COMPACT:
+    if len(agent.messages) < _MIN_MESSAGES_TO_COMPACT:
         console.print(
             "\n[info]Not enough conversation history to compact yet.[/info]\n"
         )
         return
 
-    _dispatch_pre_compact(agent)
-
-    pre_msgs = len(messages)
     system_prompt = agent._build_system_prompt()
-    pre_tokens = cm.estimate_tokens(
-        [{"role": "system", "content": system_prompt}] + messages
+    pre_msgs = len(agent.messages)
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("manual", "full", "manual_cli"),
+        system_prompt=system_prompt,
+        measure_system_tokens=True,
     )
+    outcome = run.outcome
 
-    t0 = time.monotonic()
-    compacted = cm.compress_messages(messages, is_auto=False)
-
-    if not _produced_fresh_compaction(messages, compacted):
+    if outcome.status != "success":
+        hint = _FAILURE_HINTS.get(outcome.detail or "")
+        detail = f" — {hint}" if hint else " (see agentao.log)"
         console.print(
-            "\n[warning]Compaction made no change — nothing to summarize "
-            "(or summarization failed; see agentao.log).[/warning]\n"
+            f"\n[warning]Compaction made no change{detail}.[/warning]\n"
         )
         return
 
-    agent.messages = compacted
-    cm.invalidate_token_anchor()  # prefix rewritten; anchor is stale
-    system_prompt = agent._build_system_prompt()
     post_msgs = len(agent.messages)
-    post_tokens = cm.estimate_tokens(
-        [{"role": "system", "content": system_prompt}] + agent.messages
-    )
-
-    agent._emit_context_compressed(
-        compression_type="full",
-        reason="manual_cli",
-        pre_msgs=pre_msgs,
-        post_msgs=post_msgs,
-        pre_tokens=pre_tokens,
-        post_tokens=post_tokens,
-        duration_ms=round((time.monotonic() - t0) * 1000),
-    )
-    # ``_last_session_summary_id`` is created lazily on the first chat turn
-    # (runtime/turn.py); a manual /compact may run before that — e.g. right
-    # after /sessions resume — so fall back to None.
-    agent._last_session_summary_id = agent._emit_session_summary_if_new(
-        getattr(agent, "_last_session_summary_id", None),
-    )
+    # Measured by the coordinator, in the system-inclusive unit this report
+    # has always used. Asked for rather than re-measured: two estimates over
+    # the full history is what a manual compaction costs today, and routing
+    # through the coordinator must not quietly double that.
+    pre_tokens = run.pre_est_tokens or 0
+    post_tokens = run.post_est_tokens or 0
 
     pct = cm.get_usage_stats(agent.messages).get("usage_percent", 0.0)
     cli._cached_ctx_pct = pct

--- a/agentao/cli/replay_render/_summary.py
+++ b/agentao/cli/replay_render/_summary.py
@@ -158,6 +158,25 @@ def _summarize_replay_event(event: dict) -> str:
             f"tok={payload.get('pre_est_tokens')}→{payload.get('post_est_tokens')}"
             f"[/dim]"
         )
+    if kind == "compaction_settled":
+        # Both non-success statuses and the token unit are the point here:
+        # ``context_compressed`` above reports the system-**inclusive**
+        # estimate, these two exclude the system prompt.
+        status = str(payload.get("status", "?"))
+        detail = payload.get("detail")
+        line = (
+            f"{markup_escape(str(payload.get('kind', '?')))} "
+            f"{markup_escape(status)} "
+            f"({markup_escape(str(payload.get('trigger', '?')))}/"
+            f"{markup_escape(str(payload.get('reason', '?')))}) "
+            f"msgs={payload.get('pre_msgs')}→{payload.get('post_msgs')} "
+            f"hist_tok={payload.get('pre_tokens_history')}→"
+            f"{payload.get('post_tokens_history')}"
+        )
+        if detail:
+            line += f" {markup_escape(str(detail)[:80])}"
+        colour = "dim" if status == "success" else "warning"
+        return f"[{colour}]{line}[/{colour}]"
     if kind == "session_summary_written":
         return (
             f"[dim]id={markup_escape(str(payload.get('summary_id', ''))[:8])} "

--- a/agentao/cli/replay_render/_turn.py
+++ b/agentao/cli/replay_render/_turn.py
@@ -221,6 +221,17 @@ def _print_turn(turn: dict, console_) -> None:
                 f"[dim]{markup_escape(str(p.get('type', '')))}  "
                 f"msgs {p.get('pre_msgs')}→{p.get('post_msgs')}[/dim]"
             )
+        elif kind == "compaction_settled":
+            p = e.get("payload") or {}
+            status = str(p.get("status", ""))
+            console_.print(
+                f"  [dim]compact[/dim]  "
+                f"[dim]{markup_escape(str(p.get('kind', '')))} "
+                f"{markup_escape(status)} "
+                f"({markup_escape(str(p.get('reason', '')))})"
+                + (f" {markup_escape(str(p.get('detail'))[:80])}" if p.get("detail") else "")
+                + "[/dim]"
+            )
         elif kind == "session_summary_written":
             p = e.get("payload") or {}
             console_.print(

--- a/agentao/compaction/__init__.py
+++ b/agentao/compaction/__init__.py
@@ -10,10 +10,22 @@ in the runtime or the LLM stack").
 
 from __future__ import annotations
 
-from .types import CompactionKind, CompactionReason, CompactionTrigger
+from .types import (
+    CompactionController,
+    CompactionDecision,
+    CompactionDecisionContext,
+    CompactionKind,
+    CompactionOutcome,
+    CompactionReason,
+    CompactionTrigger,
+)
 
 __all__ = [
+    "CompactionController",
+    "CompactionDecision",
+    "CompactionDecisionContext",
     "CompactionKind",
+    "CompactionOutcome",
     "CompactionReason",
     "CompactionTrigger",
 ]

--- a/agentao/compaction/coordinator.py
+++ b/agentao/compaction/coordinator.py
@@ -1,0 +1,433 @@
+"""``CompactionCoordinator`` — the one place a compaction is decided.
+
+Compaction used to be orchestrated in four unrelated places: two threshold
+tiers in the chat loop, a two-rung API-overflow ladder in the runner, and the
+manual ``/compact`` command in the CLI. They disagreed about what a trigger is
+called, about whether a failure counts, and — worst — about whether
+"compacted" means history actually changed: the overflow path announced a
+successful compaction even when the circuit breaker had made it a no-op,
+emitting ``CONTEXT_COMPRESSED`` with ``pre_msgs == post_msgs``.
+
+This class is the seam that makes them agree. It owns *whether to run, whose
+summary to take, how to recover, and what to emit*. It does **not** own how
+history is rewritten — every content transform stays behind a
+``ContextManager`` method, and the dependency points one way only:
+``ContextManager`` neither imports nor holds a coordinator.
+
+The division in one line: policy and observability here, content transforms
+there, and one :class:`CompactionOutcome` out of every entry point.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from .types import (
+    CompactionKind,
+    CompactionOutcome,
+    CompactionReason,
+    CompactionTrigger,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..agent import Agentao
+
+
+@dataclass(frozen=True)
+class CompactionRequest:
+    """Which compaction is being asked for.
+
+    All three kinds share this one request type; the difference lives
+    entirely in what the transform produces, so the coordinator has a single
+    skeleton rather than three.
+    """
+
+    trigger: CompactionTrigger
+    kind: CompactionKind
+    reason: CompactionReason
+
+
+@dataclass(frozen=True)
+class CompactionRun:
+    """The outcome plus the post-state the caller has to splice back.
+
+    The chat loop threads ``(messages_with_system, system_prompt)`` through
+    every iteration, and a full compaction rewrites the history the prompt is
+    built against — so both come back from here rather than being recomputed
+    by each caller, which is how the five entry points drifted apart in the
+    first place.
+    """
+
+    outcome: CompactionOutcome
+    system_prompt: str
+    messages_with_system: List[Dict[str, Any]]
+    # The system-**inclusive** pair, populated only when the caller asked
+    # for it via ``measure_system_tokens``. Handed back so a caller that
+    # wants to report the numbers does not measure the same history a third
+    # and fourth time — this is the unit ``CONTEXT_COMPRESSED`` uses, not
+    # the history-only one on the outcome.
+    pre_est_tokens: Optional[int] = None
+    post_est_tokens: Optional[int] = None
+
+
+class CompactionCoordinator:
+    """Policy, host dispatch, and observability for every compaction."""
+
+    def __init__(self, agent: "Agentao") -> None:
+        self._agent = agent
+
+    # ------------------------------------------------------------------
+    # The one entry point
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        request: CompactionRequest,
+        *,
+        system_prompt: str,
+        messages_with_system: Optional[List[Dict[str, Any]]] = None,
+        measure_system_tokens: bool = False,
+        keep_tail: int = 2,
+    ) -> CompactionRun:
+        """Gate, dispatch, transform, emit — in that order.
+
+        ``measure_system_tokens`` decides whether the legacy
+        ``CONTEXT_COMPRESSED`` event carries its system-**inclusive** token
+        pair. It is false on both API-overflow rungs, matching today: those
+        two never passed tokens, and filling them in would mean two new
+        full-history estimates on precisely the path where the context has
+        already blown up and the request has just been rejected.
+
+        ``messages_with_system`` is the caller's already-assembled list. It
+        is handed straight back whenever history did not change, so a gate
+        that fires on every loop iteration does not rebuild it every time.
+
+        ``keep_tail`` applies to ``minimal_history`` only.
+        """
+        agent = self._agent
+        cm = agent.context_manager
+
+        gate = self._gate(request)
+        if gate is not None:
+            # ``skipped`` is silent by construction: three of the four
+            # skipped cases re-trigger on *every* loop iteration, so emitting
+            # an event each time is a fresh event storm — the exact thing the
+            # stand-down comments this class absorbed were written to stop.
+            return CompactionRun(
+                outcome=gate,
+                system_prompt=system_prompt,
+                messages_with_system=(
+                    messages_with_system
+                    if messages_with_system is not None
+                    else self._with_system(system_prompt)
+                ),
+            )
+
+        # Logged after the gate, not before it: the whole point of the gate
+        # is that these attempts do not happen, and the threshold is
+        # re-checked every iteration, so announcing first would print a line
+        # per iteration for a compaction that never runs.
+        self._info(
+            f"Compaction triggered: kind={request.kind} reason={request.reason}"
+        )
+        self.dispatch_pre_compact(request)
+
+        t0 = time.monotonic()
+        pre_msgs = len(agent.messages)
+        if messages_with_system is None:
+            messages_with_system = self._with_system(system_prompt)
+        pre_est_tokens = (
+            cm.estimate_tokens(messages_with_system) if measure_system_tokens else None
+        )
+
+        outcome = self._transform(request, keep_tail=keep_tail)
+
+        if request.kind == "full" and request.trigger == "auto":
+            # The summarization LLM call goes straight to ``llm_client`` and
+            # never passes the runner's finish-reason detector, so fold its
+            # observation in here. This is the call whose output permanently
+            # rewrites history, so a turn that compacted against an
+            # unconfirmed summary has to say so. Manual ``/compact`` is
+            # exempt because it runs outside a turn — there is no turn flag
+            # to set, and setting one would leak into the next turn.
+            if cm.last_summary_finish_reason_missing:
+                agent._turn_finish_reason_missing = True
+
+        if outcome.status == "success":
+            agent.messages = outcome.messages
+            if request.kind != "microcompact" or cm.last_microcompact_mutated:
+                # Only a microcompact pass that actually shortened something
+                # invalidates the already-sent prefix. Dropping the anchor on
+                # a no-op pass forces a full re-encode of the entire history
+                # on every iteration spent in the microcompact band —
+                # precisely when it is most expensive.
+                cm.invalidate_token_anchor()
+            if request.kind == "full":
+                system_prompt = agent._build_system_prompt()
+
+        if outcome.status == "success":
+            messages_with_system = self._with_system(system_prompt)
+        post_est_tokens = (
+            cm.estimate_tokens(messages_with_system)
+            if measure_system_tokens and outcome.status == "success"
+            else None
+        )
+
+        self._emit(
+            request,
+            outcome,
+            pre_msgs=pre_msgs,
+            post_msgs=len(agent.messages),
+            pre_est_tokens=pre_est_tokens,
+            post_est_tokens=post_est_tokens,
+            duration_ms=round((time.monotonic() - t0) * 1000),
+        )
+
+        if request.kind == "full" and outcome.status == "success":
+            # ``_last_session_summary_id`` is created lazily at the start of a
+            # turn (``runtime/turn.py``); a manual ``/compact`` may run before
+            # that — e.g. right after ``/sessions resume`` — so fall back.
+            agent._last_session_summary_id = agent._emit_session_summary_if_new(
+                getattr(agent, "_last_session_summary_id", None),
+            )
+
+        self._info(
+            f"Compaction {outcome.status}: kind={request.kind} "
+            f"reason={request.reason} messages {pre_msgs} -> {len(agent.messages)}"
+            + (f" ({outcome.detail})" if outcome.detail else "")
+        )
+
+        return CompactionRun(
+            outcome=outcome,
+            system_prompt=system_prompt,
+            messages_with_system=messages_with_system,
+            pre_est_tokens=pre_est_tokens,
+            post_est_tokens=post_est_tokens,
+        )
+
+    # ------------------------------------------------------------------
+    # Policy
+    # ------------------------------------------------------------------
+
+    def _gate(self, request: CompactionRequest) -> Optional[CompactionOutcome]:
+        """Return a ``skipped`` outcome when this attempt must not run.
+
+        Nothing here counts against the circuit breaker: ``skipped`` means
+        nothing was attempted, which is exactly what the two short-circuits
+        it absorbed already did.
+        """
+        agent = self._agent
+        cm = agent.context_manager
+
+        if request.kind == "full" and cm.compaction_circuit_open:
+            # Announcing this would fork a PreCompact hook subprocess per
+            # iteration for something that never happens, and emit a
+            # CONTEXT_COMPRESSED reporting pre == post. Stand down and let
+            # the API-overflow recovery path own it from here.
+            #
+            # Still log it: standing down before the transform skips the
+            # breaker warning it used to emit, and that line is the only
+            # signal that auto-compaction is dead for the rest of the session
+            # (the counter has no reset path).
+            self._warn(
+                "Compact circuit breaker open "
+                f"({cm.circuit_breaker_failures} consecutive failures) — "
+                "skipping compaction; context stays over threshold until the "
+                "API-overflow path recovers it"
+            )
+            return self._skipped(request, "circuit_open")
+
+        if request.kind == "microcompact" and not cm.microcompact_would_mutate(
+            agent.messages
+        ):
+            # Being *in* the band says nothing about there being anything
+            # left to shorten: once every old tool result is at or under the
+            # limit, every further iteration in the band is a no-op.
+            return self._skipped(request, "no_microcompact_targets")
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Transforms — all of them behind a ContextManager method
+    # ------------------------------------------------------------------
+
+    def _transform(
+        self, request: CompactionRequest, *, keep_tail: int,
+    ) -> CompactionOutcome:
+        agent = self._agent
+        cm = agent.context_manager
+
+        if request.kind == "full":
+            # Private on purpose, and shared with the legacy
+            # ``compress_messages`` wrapper: it is the only layer that can
+            # produce an authoritative ``status`` for this kind, and it owns
+            # the failure counter, which the coordinator must never touch.
+            return cm._run_compaction(
+                agent.messages,
+                is_auto=(request.trigger == "auto"),
+                reason=request.reason,
+                decide=None,
+            )
+
+        if request.kind == "microcompact":
+            return CompactionOutcome(
+                status="success",
+                trigger=request.trigger,
+                kind=request.kind,
+                reason=request.reason,
+                messages=cm.microcompact_messages(agent.messages),
+                # Both null deliberately. Microcompaction runs on every
+                # iteration inside its band; two extra full-history estimates
+                # there is the cost this design refuses to add. Read the old
+                # event for microcompaction tokens — in its own unit.
+                pre_tokens=None,
+                post_tokens=None,
+            )
+
+        return CompactionOutcome(
+            status="success",
+            trigger=request.trigger,
+            kind=request.kind,
+            reason=request.reason,
+            messages=cm.apply_minimal_history(agent.messages, keep_tail=keep_tail),
+            # This path makes no token estimate at all, and it is reached
+            # only after the API has rejected the request twice.
+            pre_tokens=None,
+            post_tokens=None,
+        )
+
+    # ------------------------------------------------------------------
+    # Host dispatch
+    # ------------------------------------------------------------------
+
+    def dispatch_pre_compact(self, request: CompactionRequest) -> None:
+        """Fire matching ``PreCompact`` command hooks (side-effect only).
+
+        One implementation for all five entry points. There used to be two —
+        the chat loop's and the CLI's — which is how manual ``/compact`` came
+        to emit a replay event saying ``manual`` beside a hook payload saying
+        ``auto`` for the same compaction.
+        """
+        agent = self._agent
+        rules = getattr(agent, "_plugin_hook_rules", None)
+        if not rules:
+            return
+        try:
+            from ..plugins.hooks import ClaudeHookPayloadAdapter, PluginHookDispatcher
+            from ..transport import AgentEvent, EventType
+
+            cwd = agent.working_directory
+            payload = ClaudeHookPayloadAdapter().build_pre_compact(
+                session_id=agent._session_id,
+                cwd=cwd,
+                trigger=request.trigger,
+                compaction_type=request.kind,
+                reason=request.reason,
+                permission_mode=agent.active_permissions().mode,
+            )
+            dispatcher = PluginHookDispatcher(cwd=cwd)
+            matched = dispatcher.select_matching_rules("PreCompact", payload, rules)
+            if not matched:
+                return
+            dispatcher.dispatch_pre_compact(payload=payload, rules=matched)
+            agent.transport.emit(AgentEvent(EventType.PLUGIN_HOOK_FIRED, {
+                "hook_name": "PreCompact",
+                "outcome": "allow",
+                "compaction_type": request.kind,
+                "trigger": request.trigger,
+                "matched_rule_count": len(matched),
+            }))
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Observability
+    # ------------------------------------------------------------------
+
+    def _emit(
+        self,
+        request: CompactionRequest,
+        outcome: CompactionOutcome,
+        *,
+        pre_msgs: int,
+        post_msgs: int,
+        pre_est_tokens: Optional[int],
+        post_est_tokens: Optional[int],
+        duration_ms: int,
+    ) -> None:
+        """Both events, from the one place that knows the outcome.
+
+        ``COMPACTION_SETTLED`` fires for ``success | cancelled | failed``;
+        ``skipped`` never reaches here. ``CONTEXT_COMPRESSED`` fires only on
+        success — that is the change from today, where the overflow path
+        emitted it unconditionally and therefore reported compactions that
+        returned history unchanged.
+        """
+        agent = self._agent
+        from ..transport import AgentEvent, EventType
+
+        try:
+            agent.transport.emit(AgentEvent(EventType.COMPACTION_SETTLED, {
+                "trigger": outcome.trigger,
+                "kind": outcome.kind,
+                "reason": outcome.reason,
+                "status": outcome.status,
+                "pre_msgs": pre_msgs,
+                "post_msgs": post_msgs,
+                # Named apart from the old event's pair on purpose: these two
+                # **exclude** the system prompt and the old ones include it.
+                # Two units, two names, so they cannot be wired to each other
+                # by accident.
+                "pre_tokens_history": outcome.pre_tokens,
+                "post_tokens_history": outcome.post_tokens,
+                "duration_ms": duration_ms,
+                "detail": outcome.detail,
+            }))
+        except Exception:
+            pass
+
+        if outcome.status != "success":
+            return
+
+        agent._emit_context_compressed(
+            compression_type=request.kind,
+            reason=request.reason,
+            pre_msgs=pre_msgs,
+            post_msgs=post_msgs,
+            pre_tokens=pre_est_tokens,
+            post_tokens=post_est_tokens,
+            duration_ms=duration_ms,
+        )
+
+    # ------------------------------------------------------------------
+    # Small helpers
+    # ------------------------------------------------------------------
+
+    def _with_system(self, system_prompt: str) -> List[Dict[str, Any]]:
+        return [{"role": "system", "content": system_prompt}] + self._agent.messages
+
+    def _skipped(
+        self, request: CompactionRequest, detail: str,
+    ) -> CompactionOutcome:
+        return CompactionOutcome(
+            status="skipped",
+            trigger=request.trigger,
+            kind=request.kind,
+            reason=request.reason,
+            messages=self._agent.messages,
+            detail=detail,
+        )
+
+    def _warn(self, message: str) -> None:
+        try:
+            self._agent.llm.logger.warning(message)
+        except Exception:
+            pass
+
+    def _info(self, message: str) -> None:
+        try:
+            self._agent.llm.logger.info(message)
+        except Exception:
+            pass

--- a/agentao/compaction/types.py
+++ b/agentao/compaction/types.py
@@ -16,7 +16,8 @@ finer provenance lives in ``kind`` and ``reason`` instead of subdividing
 
 from __future__ import annotations
 
-from typing import Literal
+from dataclasses import dataclass
+from typing import Literal, Protocol
 
 #: Where the compaction came from, as the PreCompact matcher sees it.
 #: Claude Code parity — do not subdivide ``auto``.
@@ -36,7 +37,116 @@ CompactionReason = Literal[
 ]
 
 __all__ = [
+    "CompactionController",
+    "CompactionDecision",
+    "CompactionDecisionContext",
     "CompactionKind",
+    "CompactionOutcome",
     "CompactionReason",
     "CompactionTrigger",
 ]
+
+
+@dataclass(frozen=True)
+class CompactionOutcome:
+    """What one compaction attempt did — the single result contract.
+
+    Every entry point returns this, whatever its ``kind``. The three
+    kinds share the **contract**, not a builder: ``kind == "full"`` is
+    built by ``ContextManager._run_compaction`` (the only holder of all
+    eight fields), while the gate short-circuits, ``microcompact`` and
+    ``minimal_history`` are built by the coordinator. Events, by
+    contrast, are *always* emitted by the coordinator, so the
+    emit-or-stay-silent criterion lives in exactly one place.
+
+    ``status`` in one line: ``skipped`` = nothing was attempted;
+    ``failed`` = attempted and did not succeed; ``cancelled`` = vetoed.
+    ``skipped`` never counts against the circuit breaker.
+
+    ``messages`` is the **original list object** on every non-success
+    status, and a new list on success. Do not infer success from that,
+    or from message counts — a successful microcompaction leaves the
+    count identical, and a successful full compaction at
+    ``len(messages) == 5`` raises it.
+
+    Both token fields **exclude the system prompt**, unlike the
+    ``CONTEXT_COMPRESSED`` event's pair. They are ``| None`` because two
+    paths genuinely have no number to report: ``minimal_history``
+    estimates nothing at all, and a ``no_safe_split`` failure returns
+    before the estimate runs.
+    """
+
+    status: Literal["success", "cancelled", "failed", "skipped"]
+    trigger: CompactionTrigger
+    kind: CompactionKind
+    reason: CompactionReason
+    messages: list[dict]
+    pre_tokens: int | None = None
+    post_tokens: int | None = None
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
+class CompactionDecisionContext:
+    """What a host controller is told before a compaction runs.
+
+    Public, redacted, **in-process only**: this object never goes on the
+    wire and is never serialized. Command hooks do not get it — they get
+    the flat Claude-compatible ``PreCompact`` payload, because that is
+    what the matcher matches on.
+
+    It carries counts, never message text. Not because a list reference
+    would be expensive (it would not — a dataclass field shares the
+    reference), but because this is a redaction boundary, and because
+    handing over the text is an invitation to mutate it. A host that
+    genuinely needs the text reads ``agent.messages``.
+
+    Several fields are ``None`` outside ``kind == "full"``; see the
+    per-kind table in the orchestration plan §4.4.3.
+    """
+
+    trigger: CompactionTrigger
+    kind: CompactionKind
+    reason: CompactionReason
+    pre_tokens: int | None = None
+    messages_to_summarize: int = 0
+    messages_to_keep: int = 0
+    recently_read_files: tuple[str, ...] = ()
+    summary_input_budget: int | None = None
+    max_summary_tokens: int | None = None
+    can_provide_summary: bool = False
+    tool_results_to_clip: int | None = None
+
+
+@dataclass(frozen=True)
+class CompactionDecision:
+    """One control-plane verdict.
+
+    ``provide_summary`` is legal only when
+    ``CompactionDecisionContext.can_provide_summary`` is true, i.e. only
+    for ``kind == "full"``. Anywhere else it is an invalid decision and
+    is treated as ``allow`` with a warning — a misconfigured control
+    plane must never be able to drive the context into the overflow
+    ladder.
+    """
+
+    action: Literal["allow", "cancel", "provide_summary"]
+    summary: str | None = None
+    reason: str | None = None
+
+
+class CompactionController(Protocol):
+    """The ``compaction_controller=`` contract.
+
+    **Synchronous.** The compaction path runs inside ``ContextManager``,
+    which holds no event loop; an awaitable return is handled as an
+    unknown return value, with a warning.
+
+    A controller that raises is caught, warned about, and treated as
+    ``allow``. That fail-open rule is not politeness: two of the five
+    entry points *are* the API-overflow recovery ladder, so an exception
+    escaping a controller would turn "context too long" into "the turn
+    crashes" — killing the recovery path this design exists to protect.
+    """
+
+    def __call__(self, ctx: CompactionDecisionContext) -> CompactionDecision: ...

--- a/agentao/context_manager.py
+++ b/agentao/context_manager.py
@@ -2,8 +2,14 @@
 
 import json
 import re
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
+
+from .compaction.types import (
+    CompactionDecisionContext,
+    CompactionOutcome,
+)
 
 try:
     import tiktoken as _tiktoken
@@ -60,6 +66,70 @@ def _heuristic_token_count(text: str) -> int:
     ascii_count = len(text.encode("ascii", "ignore"))
     non_ascii = n - ascii_count
     return (ascii_count * 25 + non_ascii * 130) // 100
+
+
+# ---------------------------------------------------------------------------
+# The prepare -> commit snapshot types.
+#
+# Deliberately **not** in ``agentao/compaction/types.py``: that module is the
+# public contract, and these two are the private hand-off between two halves
+# of one method. The coordinator never sees either — it reaches this layer
+# only through ``_run_compaction`` and the narrow ``apply_*`` methods.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PrepareRejected:
+    """Prepare decided there is nothing to hand to a summarizer.
+
+    Two cases, and they are **not** the same severity: too little history is
+    ``skipped`` and costs nothing, while no safe split point is a structural
+    ``failed`` that has to be counted on the auto path or the caller re-enters
+    every iteration.
+    """
+
+    status: str          # "skipped" | "failed"
+    detail: str          # "history_too_short" | "no_safe_split"
+    counts_as_failure: bool
+
+
+@dataclass(frozen=True)
+class PreparedCompaction:
+    """Everything ``commit_compaction`` needs, computed before summarizing.
+
+    Every field here has a reader in commit — the crystallize input, the two
+    counts in the boundary marker and ``_last_compact_stats``, the pinned
+    block and surviving half that are spliced into the result, and
+    ``pre_tokens`` for the boundary marker and the session-summary row.
+    """
+
+    trigger: str
+    kind: str
+    reason: str
+    is_auto: bool
+    split_index: int
+    to_summarize: List[Dict[str, Any]]
+    to_keep: List[Dict[str, Any]]
+    pinned: List[Dict[str, Any]]
+    recently_read: List[str]
+    summary_messages: List[Dict[str, Any]]
+    summary_input: str
+    pre_tokens: int
+
+
+PrepareResult = Union[PreparedCompaction, PrepareRejected]
+
+
+def _compose_detail(internal: Optional[str], decision: Optional[str]) -> Optional[str]:
+    """Join the internal failure class with the control plane's own reason.
+
+    Composed here, inside the layer that holds the decision object, so that
+    ``CompactionOutcome.detail`` is final the moment it is built — the layer
+    above copies it straight across rather than appending to it.
+    """
+    if internal and decision:
+        return f"{internal}; {decision}"
+    return internal or decision or None
 
 
 class ContextManager:
@@ -420,6 +490,16 @@ class ContextManager:
     # -----------------------------------------------------------------------
 
     @property
+    def circuit_breaker_failures(self) -> int:
+        """Consecutive compaction failures — the breaker's read-only state.
+
+        Already exported through ``get_usage_stats()`` and rendered by
+        ``/context``; this is the same number without the dictionary, for
+        callers that only want to log it.
+        """
+        return self._consecutive_compact_failures
+
+    @property
     def compaction_circuit_open(self) -> bool:
         """True once :meth:`compress_messages` has given up on auto-compaction.
 
@@ -474,6 +554,26 @@ class ContextManager:
             return None
         return chosen
 
+    # -----------------------------------------------------------------------
+    # Compaction — the ``kind == "full"`` transform
+    #
+    # ``compress_messages`` used to do all of this in one call: the breaker
+    # short-circuit, the cut point, microcompaction of the surviving half, the
+    # crystallize write, summarization, failure counting, the session-summary
+    # write and message assembly. It comes apart because the host control
+    # plane has to replace exactly one step — summarization — and because a
+    # cancelled compaction must leave **no** irreversible side effect behind,
+    # which the old order could not promise: crystallize ran before the
+    # summarizer.
+    #
+    # The seam is prepare / commit, with the decision step between them.
+    # Ownership: ``prepare`` and ``commit`` make no policy judgement at all
+    # (no breaker query, no hook dispatch); the coordinator above owns policy
+    # and events; ``_run_compaction`` strings the four stages together and
+    # owns the failure counter, because it is the only layer both callers
+    # share — the legacy wrapper below has no coordinator in hand.
+    # -----------------------------------------------------------------------
+
     def compress_messages(
         self,
         messages: List[Dict[str, Any]],
@@ -496,6 +596,14 @@ class ContextManager:
         Circuit breaker: after CIRCUIT_BREAKER_LIMIT consecutive failures this
         method returns messages unchanged and logs a warning.
 
+        This is the **legacy surface**, kept because it is documented, pinned
+        by tests that call it directly, and reachable from outside the tree.
+        It is now a thin composition over :meth:`_run_compaction` and returns
+        only the message list, so it cannot say *why* nothing changed. New
+        code goes through ``CompactionCoordinator``, which additionally gets
+        the host control plane and the breaker's probe policy — a direct call
+        here bypasses both.
+
         Args:
             messages: Current conversation messages (without system prompt)
             is_auto: True for threshold-triggered compression, False for manual
@@ -503,7 +611,10 @@ class ContextManager:
         Returns:
             Compressed messages list
         """
-        # --- Circuit breaker ------------------------------------------------
+        # The gate stays in front of this method specifically: it is in the
+        # docstring above and pinned by a test that calls this method
+        # directly. The coordinator applies the same gate itself, one layer
+        # up, where it can also decide that this attempt is a probe.
         if self.compaction_circuit_open:
             try:
                 self.llm_client.logger.warning(
@@ -514,8 +625,39 @@ class ContextManager:
                 pass
             return messages
 
+        # This method has no ``reason`` parameter — its signature is pinned —
+        # so derive one. The mapping is one-to-one with the two values a
+        # direct caller could mean, and it serves out-of-tree callers only:
+        # every in-tree entry point passes its real reason through the
+        # coordinator, including API overflow, whose true reason is
+        # ``api_overflow`` and which used to ride this default.
+        reason = "compression_threshold" if is_auto else "manual_cli"
+        return self._run_compaction(
+            messages, is_auto=is_auto, reason=reason, decide=None,
+        ).messages
+
+    def prepare_compaction(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        trigger: str,
+        kind: str,
+        reason: str,
+    ) -> "PrepareResult":
+        """Everything up to — but not including — the summarization call.
+
+        Pure computation plus one flag and one log line. Deliberately **no**
+        SQLite write and no touch of ``agent.messages``: those are exactly the
+        side effects a cancelled compaction must not have already caused, so
+        they belong to :meth:`commit_compaction`.
+
+        Makes no breaker judgement. That is policy, and policy lives above.
+
+        Returns either a :class:`PreparedCompaction` snapshot or a
+        :class:`PrepareRejected` saying which of the two early exits fired.
+        """
         if len(messages) < 5:
-            return messages
+            return PrepareRejected("skipped", "history_too_short", False)
 
         # --- Step 2: partial compaction split -------------------------------
         # Keep at most KEEP_RECENT_MESSAGES, but no more than 60% of total
@@ -526,32 +668,14 @@ class ContextManager:
         split_index = self._find_split_index(messages, len(messages) - keep_count)
 
         if split_index is None:
-            # Structural failure, not a summarization failure — but on the auto
-            # path it has to count as one, or the caller re-enters every
+            # Structural failure, not a summarization failure — but the caller
+            # still has to count it on the auto path, or it re-enters every
             # iteration (firing PreCompact hook subprocesses each time) while
             # the context keeps growing, until the API rejects it and the
-            # overflow ladder cuts history to the last two messages.
-            #
-            # Manual ``/compact`` is deliberately exempt: it is user-driven and
-            # does not loop, so there is no runaway to arrest — and the breaker
-            # it would trip disables *automatic* compaction for the rest of the
-            # session with no reset path.
-            if is_auto:
-                self._consecutive_compact_failures += 1
-                tally = f" ({self._consecutive_compact_failures} consecutive failures)"
-            else:
-                # The manual path does not increment, so reporting the counter
-                # here would attribute the auto path's tally — usually 0 — to
-                # this failure.
-                tally = ""
-            try:
-                self.llm_client.logger.warning(
-                    "Compaction found no safe split point — history has no non-tool "
-                    f"boundary in the summarizable range; skipping{tally}"
-                )
-            except Exception:
-                pass
-            return messages
+            # overflow ladder cuts history to the last two messages. The
+            # counting itself is ``_run_compaction``'s, which is why this
+            # carries a flag rather than incrementing here.
+            return PrepareRejected("failed", "no_safe_split", True)
 
         # ``_find_split_index`` never returns 0, so ``to_summarize`` is
         # non-empty by construction — no second emptiness check needed here.
@@ -573,24 +697,56 @@ class ContextManager:
         # --- Step 4: extract recently read files ----------------------------
         recently_read = self._extract_recently_read_files(to_summarize)
 
+        # --- Step 4b: assemble the summarizer's input -----------------------
+        # ``[PIN]`` messages are dropped here rather than inside the
+        # summarizer: they are spliced verbatim into the result below, so
+        # summarizing them too would put the same text in twice — and a host
+        # inspecting ``summary_input`` should see exactly what the model will.
+        summary_messages = [m for m in to_summarize if m not in pinned]
+        summary_input = self._format_for_summary(summary_messages)
+
+        return PreparedCompaction(
+            trigger=trigger,
+            kind=kind,
+            reason=reason,
+            is_auto=(trigger == "auto"),
+            split_index=split_index,
+            to_summarize=to_summarize,
+            to_keep=to_keep,
+            pinned=pinned,
+            recently_read=recently_read,
+            summary_messages=summary_messages,
+            summary_input=summary_input,
+            # Excludes the system prompt — the same unit ``post_tokens``
+            # below is measured in, and *not* the unit the CONTEXT_COMPRESSED
+            # event's token pair uses.
+            pre_tokens=self.estimate_tokens(messages),
+        )
+
+    def commit_compaction(
+        self,
+        prep: "PreparedCompaction",
+        summary: str,
+    ) -> List[Dict[str, Any]]:
+        """The irreversible half: two SQLite writes and the new message list.
+
+        Everything here is reached only once a summary exists, so a
+        cancelled or failed compaction leaves the store untouched. That is a
+        deliberate change from the old ordering, where ``crystallize`` ran
+        *before* summarization and therefore wrote even when summarization
+        then returned nothing.
+        """
+        pre_tokens = prep.pre_tokens
+
         # --- Step 4b: crystallize from raw user messages --------------------
-        # Run *before* summarization so the rule-based extractor sees
-        # authentic user text, never the LLM's narration of it. Best-effort —
-        # must never break the compaction pipeline.
+        # Runs on the authentic user text, never the LLM's narration of it —
+        # ``to_summarize`` is the pre-summary window. Best-effort: it must
+        # never break the compaction pipeline.
         if self.memory_manager is not None:
             try:
-                self.memory_manager.crystallize_user_messages(to_summarize)
+                self.memory_manager.crystallize_user_messages(prep.to_summarize)
             except Exception:
                 pass
-
-        # --- Step 5: LLM summarization --------------------------------------
-        pre_tokens = self.estimate_tokens(messages)
-        summary = self._summarize_messages(to_summarize)
-        if not summary:
-            self._consecutive_compact_failures += 1
-            return messages  # graceful degradation
-
-        self._consecutive_compact_failures = 0  # reset on success
 
         # --- Step 6: save session summary to SQLite --------------------------
         if self.memory_manager is not None:
@@ -598,7 +754,7 @@ class ContextManager:
                 self.memory_manager.save_session_summary(
                     summary=summary,
                     tokens_before=pre_tokens,
-                    messages_summarized=len(to_summarize),
+                    messages_summarized=len(prep.to_summarize),
                 )
             except Exception:
                 pass
@@ -608,10 +764,10 @@ class ContextManager:
             "role": "system",
             "content": (
                 f"[Compact Boundary | tokens_before={pre_tokens} | "
-                f"messages_summarized={len(to_summarize)} | "
-                f"messages_kept={len(to_keep)} | "
+                f"messages_summarized={len(prep.to_summarize)} | "
+                f"messages_kept={len(prep.to_keep)} | "
                 f"timestamp={datetime.now().strftime('%Y-%m-%d %H:%M:%S')} | "
-                f"auto={is_auto}]"
+                f"auto={prep.is_auto}]"
             ),
         }
 
@@ -626,8 +782,8 @@ class ContextManager:
         }
 
         file_hint_msgs: List[Dict[str, Any]] = []
-        if recently_read:
-            file_list = "\n".join(f"  - {p}" for p in recently_read)
+        if prep.recently_read:
+            file_list = "\n".join(f"  - {p}" for p in prep.recently_read)
             file_hint_msgs.append({
                 "role": "system",
                 "content": (
@@ -636,27 +792,235 @@ class ContextManager:
                 ),
             })
 
-        result = [boundary_msg, summary_msg] + file_hint_msgs + pinned + to_keep
+        result = [boundary_msg, summary_msg] + file_hint_msgs + prep.pinned + prep.to_keep
 
         post_tokens = self.estimate_tokens(result)
         self._last_compact_stats = {
             "timestamp": datetime.now().isoformat(),
             "pre_compact_tokens": pre_tokens,
             "post_compact_tokens": post_tokens,
-            "messages_summarized": len(to_summarize),
-            "messages_kept": len(to_keep),
-            "is_auto": is_auto,
-            "recently_read_files": recently_read,
+            "messages_summarized": len(prep.to_summarize),
+            "messages_kept": len(prep.to_keep),
+            "is_auto": prep.is_auto,
+            "recently_read_files": prep.recently_read,
         }
         try:
             self.llm_client.logger.info(
                 f"Compression complete: {pre_tokens} → {post_tokens} tokens, "
-                f"{len(to_summarize)} messages summarized, {len(to_keep)} kept"
+                f"{len(prep.to_summarize)} messages summarized, {len(prep.to_keep)} kept"
             )
         except Exception:
             pass
 
         return result
+
+    def apply_minimal_history(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        keep_tail: int = 2,
+    ) -> List[Dict[str, Any]]:
+        """The overflow ladder's last rung: keep only the newest ``keep_tail``.
+
+        One line, and it lived inline in the runner. It belongs here because
+        rewriting history is this class's job and the coordinator's explicit
+        non-job — and because the ladder's most destructive step deserves a
+        named, unit-testable seam rather than a slice buried in an
+        exception handler.
+        """
+        return messages[-keep_tail:]
+
+    def _validate_host_summary(
+        self,
+        summary: Any,
+        max_summary_tokens: int,
+    ) -> Optional[str]:
+        """Return the name of the first failed check, or ``None`` if valid.
+
+        Four shapes are rejected. The last is the least obvious: a host
+        summary containing ``SUMMARY_END_MARKER`` would break the *next*
+        compaction's carry-stripping, so the damage would surface one
+        compaction later, attributed to the wrong place.
+        """
+        if not isinstance(summary, str):
+            return "not_a_string"
+        if not summary.strip():
+            return "empty"
+        if self.SUMMARY_END_MARKER in summary:
+            return "contains_end_marker"
+        if self.count_tokens_in_text(summary) > max_summary_tokens:
+            return "over_budget"
+        return None
+
+    def _run_compaction(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        is_auto: bool,
+        reason: str,
+        decide=None,
+    ) -> CompactionOutcome:
+        """prepare -> decide -> summarize -> commit, and the failure counter.
+
+        Handles ``kind == "full"`` only. Microcompaction and
+        ``minimal_history`` do not come through here because they have
+        nothing to share with it: neither calls a summarizer, writes SQLite,
+        or touches the breaker counter. Forcing them through would make every
+        field optional and buy no reuse.
+
+        ``trigger`` and ``kind`` are not parameters because they are not
+        inputs: ``trigger`` is exactly ``is_auto`` in another encoding, and
+        ``kind`` is constantly ``full`` here. ``is_auto`` stays in the
+        signature rather than being replaced by ``trigger`` because
+        :meth:`compress_messages`'s signature is pinned and both callers
+        share this layer.
+
+        All three counting points live here — increment on a structural
+        failure, increment on an empty summary, reset on success. They cannot
+        live in ``commit``, which never runs when summarization returns
+        nothing, and they cannot live in the coordinator, which
+        :meth:`compress_messages` does not have.
+
+        Never returns ``skipped`` for an open breaker or a suppression latch:
+        both are decided above and never reach here. The only ``skipped`` it
+        can produce is ``history_too_short``.
+        """
+        trigger = "auto" if is_auto else "manual"
+        kind = "full"
+
+        prep = self.prepare_compaction(
+            messages, trigger=trigger, kind=kind, reason=reason,
+        )
+        if isinstance(prep, PrepareRejected):
+            if prep.counts_as_failure:
+                # Manual ``/compact`` is deliberately exempt: it is user-driven
+                # and does not loop, so there is no runaway to arrest — and the
+                # breaker it would trip disables *automatic* compaction for the
+                # rest of the session with no reset path.
+                if is_auto:
+                    self._consecutive_compact_failures += 1
+                    tally = f" ({self._consecutive_compact_failures} consecutive failures)"
+                else:
+                    # The manual path does not increment, so reporting the
+                    # counter here would attribute the auto path's tally —
+                    # usually 0 — to this failure.
+                    tally = ""
+                try:
+                    self.llm_client.logger.warning(
+                        "Compaction found no safe split point — history has no non-tool "
+                        f"boundary in the summarizable range; skipping{tally}"
+                    )
+                except Exception:
+                    pass
+            return CompactionOutcome(
+                status=prep.status,
+                trigger=trigger,
+                kind=kind,
+                reason=reason,
+                messages=messages,
+                pre_tokens=None,
+                post_tokens=None,
+                detail=prep.detail,
+            )
+
+        # ``decision_reason`` starts unset and is assigned **only** once
+        # ``decide`` has actually been called and returned a usable decision.
+        # The two branches above return before the decision step exists at
+        # all, and ``decide`` may legitimately be ``None`` (the legacy
+        # wrapper passes exactly that) — so there is no ``decision.reason`` to
+        # read on either path, and no exception has to be carved out of the
+        # composition rule below.
+        decision_reason: Optional[str] = None
+        internal_reason: Optional[str] = None
+        summary: Optional[str] = None
+
+        if decide is not None:
+            max_summary_tokens = self._summary_input_budget() // 2
+            ctx = CompactionDecisionContext(
+                trigger=trigger,
+                kind=kind,
+                reason=reason,
+                pre_tokens=prep.pre_tokens,
+                messages_to_summarize=len(prep.to_summarize),
+                messages_to_keep=len(prep.to_keep),
+                recently_read_files=tuple(prep.recently_read),
+                summary_input_budget=self._summary_input_budget(),
+                max_summary_tokens=max_summary_tokens,
+                can_provide_summary=True,
+                tool_results_to_clip=None,
+            )
+            decision = decide(ctx)
+            decision_reason = decision.reason
+            if decision.action == "cancel":
+                # No internal reason of its own: running the decision's own
+                # reason through the composition rule as well would render it
+                # twice.
+                return CompactionOutcome(
+                    status="cancelled",
+                    trigger=trigger,
+                    kind=kind,
+                    reason=reason,
+                    messages=messages,
+                    pre_tokens=prep.pre_tokens,
+                    post_tokens=None,
+                    detail=_compose_detail(None, decision_reason),
+                )
+            if decision.action == "provide_summary":
+                failed_check = self._validate_host_summary(
+                    decision.summary, max_summary_tokens,
+                )
+                if failed_check is None:
+                    summary = decision.summary
+                else:
+                    # Rejecting host text is **not** a terminal state: fall
+                    # through to the built-in summarizer as if the host had
+                    # said ``allow``. So a bad controller costs one extra
+                    # summarization and can never disable auto-compaction in
+                    # three calls — what the breaker counts is always the
+                    # built-in summarizer's failure.
+                    internal_reason = f"host_summary_rejected:{failed_check}"
+                    try:
+                        self.llm_client.logger.warning(
+                            "Host-provided compaction summary rejected "
+                            f"({failed_check}); falling back to the built-in summarizer"
+                        )
+                    except Exception:
+                        pass
+
+        if summary is None:
+            summary = self._summarize_formatted(prep.summary_input)
+
+        if not summary:
+            internal_reason = (
+                f"{internal_reason}+summary_empty" if internal_reason else "summary_empty"
+            )
+            self._consecutive_compact_failures += 1
+            return CompactionOutcome(
+                status="failed",
+                trigger=trigger,
+                kind=kind,
+                reason=reason,
+                messages=messages,
+                pre_tokens=prep.pre_tokens,
+                post_tokens=None,
+                detail=_compose_detail(internal_reason, decision_reason),
+            )
+
+        result = self.commit_compaction(prep, summary)
+        self._consecutive_compact_failures = 0  # reset on success
+        return CompactionOutcome(
+            status="success",
+            trigger=trigger,
+            kind=kind,
+            reason=reason,
+            messages=result,
+            pre_tokens=prep.pre_tokens,
+            # Written by ``commit_compaction`` a moment ago. Read back rather
+            # than re-estimated: a second ``estimate_tokens`` over the whole
+            # result is the one cost this plan promises not to add.
+            post_tokens=(self._last_compact_stats or {}).get("post_compact_tokens"),
+            detail=_compose_detail(internal_reason, decision_reason),
+        )
 
     # -----------------------------------------------------------------------
     # Recently read file extraction
@@ -835,23 +1199,37 @@ class ContextManager:
         Uses an <analysis> thinking block (stripped from output) followed by
         a <summary> block for the final result.
 
+        Takes a raw message window and does its own ``[PIN]`` filtering and
+        formatting. The compaction path no longer comes through here — it
+        assembles the input in ``prepare_compaction`` (so the host control
+        plane can see exactly what the model will) and calls
+        :meth:`_summarize_formatted` directly. Kept for callers that hold
+        messages rather than a formatted transcript.
+
+        Returns:
+            Formatted summary text, or empty string on failure.
+        """
+        to_summarize = [
+            m for m in messages
+            if not (
+                isinstance(m.get("content"), str)
+                and m["content"].startswith("[PIN]")
+            )
+        ]
+        return self._summarize_formatted(self._format_for_summary(to_summarize))
+
+    def _summarize_formatted(self, formatted: str) -> str:
+        """The LLM half of summarization, over an already-assembled transcript.
+
         Returns:
             Formatted summary text, or empty string on failure.
         """
         # Per-call, so the flag describes *this* summarization and not one
         # from an earlier compaction. ``run_turn`` additionally clears it per
-        # turn, for the case where ``compress_messages`` returns without ever
-        # reaching this method.
+        # turn, for the case where a compaction returns without ever reaching
+        # this method.
         self.last_summary_finish_reason_missing = False
         try:
-            to_summarize = [
-                m for m in messages
-                if not (
-                    isinstance(m.get("content"), str)
-                    and m["content"].startswith("[PIN]")
-                )
-            ]
-            formatted = self._format_for_summary(to_summarize)
             recall_messages = [
                 {"role": "system", "content": self._SUMMARIZE_SYSTEM_PROMPT},
                 {"role": "user", "content": f"Summarize this conversation:\n\n{formatted}"},

--- a/agentao/memory/manager.py
+++ b/agentao/memory/manager.py
@@ -253,10 +253,13 @@ class MemoryManager:
     ) -> None:
         """Persist a compact summary block to SQLite. Never raises.
 
-        This method does NOT crystallize. Crystallization runs upstream in
-        ``ContextManager.compress_messages()`` against the raw user messages
+        This method does NOT crystallize. Crystallization runs beside it in
+        ``ContextManager.commit_compaction()`` against the raw user messages
         that are about to be summarized away — the LLM-generated summary text
-        contains assistant narration and is not safe to regex against.
+        contains assistant narration and is not safe to regex against. Both
+        writes live in commit rather than before summarization, so a
+        compaction that is cancelled or whose summarization fails leaves the
+        store untouched.
         """
         try:
             record = SessionSummaryRecord(
@@ -377,8 +380,10 @@ class MemoryManager:
 
         Used by:
 
-        - ``ContextManager.compress_messages()`` — passes the about-to-be-
+        - ``ContextManager.commit_compaction()`` — passes the about-to-be-
           summarized window so we crystallize before the messages are gone.
+          It runs only once a summary exists, so a failed summarization no
+          longer writes.
         - ``/memory crystallize`` (CLI) — passes ``self.agent.messages`` so
           the user can manually re-run extraction over the live conversation
           buffer.

--- a/agentao/replay/adapter.py
+++ b/agentao/replay/adapter.py
@@ -417,6 +417,15 @@ class ReplayAdapter:
             )
             return
 
+        if kind == EventType.COMPACTION_SETTLED:
+            self._recorder.record(
+                EventKind.COMPACTION_SETTLED,
+                turn_id=self._current_turn_id(),
+                parent_turn_id=self._current_parent_turn(),
+                payload=dict(data),
+            )
+            return
+
         if kind == EventType.SESSION_SUMMARY_WRITTEN:
             self._recorder.record(
                 EventKind.SESSION_SUMMARY_WRITTEN,

--- a/agentao/replay/events.py
+++ b/agentao/replay/events.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
 
-SCHEMA_VERSION = "1.2"
+SCHEMA_VERSION = "1.3"
 
 
 class EventKind:
@@ -39,6 +39,15 @@ class EventKind:
       payload schemas as the per-kind variant. v1.0 / v1.1 schemas
       remain frozen and continue to validate older replays — see
       ``docs/reference/replay-schema-policy.md``.
+    - 1.3 — adds ``compaction_settled``, the terminal event for one
+      compaction attempt whatever the outcome. ``context_compressed``
+      only ever describes a compaction that changed history — and until
+      the compaction entry points were unified it did not even manage
+      that, since the API-overflow path emitted it unconditionally, so a
+      no-op under an open circuit breaker was recorded as a successful
+      compression. Reading the audit trail now means reading both:
+      ``compaction_settled`` for what was attempted and how it ended,
+      ``context_compressed`` for the successes.
     """
 
     REPLAY_HEADER = "replay_header"
@@ -153,9 +162,18 @@ class EventKind:
 
     V1_2 = V1_1 | V1_2_NEW
 
+    # v1.3 event kinds — compaction orchestration.
+    COMPACTION_SETTLED = "compaction_settled"
+
+    V1_3_NEW = frozenset({
+        COMPACTION_SETTLED,
+    })
+
+    V1_3 = V1_2 | V1_3_NEW
+
     # Back-compat alias. Existing callers that imported ``EventKind.ALL``
     # keep working; new code should pick the version-specific set.
-    ALL = V1_2
+    ALL = V1_3
 
 
 @dataclass

--- a/agentao/replay/schema.py
+++ b/agentao/replay/schema.py
@@ -46,6 +46,8 @@ def _kinds_for_version(version: str) -> FrozenSet[str]:
         return EventKind.V1_1
     if version == "1.2":
         return EventKind.V1_2
+    if version == "1.3":
+        return EventKind.V1_3
     raise ValueError(f"unknown replay schema version: {version!r}")
 
 
@@ -216,7 +218,7 @@ def build_event_schema(version: str) -> dict:
     }
 
 
-SUPPORTED_VERSIONS: tuple = ("1.0", "1.1", "1.2")
+SUPPORTED_VERSIONS: tuple = ("1.0", "1.1", "1.2", "1.3")
 
 
 def render(version: str) -> str:

--- a/agentao/runtime/chat_loop/_compaction.py
+++ b/agentao/runtime/chat_loop/_compaction.py
@@ -1,20 +1,21 @@
 """Pre-LLM-call compaction steps for ``ChatLoopRunner``.
 
-The runner's loop body invokes both methods on every iteration; each
-checks its own threshold against ``ContextManager`` and short-circuits
-when no compaction is needed. Both fire a ``PreCompact`` plugin hook
-before mutating history so plugin authors can react to the imminent
-context change.
+The runner's loop body invokes both methods on every iteration; each checks
+its own threshold against ``ContextManager`` and short-circuits when no
+compaction is needed. Everything past that check — the ``PreCompact`` hook,
+the circuit-breaker gate, the transform itself, and both events — belongs to
+``CompactionCoordinator``, which the API-overflow ladder and manual
+``/compact`` go through as well. These two methods are threshold detectors
+now, and nothing else.
 
-Mixed into :class:`ChatLoopRunner`; relies on
-``self._dispatch_pre_compact`` (provided by ``_HookDispatchMixin``) and
-``self._agent``.
+Mixed into :class:`ChatLoopRunner`; relies on ``self._agent``.
 """
 
 from __future__ import annotations
 
-import time
 from typing import Tuple
+
+from ...compaction.coordinator import CompactionRequest
 
 
 class _CompactionMixin:
@@ -29,43 +30,13 @@ class _CompactionMixin:
         agent = self._agent
         if not agent.context_manager.needs_microcompaction(messages_with_system, tokens=tokens):
             return messages_with_system, system_prompt
-        if not agent.context_manager.microcompact_would_mutate(agent.messages):
-            # Same stand-down as the open breaker below, one tier cheaper.
-            # Being *in* the 55-80% band says nothing about there being
-            # anything left to shorten: once every old tool result is at or
-            # under the limit, every further iteration in the band is a no-op —
-            # and running the preamble anyway forks a PreCompact hook
-            # subprocess per iteration and emits a CONTEXT_COMPRESSED reporting
-            # pre == post, on top of two full-history token estimates.
-            return messages_with_system, system_prompt
-        self._dispatch_pre_compact(
-            trigger="auto",
-            compaction_type="microcompact",
-            reason="microcompact_threshold",
+        run = agent.compaction_coordinator.run(
+            CompactionRequest("auto", "microcompact", "microcompact_threshold"),
+            system_prompt=system_prompt,
+            messages_with_system=messages_with_system,
+            measure_system_tokens=True,
         )
-        t0 = time.monotonic()
-        pre_tokens = agent.context_manager.estimate_tokens(messages_with_system)
-        pre_msgs = len(agent.messages)
-        agent.messages = agent.context_manager.microcompact_messages(agent.messages)
-        if agent.context_manager.last_microcompact_mutated:
-            # Only a pass that actually shortened something invalidates the
-            # already-sent prefix. Dropping the anchor unconditionally forced a
-            # full re-encode of the entire history on every iteration spent in
-            # the microcompact band — precisely when it is most expensive.
-            agent.context_manager.invalidate_token_anchor()
-        messages_with_system = [
-            {"role": "system", "content": system_prompt}
-        ] + agent.messages
-        agent._emit_context_compressed(
-            compression_type="microcompact",
-            reason="microcompact_threshold",
-            pre_msgs=pre_msgs,
-            post_msgs=len(agent.messages),
-            pre_tokens=pre_tokens,
-            post_tokens=agent.context_manager.estimate_tokens(messages_with_system),
-            duration_ms=round((time.monotonic() - t0) * 1000),
-        )
-        return messages_with_system, system_prompt
+        return run.messages_with_system, run.system_prompt
 
     def _maybe_full_compress(
         self,
@@ -76,54 +47,10 @@ class _CompactionMixin:
         agent = self._agent
         if not agent.context_manager.needs_compression(messages_with_system, tokens=tokens):
             return messages_with_system, system_prompt
-        if agent.context_manager.compaction_circuit_open:
-            # Every attempt now returns history unchanged, so announcing the
-            # compaction would fork a PreCompact hook subprocess per iteration
-            # for something that never happens — and emit a CONTEXT_COMPRESSED
-            # reporting pre == post. Stand down and let the API-overflow
-            # recovery path in ``_runner`` own it from here.
-            #
-            # Still log it: standing down before ``compress_messages`` skips
-            # the breaker warning *it* used to emit, and that line was the only
-            # signal that auto-compaction is dead for the rest of the session
-            # (the counter has no reset path).
-            agent.llm.logger.warning(
-                "Compact circuit breaker open — skipping auto-compaction; "
-                "context stays over threshold until the API-overflow path recovers it"
-            )
-            return messages_with_system, system_prompt
-        self._dispatch_pre_compact(
-            trigger="auto",
-            compaction_type="full",
-            reason="compression_threshold",
+        run = agent.compaction_coordinator.run(
+            CompactionRequest("auto", "full", "compression_threshold"),
+            system_prompt=system_prompt,
+            messages_with_system=messages_with_system,
+            measure_system_tokens=True,
         )
-        agent.llm.logger.info("Context compression triggered inside loop")
-        t0 = time.monotonic()
-        pre_tokens = agent.context_manager.estimate_tokens(messages_with_system)
-        pre_msgs = len(agent.messages)
-        agent.messages = agent.context_manager.compress_messages(agent.messages, is_auto=True)
-        # The summarization LLM call bypasses the runner's detector (it goes
-        # straight to ``llm_client``), so fold its observation in here. This is
-        # the call whose output permanently rewrites history, so a turn that
-        # compacted against an unconfirmed summary must say so.
-        if agent.context_manager.last_summary_finish_reason_missing:
-            agent._turn_finish_reason_missing = True
-        agent.context_manager.invalidate_token_anchor()  # prefix rewritten; real count is stale
-        system_prompt = agent._build_system_prompt()
-        messages_with_system = [
-            {"role": "system", "content": system_prompt}
-        ] + agent.messages
-        agent.llm.logger.info(f"Context compressed to {len(agent.messages)} messages")
-        agent._emit_context_compressed(
-            compression_type="full",
-            reason="compression_threshold",
-            pre_msgs=pre_msgs,
-            post_msgs=len(agent.messages),
-            pre_tokens=pre_tokens,
-            post_tokens=agent.context_manager.estimate_tokens(messages_with_system),
-            duration_ms=round((time.monotonic() - t0) * 1000),
-        )
-        agent._last_session_summary_id = agent._emit_session_summary_if_new(
-            agent._last_session_summary_id,
-        )
-        return messages_with_system, system_prompt
+        return run.messages_with_system, run.system_prompt

--- a/agentao/runtime/chat_loop/_hook_dispatch.py
+++ b/agentao/runtime/chat_loop/_hook_dispatch.py
@@ -172,45 +172,18 @@ class _HookDispatchMixin:
         compaction_type: CompactionKind,
         reason: CompactionReason,
     ) -> None:
-        """PreCompact dispatch — fires before the about-to-mutate
-        compaction site; side-effect only with the same no-emit gate as
-        ``_dispatch_stop``.
+        """PreCompact dispatch — thin delegation to the coordinator.
 
-        ``trigger`` carries the provenance the matcher reads. Every site
-        reachable from here is automatic, so all four pass ``"auto"`` —
-        but it is passed rather than assumed, because assuming it is what
-        made manual ``/compact`` report itself as ``auto``.
+        The dispatch itself moved to ``CompactionCoordinator``, which every
+        compaction entry point now goes through, so that the payload and the
+        ``PLUGIN_HOOK_FIRED`` event are built once instead of once here and
+        once in the CLI's manual ``/compact`` copy — the split that let the
+        two disagree about ``trigger`` for the same compaction.
+
+        Kept as a method because the mixin is this class's documented hook
+        surface and callers reach it as ``runner._dispatch_pre_compact``.
         """
-        agent = self._agent
-        if not agent._plugin_hook_rules:
-            return
-        from ...plugins.hooks import (
-            ClaudeHookPayloadAdapter,
-            PluginHookDispatcher,
+        from ...compaction.coordinator import CompactionRequest
+        self._agent.compaction_coordinator.dispatch_pre_compact(
+            CompactionRequest(trigger, compaction_type, reason),
         )
-        cwd = agent.working_directory
-        payload = ClaudeHookPayloadAdapter().build_pre_compact(
-            session_id=agent._session_id,
-            cwd=cwd,
-            trigger=trigger,
-            compaction_type=compaction_type,
-            reason=reason,
-            permission_mode=agent.active_permissions().mode,
-        )
-        dispatcher = PluginHookDispatcher(cwd=cwd)
-        matched = dispatcher.select_matching_rules(
-            "PreCompact", payload, agent._plugin_hook_rules,
-        )
-        if not matched:
-            return
-        dispatcher.dispatch_pre_compact(payload=payload, rules=matched)
-        try:
-            agent.transport.emit(AgentEvent(EventType.PLUGIN_HOOK_FIRED, {
-                "hook_name": "PreCompact",
-                "outcome": "allow",
-                "compaction_type": compaction_type,
-                "trigger": trigger,
-                "matched_rule_count": len(matched),
-            }))
-        except Exception:
-            pass

--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from xml.sax.saxutils import quoteattr
 
 from ...cancellation import AgentCancelledError, CancellationToken
+from ...compaction.coordinator import CompactionRequest
 from ...context_manager import is_context_too_long_error
 from ...llm._retry import _is_image_unsupported
 from ...transport import AgentEvent, EventType
@@ -1158,33 +1159,25 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                 agent.messages.append({"role": "assistant", "content": err_msg})
                 return ChatLoopRunner._LlmOutcome(error_return=err_msg)
             agent.llm.logger.warning(f"Context overflow from API, forcing compression: {e}")
-            self._dispatch_pre_compact(
-                trigger="auto",
-                compaction_type="full",
-                reason="api_overflow",
+            # Rung 1 of the ladder. It goes through the coordinator like every
+            # other entry — which is what finally lets it pass its real
+            # ``api_overflow`` reason instead of riding ``compress_messages``'s
+            # ``is_auto=True`` default and reporting itself as a threshold
+            # compaction, contradicting the hook payload it just emitted. It
+            # also stops announcing success when the breaker made the attempt
+            # a no-op.
+            run = agent.compaction_coordinator.run(
+                CompactionRequest("auto", "full", "api_overflow"),
+                system_prompt=system_prompt,
+                messages_with_system=messages_with_system,
+                # Unchanged from today: this rung has never carried tokens on
+                # the event, and filling them in would mean two new
+                # full-history estimates on the path where the context has
+                # already blown up.
+                measure_system_tokens=False,
             )
-            t0 = time.monotonic()
-            pre_msgs = len(agent.messages)
-            agent.messages = agent.context_manager.compress_messages(agent.messages)
-            # Same fold-in as the threshold path in ``_compaction.py``: the
-            # summarization call never passes the detector above.
-            if agent.context_manager.last_summary_finish_reason_missing:
-                agent._turn_finish_reason_missing = True
-            agent.context_manager.invalidate_token_anchor()  # prefix rewritten; anchor is stale
-            system_prompt = agent._build_system_prompt()
-            messages_with_system = [
-                {"role": "system", "content": system_prompt}
-            ] + agent.messages
-            agent._emit_context_compressed(
-                compression_type="full",
-                reason="api_overflow",
-                pre_msgs=pre_msgs,
-                post_msgs=len(agent.messages),
-                duration_ms=round((time.monotonic() - t0) * 1000),
-            )
-            agent._last_session_summary_id = agent._emit_session_summary_if_new(
-                agent._last_session_summary_id,
-            )
+            system_prompt = run.system_prompt
+            messages_with_system = run.messages_with_system
             try:
                 response = agent._llm_call(messages_with_system, tools, token)
                 return ChatLoopRunner._LlmOutcome(
@@ -1197,22 +1190,15 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                     agent.llm.logger.warning(
                         "Context still too long after compression, keeping minimal history"
                     )
-                    self._dispatch_pre_compact(
-                        trigger="auto",
-                        compaction_type="minimal_history",
-                        reason="api_overflow_after_compression",
+                    run = agent.compaction_coordinator.run(
+                        CompactionRequest(
+                            "auto", "minimal_history", "api_overflow_after_compression",
+                        ),
+                        system_prompt=system_prompt,
+                        messages_with_system=messages_with_system,
+                        measure_system_tokens=False,
                     )
-                    pre = len(agent.messages)
-                    agent.messages = agent.messages[-2:]
-                    messages_with_system = [
-                        {"role": "system", "content": system_prompt}
-                    ] + agent.messages
-                    agent._emit_context_compressed(
-                        compression_type="minimal_history",
-                        reason="api_overflow_after_compression",
-                        pre_msgs=pre,
-                        post_msgs=len(agent.messages),
-                    )
+                    messages_with_system = run.messages_with_system
                     try:
                         response = agent._llm_call(messages_with_system, tools, token)
                         return ChatLoopRunner._LlmOutcome(

--- a/agentao/transport/events.py
+++ b/agentao/transport/events.py
@@ -34,6 +34,12 @@ class EventType(str, Enum):
     ASK_USER_ANSWERED  = "ask_user_answered"
     BACKGROUND_NOTIFICATION_INJECTED = "background_notification_injected"
     CONTEXT_COMPRESSED = "context_compressed"
+    # Terminal event for one compaction attempt, whatever the outcome.
+    # CONTEXT_COMPRESSED only ever describes a compaction that *changed*
+    # history; this one also reports the attempts that were skipped by
+    # policy, vetoed, or failed — and its two token fields are named apart
+    # because they exclude the system prompt where the older pair includes it.
+    COMPACTION_SETTLED = "compaction_settled"
     SESSION_SUMMARY_WRITTEN = "session_summary_written"
     # Step 6 — runtime state changes
     SKILL_ACTIVATED         = "skill_activated"

--- a/docs/reference/host-api.md
+++ b/docs/reference/host-api.md
@@ -380,10 +380,27 @@ of this writing:
 | LLM call | `LLM_CALL_STARTED`, `LLM_CALL_COMPLETED`, `LLM_CALL_DELTA`, `LLM_CALL_IO`, `LLM_TEXT`, `THINKING` |
 | Sub-agent (raw) | `AGENT_START`, `AGENT_END` |
 | Interaction | `TOOL_CONFIRMATION`, `ASK_USER_REQUESTED`, `ASK_USER_ANSWERED` |
-| History | `BACKGROUND_NOTIFICATION_INJECTED`, `CONTEXT_COMPRESSED`, `SESSION_SUMMARY_WRITTEN` |
+| History | `BACKGROUND_NOTIFICATION_INJECTED`, `CONTEXT_COMPRESSED`, `COMPACTION_SETTLED`, `SESSION_SUMMARY_WRITTEN` |
 | Memory | `MEMORY_WRITE`, `MEMORY_DELETE`, `MEMORY_CLEARED` |
 | Runtime state | `SKILL_ACTIVATED`, `SKILL_DEACTIVATED`, `MODEL_CHANGED`, `PERMISSION_MODE_CHANGED`, `READONLY_MODE_CHANGED`, `PLUGIN_HOOK_FIRED` |
 | Errors | `ERROR` |
+
+**Reading the two compaction events together.** `CONTEXT_COMPRESSED`
+describes only a compaction that **changed history**, and it is emitted
+after the change. `COMPACTION_SETTLED` is the terminal event for one
+compaction *attempt* and also covers the ones that were vetoed or failed
+(`status` is `success | cancelled | failed`). A `skipped` attempt emits
+**neither**, deliberately: three of the four skipped cases re-trigger on
+every loop iteration, so one event each would be an event storm rather
+than a signal.
+
+Their token fields are **different units and are named apart for that
+reason**. `CONTEXT_COMPRESSED`'s `pre_est_tokens` / `post_est_tokens`
+measure `[system prompt] + messages`; `COMPACTION_SETTLED`'s
+`pre_tokens_history` / `post_tokens_history` measure the message list
+alone. Do not wire one into the other. Both are `null` on the two
+API-overflow rungs and on microcompaction, because filling them in would
+mean full-history estimates on the paths where they are most expensive.
 
 Every `AgentEvent` carries a `schema_version: int` field; bumps are
 the *only* signal that a payload's shape changed. It is a **single

--- a/docs/reference/host-api.zh.md
+++ b/docs/reference/host-api.zh.md
@@ -315,10 +315,23 @@ for ev in events:
 | LLM 调用 | `LLM_CALL_STARTED`、`LLM_CALL_COMPLETED`、`LLM_CALL_DELTA`、`LLM_CALL_IO`、`LLM_TEXT`、`THINKING` |
 | 子 Agent（原始） | `AGENT_START`、`AGENT_END` |
 | 交互 | `TOOL_CONFIRMATION`、`ASK_USER_REQUESTED`、`ASK_USER_ANSWERED` |
-| 历史 | `BACKGROUND_NOTIFICATION_INJECTED`、`CONTEXT_COMPRESSED`、`SESSION_SUMMARY_WRITTEN` |
+| 历史 | `BACKGROUND_NOTIFICATION_INJECTED`、`CONTEXT_COMPRESSED`、`COMPACTION_SETTLED`、`SESSION_SUMMARY_WRITTEN` |
 | Memory | `MEMORY_WRITE`、`MEMORY_DELETE`、`MEMORY_CLEARED` |
 | Runtime 状态 | `SKILL_ACTIVATED`、`SKILL_DEACTIVATED`、`MODEL_CHANGED`、`PERMISSION_MODE_CHANGED`、`READONLY_MODE_CHANGED`、`PLUGIN_HOOK_FIRED` |
 | 错误 | `ERROR` |
+
+**两个压缩事件要一起读。** `CONTEXT_COMPRESSED` 只描述**真的改动了历史**
+的那次压缩，且在改动之后发出。`COMPACTION_SETTLED` 是**一次压缩尝试**的终态
+事件，被否决和失败的那些也在内（`status` 取 `success | cancelled | failed`）。
+`skipped` 的尝试**两个都不发**，这是有意的：四类 skipped 里有三类**每轮迭代
+都会重新触发**，一次一个事件就不是信号而是事件风暴。
+
+两者的 token 字段是**不同单位，正因如此才取了不同的名字**。
+`CONTEXT_COMPRESSED` 的 `pre_est_tokens` / `post_est_tokens` 量的是
+`[system prompt] + messages`；`COMPACTION_SETTLED` 的
+`pre_tokens_history` / `post_tokens_history` 只量消息列表本身。**不要把它们
+接到一起。** 在 API 溢出的两级和微压缩上两者都是 `null` —— 在那些路径上补齐
+它们意味着在最贵的时候做全量历史估算。
 
 每个 `AgentEvent` 都带 `schema_version: int` 字段；这是载荷形状变化
 的**唯一**信号。它是**所有事件类型共用的单个值**，不是按载荷分版本的

--- a/docs/reference/replay-schema-policy.md
+++ b/docs/reference/replay-schema-policy.md
@@ -1,7 +1,7 @@
 # Replay schema versioning policy
 
 This document defines how the JSON Schema files under `schemas/` evolve.
-It exists so that "what does `SCHEMA_VERSION = "1.2"` mean?" has a
+It exists so that "what does `SCHEMA_VERSION = "1.3"` mean?" has a
 machine-checkable answer instead of living in a dataclass docstring.
 
 ## Source of truth
@@ -56,7 +56,8 @@ Required when:
   would fail validation.
 
 Major bumps freeze the previous schema file. `schemas/replay-event-1.0.json`,
-`schemas/replay-event-1.1.json`, and `schemas/replay-event-1.2.json` each
+`schemas/replay-event-1.1.json`, `schemas/replay-event-1.2.json`, and
+`schemas/replay-event-1.3.json` each
 keep validating every replay file written under their respective minor,
 indefinitely.
 
@@ -149,3 +150,16 @@ belongs in `agentao/replay/schema.py` so it is unit-testable.
   the sink so every published harness event also lands in the JSONL.
   Backward-compatible with 1.1 — every 1.1 kind survives, and a 1.0 /
   1.1 reader treats the three new kinds as unknown and skips them.
+- **1.3** — adds one kind, `compaction_settled`: the terminal event for
+  one compaction attempt, whatever the outcome
+  (`success | cancelled | failed`; `skipped` is silent by design,
+  because three of its four cases re-trigger on every loop iteration).
+  It exists because `context_compressed` describes only compactions that
+  changed history — and, before the entry points were unified, not even
+  that: the API-overflow path emitted it unconditionally, so a no-op
+  under an open circuit breaker was recorded as a successful
+  compression. `context_compressed`'s own payload is **unchanged**,
+  including both token fields' system-**inclusive** unit; the new event's
+  `pre_tokens_history` / `post_tokens_history` are named apart precisely
+  because they exclude the system prompt. Backward-compatible with 1.2 —
+  every 1.2 kind survives, and older readers skip the new one.

--- a/schemas/replay-event-1.3.json
+++ b/schemas/replay-event-1.3.json
@@ -1,0 +1,975 @@
+{
+  "$id": "urn:agentao:schema:replay-event:1.3",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "One JSONL line in a replay file. Source of truth: agentao/replay/events.py - regenerate via scripts/write_replay_schema.py.",
+  "oneOf": [
+    {
+      "properties": {
+        "kind": {
+          "const": "ask_user_answered"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "ask_user_requested"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "assistant_text_chunk"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "assistant_thought_chunk"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "background_notification_injected"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "compaction_settled"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "context_compressed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "error"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "llm_call_completed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "llm_call_delta"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "llm_call_io"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "llm_call_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "memory_cleared"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "memory_delete"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "memory_write"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "model_changed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "permission_decision"
+        },
+        "payload": {
+          "additionalProperties": false,
+          "description": "Public projection of a single permission decision.\n\nFires on **every** decision; hosts that do not render ``allow``\ndecisions must still drain the iterator to avoid backpressure.\n\n``matched_rule`` intentionally has no per-rule source label in MVP.\nUse ``loaded_sources`` for global context. ``reason`` is a\nredacted/truncated host-facing string.",
+          "properties": {
+            "decided_at": {
+              "description": "RFC 3339 UTC timestamp with the canonical 'Z' suffix; offsets such as +00:00 are intentionally rejected for canonical form.",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+              "title": "Decided At",
+              "type": "string"
+            },
+            "decision_id": {
+              "title": "Decision Id",
+              "type": "string"
+            },
+            "event_type": {
+              "const": "permission_decision",
+              "default": "permission_decision",
+              "title": "Event Type",
+              "type": "string"
+            },
+            "loaded_sources": {
+              "items": {
+                "type": "string"
+              },
+              "title": "Loaded Sources",
+              "type": "array"
+            },
+            "matched_rule": {
+              "anyOf": [
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Matched Rule"
+            },
+            "mode": {
+              "enum": [
+                "read-only",
+                "workspace-write",
+                "full-access",
+                "plan"
+              ],
+              "title": "Mode",
+              "type": "string"
+            },
+            "outcome": {
+              "enum": [
+                "allow",
+                "deny",
+                "prompt"
+              ],
+              "title": "Outcome",
+              "type": "string"
+            },
+            "reason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Reason"
+            },
+            "redacted": {
+              "type": "string"
+            },
+            "redacted_fields": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "redaction_hits": {
+              "additionalProperties": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "type": "object"
+            },
+            "session_id": {
+              "title": "Session Id",
+              "type": "string"
+            },
+            "tool_call_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Tool Call Id"
+            },
+            "tool_name": {
+              "title": "Tool Name",
+              "type": "string"
+            },
+            "turn_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Turn Id"
+            }
+          },
+          "required": [
+            "session_id",
+            "tool_name",
+            "decision_id",
+            "outcome",
+            "mode",
+            "loaded_sources",
+            "decided_at"
+          ],
+          "title": "PermissionDecisionEvent",
+          "type": "object"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "permission_mode_changed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "plugin_hook_fired"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "readonly_mode_changed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "replay_footer"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "replay_header"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_ended"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_forked"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_loaded"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_saved"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_summary_written"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "skill_activated"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "skill_deactivated"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "subagent_completed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "subagent_lifecycle"
+        },
+        "payload": {
+          "additionalProperties": false,
+          "description": "Public lineage fact for a sub-agent task/session.\n\nUnlike :class:`ToolLifecycleEvent`, this model exposes ``cancelled``\nas a distinct phase because sub-agent lineage tracking benefits from\nexplicit cancellation in the phase value. ``ToolLifecycleEvent``\nkeeps cancellation under ``phase=\"failed\", outcome=\"cancelled\"`` to\nkeep the tool-call shape compact.\n\n``task_summary`` is redacted/truncated, never raw user input or raw\nchild-agent prompt text.",
+          "properties": {
+            "child_session_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Child Session Id"
+            },
+            "child_task_id": {
+              "title": "Child Task Id",
+              "type": "string"
+            },
+            "completed_at": {
+              "anyOf": [
+                {
+                  "description": "RFC 3339 UTC timestamp with the canonical 'Z' suffix; offsets such as +00:00 are intentionally rejected for canonical form.",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Completed At"
+            },
+            "error_type": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Error Type"
+            },
+            "event_type": {
+              "const": "subagent_lifecycle",
+              "default": "subagent_lifecycle",
+              "title": "Event Type",
+              "type": "string"
+            },
+            "parent_session_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Parent Session Id"
+            },
+            "parent_task_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Parent Task Id"
+            },
+            "phase": {
+              "enum": [
+                "spawned",
+                "completed",
+                "failed",
+                "cancelled"
+              ],
+              "title": "Phase",
+              "type": "string"
+            },
+            "redacted": {
+              "type": "string"
+            },
+            "redacted_fields": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "redaction_hits": {
+              "additionalProperties": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "type": "object"
+            },
+            "session_id": {
+              "title": "Session Id",
+              "type": "string"
+            },
+            "started_at": {
+              "description": "RFC 3339 UTC timestamp with the canonical 'Z' suffix; offsets such as +00:00 are intentionally rejected for canonical form.",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+              "title": "Started At",
+              "type": "string"
+            },
+            "task_summary": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Task Summary"
+            }
+          },
+          "required": [
+            "session_id",
+            "child_task_id",
+            "phase",
+            "started_at"
+          ],
+          "title": "SubagentLifecycleEvent",
+          "type": "object"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "subagent_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_completed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_confirmation_requested"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_confirmation_resolved"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_lifecycle"
+        },
+        "payload": {
+          "additionalProperties": false,
+          "description": "Public lifecycle envelope for a single tool call.\n\nMust not include full tool args, raw stdout/stderr, raw diffs, MCP\nraw responses, or unredacted large outputs. ``summary`` is a\nredacted/truncated host-facing string.\n\n``phase=\"failed\"`` covers both execution errors and cancellation;\nhosts read ``outcome`` to distinguish error from cancelled. For\ncancellation, ``error_type`` is ``None``.",
+          "properties": {
+            "completed_at": {
+              "anyOf": [
+                {
+                  "description": "RFC 3339 UTC timestamp with the canonical 'Z' suffix; offsets such as +00:00 are intentionally rejected for canonical form.",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Completed At"
+            },
+            "error_type": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Error Type"
+            },
+            "event_type": {
+              "const": "tool_lifecycle",
+              "default": "tool_lifecycle",
+              "title": "Event Type",
+              "type": "string"
+            },
+            "outcome": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "ok",
+                    "error",
+                    "cancelled"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Outcome"
+            },
+            "phase": {
+              "enum": [
+                "started",
+                "completed",
+                "failed"
+              ],
+              "title": "Phase",
+              "type": "string"
+            },
+            "redacted": {
+              "type": "string"
+            },
+            "redacted_fields": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "redaction_hits": {
+              "additionalProperties": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "type": "object"
+            },
+            "session_id": {
+              "title": "Session Id",
+              "type": "string"
+            },
+            "started_at": {
+              "description": "RFC 3339 UTC timestamp with the canonical 'Z' suffix; offsets such as +00:00 are intentionally rejected for canonical form.",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+              "title": "Started At",
+              "type": "string"
+            },
+            "summary": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Summary"
+            },
+            "tool_call_id": {
+              "title": "Tool Call Id",
+              "type": "string"
+            },
+            "tool_name": {
+              "title": "Tool Name",
+              "type": "string"
+            },
+            "turn_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Turn Id"
+            }
+          },
+          "required": [
+            "session_id",
+            "tool_call_id",
+            "tool_name",
+            "phase",
+            "started_at"
+          ],
+          "title": "ToolLifecycleEvent",
+          "type": "object"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_output_chunk"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_result"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "turn_completed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "turn_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "user_message"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    }
+  ],
+  "properties": {
+    "event_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "instance_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "kind": {
+      "enum": [
+        "ask_user_answered",
+        "ask_user_requested",
+        "assistant_text_chunk",
+        "assistant_thought_chunk",
+        "background_notification_injected",
+        "compaction_settled",
+        "context_compressed",
+        "error",
+        "llm_call_completed",
+        "llm_call_delta",
+        "llm_call_io",
+        "llm_call_started",
+        "memory_cleared",
+        "memory_delete",
+        "memory_write",
+        "model_changed",
+        "permission_decision",
+        "permission_mode_changed",
+        "plugin_hook_fired",
+        "readonly_mode_changed",
+        "replay_footer",
+        "replay_header",
+        "session_ended",
+        "session_forked",
+        "session_loaded",
+        "session_saved",
+        "session_started",
+        "session_summary_written",
+        "skill_activated",
+        "skill_deactivated",
+        "subagent_completed",
+        "subagent_lifecycle",
+        "subagent_started",
+        "tool_completed",
+        "tool_confirmation_requested",
+        "tool_confirmation_resolved",
+        "tool_lifecycle",
+        "tool_output_chunk",
+        "tool_result",
+        "tool_started",
+        "turn_completed",
+        "turn_started",
+        "user_message"
+      ],
+      "type": "string"
+    },
+    "parent_turn_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "payload": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "seq": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "session_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "ts": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "turn_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "event_id",
+    "session_id",
+    "instance_id",
+    "seq",
+    "ts",
+    "kind",
+    "payload"
+  ],
+  "title": "Agentao replay event (v1.3)",
+  "type": "object"
+}

--- a/tests/test_compact_command.py
+++ b/tests/test_compact_command.py
@@ -1,16 +1,41 @@
-"""Tests for the manual /compact slash command."""
+"""Tests for the manual /compact slash command.
+
+``/compact`` no longer decides anything itself. It asks the coordinator to
+run a ``manual`` / ``full`` / ``manual_cli`` compaction and reports the
+``CompactionOutcome`` it gets back, so these tests drive the **real**
+coordinator over a mocked ``ContextManager`` — the seam under test is
+``_run_compaction``'s status, not a sniffed message marker.
+"""
 
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 from agentao.cli.commands import handle_compact_command
+from agentao.compaction.coordinator import CompactionCoordinator
+from agentao.compaction.types import CompactionOutcome
 
 
-def _cli_with_messages(messages: list[dict], compacted: list[dict] | None = None):
+def _outcome(status, messages, **kw):
+    return CompactionOutcome(
+        status=status,
+        trigger="manual",
+        kind="full",
+        reason="manual_cli",
+        messages=messages,
+        **kw,
+    )
+
+
+def _cli_with_messages(messages: list[dict], outcome: CompactionOutcome | None = None):
     cm = Mock()
     cm.CIRCUIT_BREAKER_LIMIT = 3
-    cm.estimate_tokens.side_effect = [1000, 250]
-    cm.compress_messages.return_value = compacted if compacted is not None else messages
+    cm.compaction_circuit_open = False
+    cm.last_summary_finish_reason_missing = False
+    cm.last_microcompact_mutated = True
+    cm.estimate_tokens.side_effect = [1000, 250, 250]
+    cm._run_compaction.return_value = (
+        outcome if outcome is not None else _outcome("failed", messages)
+    )
     cm.get_usage_stats.return_value = {
         "usage_percent": 12.5,
         "circuit_breaker_failures": 0,
@@ -18,12 +43,15 @@ def _cli_with_messages(messages: list[dict], compacted: list[dict] | None = None
     agent = SimpleNamespace(
         messages=messages,
         context_manager=cm,
+        transport=SimpleNamespace(emit=Mock()),
+        llm=SimpleNamespace(logger=Mock()),
         _plugin_hook_rules=[],
         _last_session_summary_id=None,
         _build_system_prompt=Mock(return_value="system"),
         _emit_context_compressed=Mock(),
         _emit_session_summary_if_new=Mock(return_value="summary-id"),
     )
+    agent.compaction_coordinator = CompactionCoordinator(agent)
     cli = SimpleNamespace(agent=agent, _cached_ctx_pct=0.0)
     return cli, agent, cm
 
@@ -35,12 +63,18 @@ def test_compact_command_updates_history_and_emits_event():
         {"role": "system", "content": "[Conversation Summary]\nsummary"},
         {"role": "user", "content": "recent"},
     ]
-    cli, agent, cm = _cli_with_messages(messages, compacted)
+    cli, agent, cm = _cli_with_messages(
+        messages, _outcome("success", compacted, pre_tokens=900, post_tokens=200),
+    )
 
     handle_compact_command(cli, "")
 
     assert agent.messages == compacted
-    cm.compress_messages.assert_called_once_with(messages, is_auto=False)
+    cm._run_compaction.assert_called_once()
+    call = cm._run_compaction.call_args
+    assert call.args[0] == messages
+    assert call.kwargs["is_auto"] is False
+    assert call.kwargs["reason"] == "manual_cli"
     agent._emit_context_compressed.assert_called_once()
     kwargs = agent._emit_context_compressed.call_args.kwargs
     assert kwargs["compression_type"] == "full"
@@ -50,27 +84,22 @@ def test_compact_command_updates_history_and_emits_event():
     assert cli._cached_ctx_pct == 12.5
 
 
-def test_compact_command_no_change_keeps_history():
-    messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
-    cli, agent, cm = _cli_with_messages(messages)  # compress_messages returns same list
+def test_compact_command_keeps_history_when_the_outcome_is_not_success():
+    """A non-success outcome must leave history alone and stay silent.
 
-    handle_compact_command(cli, "")
+    The old code inferred this by looking for a freshly prepended
+    ``[Compact Boundary]`` marker on ``messages[0]``, which is why a
+    microcompacted copy — a *new* list with no summary in it — had to be
+    special-cased. There is a ``status`` now.
+    """
+    for status in ("failed", "skipped", "cancelled"):
+        messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+        cli, agent, cm = _cli_with_messages(messages, _outcome(status, messages))
 
-    assert agent.messages == messages
-    agent._emit_context_compressed.assert_not_called()
+        handle_compact_command(cli, "")
 
-
-def test_compact_command_treats_summarization_failure_as_no_change():
-    # compress_messages can return a *new* list (microcompacted copy) without
-    # ever producing a [Conversation Summary] — that must not count as success.
-    messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
-    failed = [dict(m) for m in messages]
-    cli, agent, cm = _cli_with_messages(messages, failed)
-
-    handle_compact_command(cli, "")
-
-    assert agent.messages == messages
-    agent._emit_context_compressed.assert_not_called()
+        assert agent.messages == messages, status
+        agent._emit_context_compressed.assert_not_called()
 
 
 def test_compact_command_skips_short_history():
@@ -79,5 +108,31 @@ def test_compact_command_skips_short_history():
 
     handle_compact_command(cli, "")
 
-    cm.compress_messages.assert_not_called()
+    cm._run_compaction.assert_not_called()
     agent._emit_context_compressed.assert_not_called()
+
+
+def test_compact_command_reports_an_open_breaker_in_words(monkeypatch):
+    """The gate's ``skipped`` outcome reaches the user as a reason.
+
+    Before, an open breaker produced "Compaction made no change — nothing to
+    summarize (or summarization failed; see agentao.log)", which named
+    neither the cause nor the fact that it will keep happening.
+    """
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+    cli, agent, cm = _cli_with_messages(messages)
+    cm.compaction_circuit_open = True
+    cm.circuit_breaker_failures = 3
+    printed: list[str] = []
+    import agentao.cli.commands.compact as mod
+    # Patched through monkeypatch, not by assignment: ``console`` is a shared
+    # module-level singleton, so an unrestored stub here silently rewrites
+    # every other test's console for the rest of the session.
+    monkeypatch.setattr(
+        mod, "console", SimpleNamespace(print=lambda text="", **kw: printed.append(str(text))),
+    )
+
+    handle_compact_command(cli, "")
+
+    cm._run_compaction.assert_not_called()
+    assert any("circuit breaker" in line for line in printed), printed

--- a/tests/test_compaction_circuit_open_no_dispatch.py
+++ b/tests/test_compaction_circuit_open_no_dispatch.py
@@ -1,10 +1,15 @@
 """An open compaction circuit breaker must stop announcing compactions.
 
-Once ``compress_messages`` has failed ``CIRCUIT_BREAKER_LIMIT`` times in a row
-it returns history unchanged. Before this, ``_maybe_full_compress`` still ran
-its whole preamble on every iteration — dispatching ``PreCompact`` (which forks
-a hook subprocess per matching rule) and emitting ``CONTEXT_COMPRESSED`` with
-``pre_msgs == post_msgs`` — for a compaction that could no longer happen.
+Once compaction has failed ``CIRCUIT_BREAKER_LIMIT`` times in a row every
+further attempt returns history unchanged. Before this, ``_maybe_full_compress``
+still ran its whole preamble on every iteration — dispatching ``PreCompact``
+(which forks a hook subprocess per matching rule) and emitting
+``CONTEXT_COMPRESSED`` with ``pre_msgs == post_msgs`` — for a compaction that
+could no longer happen.
+
+The gate now lives in ``CompactionCoordinator``, which is what the
+API-overflow ladder goes through too — so this behaviour reaches the entry
+point that used to lack it entirely.
 
 Pairs with the split-point fix in ``test_context_manager.py``: that one stops
 the breaker from being reached spuriously, this one bounds the cost once it is.
@@ -12,6 +17,7 @@ the breaker from being reached spuriously, this one bounds the cost once it is.
 
 from __future__ import annotations
 
+from agentao.compaction.types import CompactionOutcome
 from agentao.plugins.models import ParsedHookRule
 
 from tests.support.stop_precompact import (
@@ -33,8 +39,25 @@ def _arm(tmp_path, monkeypatch, *, circuit_open: bool):
     cm = agent.context_manager
 
     monkeypatch.setattr(cm, "needs_compression", lambda messages, tokens=None: True)
-    # compress_messages is the no-op an open breaker produces.
-    monkeypatch.setattr(cm, "compress_messages", lambda messages, is_auto=True: messages)
+
+    def _compact(msgs, *, is_auto=True, reason="compression_threshold", decide=None):
+        # Stubbed at the seam that produces the outcome, so the closed-breaker
+        # case exercises a real success rather than asserting on a no-op that
+        # would emit nothing either way.
+        return CompactionOutcome(
+            status="success",
+            trigger="auto" if is_auto else "manual",
+            kind="full",
+            reason=reason,
+            messages=[
+                {"role": "system", "content": "[Compact Boundary | auto=True]"},
+                {"role": "system", "content": "[Conversation Summary]\nx"},
+            ] + msgs[-1:],
+            pre_tokens=100,
+            post_tokens=20,
+        )
+
+    monkeypatch.setattr(cm, "_run_compaction", _compact)
     if circuit_open:
         cm._consecutive_compact_failures = cm.CIRCUIT_BREAKER_LIMIT
 
@@ -59,6 +82,11 @@ def test_open_circuit_skips_precompact_dispatch_and_event(tmp_path, monkeypatch)
     assert not capture.exists(), "PreCompact hook subprocess was forked anyway"
     assert "plugin_hook_fired" not in kinds
     assert "context_compressed" not in kinds
+    # And the terminal event stays silent too. ``skipped`` emits nothing, on
+    # purpose: this gate fires on *every* loop iteration once the breaker is
+    # open, so one event each would be a fresh storm in place of the one this
+    # guard removed.
+    assert "compaction_settled" not in kinds
 
 
 def test_closed_circuit_still_dispatches(tmp_path, monkeypatch):
@@ -67,3 +95,4 @@ def test_closed_circuit_still_dispatches(tmp_path, monkeypatch):
 
     assert capture.exists(), "PreCompact should still fire while the breaker is closed"
     assert "context_compressed" in kinds
+    assert "compaction_settled" in kinds

--- a/tests/test_compaction_coordinator.py
+++ b/tests/test_compaction_coordinator.py
@@ -1,0 +1,404 @@
+"""The coordinator's contract: one outcome per attempt, honest events.
+
+Five entry points used to orchestrate compaction independently, and they
+disagreed about the two things that matter: whether a failure counts, and
+whether "compacted" means history actually changed. These tests pin the
+contract that replaced them —
+
+* every attempt produces one ``CompactionOutcome`` with a ``status``;
+* ``COMPACTION_SETTLED`` fires for ``success | cancelled | failed`` and
+  **never** for ``skipped``, because three of the four skipped cases
+  re-trigger on every loop iteration;
+* ``CONTEXT_COMPRESSED`` fires only on ``success`` — and its payload does not
+  change by a single key.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from agentao.compaction.coordinator import CompactionCoordinator, CompactionRequest
+from agentao.compaction.types import CompactionOutcome
+from agentao.context_manager import ContextManager, PrepareRejected
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+def _make_cm(max_tokens=200_000, memory_manager=None):
+    llm = Mock()
+    llm.logger = Mock()
+    llm.model = "test-model"
+    return ContextManager(
+        llm, Mock(), max_tokens=max_tokens, memory_manager=memory_manager,
+    )
+
+
+def _make_agent(cm, messages):
+    events = []
+    agent = SimpleNamespace(
+        messages=messages,
+        context_manager=cm,
+        transport=SimpleNamespace(emit=events.append),
+        llm=SimpleNamespace(logger=Mock()),
+        _plugin_hook_rules=[],
+        _last_session_summary_id=None,
+        _turn_finish_reason_missing=False,
+        _build_system_prompt=lambda: "sys",
+        _emit_session_summary_if_new=lambda _prev: "summary-id",
+    )
+
+    def _emit_context_compressed(**kw):
+        events.append(SimpleNamespace(type="context_compressed", data=kw))
+
+    agent._emit_context_compressed = _emit_context_compressed
+    agent.compaction_coordinator = CompactionCoordinator(agent)
+    return agent, events
+
+
+def _kinds(events):
+    return [getattr(getattr(e, "type", None), "value", getattr(e, "type", None)) for e in events]
+
+
+def _settled(events):
+    return [e for e in events if _kinds([e])[0] == "compaction_settled"]
+
+
+def _history(n=12):
+    out = []
+    for i in range(n):
+        out.append({"role": "user", "content": f"user {i} " + "x" * 200})
+        out.append({"role": "assistant", "content": f"assistant {i} " + "y" * 200})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# status -> events
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("status", ["success", "cancelled", "failed"])
+def test_every_non_skipped_status_emits_exactly_one_settled_event(status):
+    cm = _make_cm()
+    msgs = _history()
+    agent, events = _make_agent(cm, msgs)
+    result = msgs + [{"role": "user", "content": "new"}] if status == "success" else msgs
+    cm._run_compaction = lambda m, **kw: CompactionOutcome(
+        status=status,
+        trigger="auto",
+        kind="full",
+        reason="compression_threshold",
+        messages=result,
+        pre_tokens=900,
+        post_tokens=100 if status == "success" else None,
+        detail=None if status == "success" else "because",
+    )
+
+    agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"),
+        system_prompt="sys",
+    )
+
+    settled = _settled(events)
+    assert len(settled) == 1
+    payload = settled[0].data
+    assert payload["status"] == status
+    assert payload["kind"] == "full"
+    assert payload["trigger"] == "auto"
+    # CONTEXT_COMPRESSED follows only success.
+    assert ("context_compressed" in _kinds(events)) is (status == "success")
+
+
+def test_skipped_emits_nothing_at_all():
+    """Both skipped cases stay silent — they re-trigger every iteration."""
+    cm = _make_cm()
+
+    # (a) breaker open, kind == full
+    agent, events = _make_agent(cm, _history())
+    cm._consecutive_compact_failures = cm.CIRCUIT_BREAKER_LIMIT
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"),
+        system_prompt="sys",
+    )
+    assert run.outcome.status == "skipped"
+    assert run.outcome.detail == "circuit_open"
+    assert events == []
+
+    # (b) microcompaction with nothing left to clip
+    cm2 = _make_cm()
+    agent2, events2 = _make_agent(cm2, [{"role": "user", "content": "short"}])
+    run2 = agent2.compaction_coordinator.run(
+        CompactionRequest("auto", "microcompact", "microcompact_threshold"),
+        system_prompt="sys",
+    )
+    assert run2.outcome.status == "skipped"
+    assert run2.outcome.detail == "no_microcompact_targets"
+    assert events2 == []
+
+
+def test_success_is_not_inferred_from_message_count():
+    """A successful microcompaction leaves the count identical.
+
+    Gating the event on ``pre_msgs != post_msgs`` would suppress every one of
+    them: ``microcompact_messages`` builds a fresh list element by element and
+    only shortens ``content``.
+    """
+    cm = _make_cm()
+    msgs = [
+        {"role": "user", "content": "go"},
+        {"role": "tool", "name": "read_file", "content": "z" * 50_000},
+        {"role": "assistant", "content": "ok"},
+    ] + [{"role": "tool", "name": "read_file", "content": "small"} for _ in range(6)]
+    agent, events = _make_agent(cm, msgs)
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "microcompact", "microcompact_threshold"),
+        system_prompt="sys",
+        measure_system_tokens=True,
+    )
+
+    assert run.outcome.status == "success"
+    settled = _settled(events)[0].data
+    assert settled["pre_msgs"] == settled["post_msgs"] == len(msgs)
+    assert "context_compressed" in _kinds(events)
+
+
+def test_context_compressed_payload_keys_and_unit_are_unchanged():
+    """The old event's seven keys and both token units stay put.
+
+    Its tokens **include** the system prompt; the new event's
+    ``*_tokens_history`` pair excludes it. Wiring the outcome's history-only
+    numbers into the old field would change a public field's meaning without
+    a schema bump, which is the one thing this split must not do.
+    """
+    cm = _make_cm()
+    msgs = _history()
+    agent, events = _make_agent(cm, msgs)
+    compacted = [{"role": "system", "content": "[Compact Boundary]"}] + msgs[-2:]
+    cm._run_compaction = lambda m, **kw: CompactionOutcome(
+        status="success", trigger="auto", kind="full",
+        reason="compression_threshold", messages=compacted,
+        pre_tokens=111, post_tokens=22,
+    )
+
+    agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"),
+        system_prompt="sys",
+        measure_system_tokens=True,
+    )
+
+    old = [e for e in events if _kinds([e])[0] == "context_compressed"][0].data
+    assert set(old) == {
+        "compression_type", "reason", "pre_msgs", "post_msgs",
+        "pre_tokens", "post_tokens", "duration_ms",
+    }
+    # System-inclusive: measured over ``[system] + messages``, so strictly
+    # larger than the outcome's history-only 111 / 22.
+    assert old["pre_tokens"] > 111
+    assert old["post_tokens"] != 22
+    new = _settled(events)[0].data
+    assert new["pre_tokens_history"] == 111
+    assert new["post_tokens_history"] == 22
+
+
+def test_overflow_rungs_carry_no_tokens_on_the_old_event():
+    """Entries 3 and 4 stay ``null`` — unchanged from before the split.
+
+    Filling them in means two new full-history estimates on precisely the
+    path where the context has already blown up and the request has just
+    been rejected.
+    """
+    cm = _make_cm()
+    msgs = _history()
+    agent, events = _make_agent(cm, msgs)
+    cm._run_compaction = lambda m, **kw: CompactionOutcome(
+        status="success", trigger="auto", kind="full", reason="api_overflow",
+        messages=msgs[-2:], pre_tokens=900, post_tokens=10,
+    )
+
+    agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "api_overflow"),
+        system_prompt="sys",
+        measure_system_tokens=False,
+    )
+
+    old = [e for e in events if _kinds([e])[0] == "context_compressed"][0].data
+    assert old["pre_tokens"] is None
+    assert old["post_tokens"] is None
+
+
+def test_minimal_history_goes_through_context_manager():
+    cm = _make_cm()
+    msgs = _history(4)
+    agent, events = _make_agent(cm, msgs)
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "minimal_history", "api_overflow_after_compression"),
+        system_prompt="sys",
+    )
+
+    assert run.outcome.status == "success"
+    assert agent.messages == msgs[-2:]
+    assert run.outcome.pre_tokens is None and run.outcome.post_tokens is None
+    assert _settled(events)[0].data["kind"] == "minimal_history"
+
+
+def test_apply_minimal_history_is_a_named_seam():
+    cm = _make_cm()
+    msgs = _history(4)
+    assert cm.apply_minimal_history(msgs) == msgs[-2:]
+    assert cm.apply_minimal_history(msgs, keep_tail=5) == msgs[-5:]
+
+
+# ---------------------------------------------------------------------------
+# prepare / commit
+# ---------------------------------------------------------------------------
+
+def test_prepare_rejects_short_history_without_counting_it():
+    cm = _make_cm()
+    prep = cm.prepare_compaction(
+        [{"role": "user", "content": "a"}] * 3,
+        trigger="auto", kind="full", reason="compression_threshold",
+    )
+    assert isinstance(prep, PrepareRejected)
+    assert prep.status == "skipped"
+    assert prep.detail == "history_too_short"
+    assert prep.counts_as_failure is False
+
+
+def test_prepare_writes_nothing_to_the_memory_store():
+    """A cancelled compaction must leave no irreversible trace.
+
+    ``crystallize_user_messages`` used to run *before* summarization, so a
+    summarization that then returned nothing had already written to the
+    store. It belongs to commit now, and this is the assertion that says so.
+    """
+    mem = Mock()
+    cm = _make_cm(memory_manager=mem)
+    prep = cm.prepare_compaction(
+        _history(), trigger="auto", kind="full", reason="compression_threshold",
+    )
+    assert not isinstance(prep, PrepareRejected)
+    mem.crystallize_user_messages.assert_not_called()
+    mem.save_session_summary.assert_not_called()
+
+
+def test_a_failed_summarization_no_longer_crystallizes():
+    """The deliberate behaviour change this split carries.
+
+    Before, crystallize ran at the old line 582 and summarization at 588, so
+    a failed summarization had still written to the store.
+    """
+    mem = Mock()
+    cm = _make_cm(memory_manager=mem)
+    cm._summarize_formatted = lambda _formatted: ""
+
+    out = cm._run_compaction(
+        _history(), is_auto=True, reason="compression_threshold",
+    )
+
+    assert out.status == "failed"
+    assert out.detail == "summary_empty"
+    mem.crystallize_user_messages.assert_not_called()
+    mem.save_session_summary.assert_not_called()
+
+
+def test_a_successful_summarization_still_crystallizes_the_raw_window():
+    mem = Mock()
+    cm = _make_cm(memory_manager=mem)
+    cm._summarize_formatted = lambda _formatted: "a summary"
+
+    out = cm._run_compaction(
+        _history(), is_auto=True, reason="compression_threshold",
+    )
+
+    assert out.status == "success"
+    mem.crystallize_user_messages.assert_called_once()
+    mem.save_session_summary.assert_called_once()
+
+
+def test_an_empty_summary_still_increments_the_failure_counter():
+    """All three counting points live in ``_run_compaction``.
+
+    Putting them in commit would silently lose this one: commit never runs
+    when summarization returns nothing.
+    """
+    cm = _make_cm()
+    cm._summarize_formatted = lambda _formatted: ""
+    assert cm.circuit_breaker_failures == 0
+
+    for expected in (1, 2, 3):
+        cm._run_compaction(_history(), is_auto=True, reason="compression_threshold")
+        assert cm.circuit_breaker_failures == expected
+
+    assert cm.compaction_circuit_open is True
+
+
+def test_pins_appear_once_in_the_result_and_never_in_the_summary_input():
+    cm = _make_cm()
+    msgs = _history()
+    msgs.insert(1, {"role": "user", "content": "[PIN] remember the ticket id"})
+    prep = cm.prepare_compaction(
+        msgs, trigger="auto", kind="full", reason="compression_threshold",
+    )
+    assert not isinstance(prep, PrepareRejected)
+    assert "[PIN] remember the ticket id" not in prep.summary_input
+    assert prep.pinned == [{"role": "user", "content": "[PIN] remember the ticket id"}]
+
+    result = cm.commit_compaction(prep, "a summary")
+    pins = [m for m in result if str(m.get("content", "")).startswith("[PIN]")]
+    assert len(pins) == 1
+
+
+# ---------------------------------------------------------------------------
+# The legacy wrapper
+# ---------------------------------------------------------------------------
+
+def test_legacy_wrapper_keeps_its_gate_and_its_return_shape():
+    cm = _make_cm()
+    cm._consecutive_compact_failures = cm.CIRCUIT_BREAKER_LIMIT
+    msgs = _history()
+    assert cm.compress_messages(msgs) is msgs
+
+
+def test_legacy_wrapper_derives_a_reason_from_is_auto():
+    """It has no ``reason`` parameter — its signature is pinned — so the two
+    values it can mean are mapped one to one."""
+    cm = _make_cm()
+    seen = []
+    cm._run_compaction = lambda m, *, is_auto, reason, decide=None: (
+        seen.append((is_auto, reason))
+        or CompactionOutcome(
+            status="failed", trigger="auto" if is_auto else "manual",
+            kind="full", reason=reason, messages=m,
+        )
+    )
+    msgs = _history()
+    cm.compress_messages(msgs, is_auto=True)
+    cm.compress_messages(msgs, is_auto=False)
+    assert seen == [(True, "compression_threshold"), (False, "manual_cli")]
+
+
+def test_manual_path_does_not_count_a_structural_failure():
+    """Unchanged from before the split: the ``no_safe_split`` exemption.
+
+    Manual ``/compact`` is user-driven and does not loop, so there is no
+    runaway to arrest — and the breaker it would trip disables *automatic*
+    compaction for the rest of the session.
+    """
+    cm = _make_cm()
+    # Every candidate boundary is a tool message, so no safe split exists.
+    msgs = [{"role": "user", "content": "go"}] + [
+        {"role": "tool", "name": "read_file", "content": f"r{i}"} for i in range(10)
+    ]
+    out = cm._run_compaction(msgs, is_auto=False, reason="manual_cli")
+    assert out.status == "failed"
+    assert out.detail == "no_safe_split"
+    assert cm.circuit_breaker_failures == 0
+
+    out = cm._run_compaction(msgs, is_auto=True, reason="compression_threshold")
+    assert out.status == "failed"
+    assert cm.circuit_breaker_failures == 1

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -1032,13 +1032,19 @@ def test_compress_does_not_microcompact_the_half_it_is_about_to_discard():
     summarized = {}
     cm.microcompact_messages = _spy  # type: ignore[method-assign]
 
+    real_format = cm._format_for_summary
+
     def _capture(window):
         summarized["raw"] = "".join(str(x.get("content", "")) for x in window)
-        return ""
+        return real_format(window)
 
-    # ``_summarize_messages`` is what calls ``_format_for_summary``; stub it at
-    # that level so the window it receives is observable.
-    cm._summarize_messages = _capture  # type: ignore[method-assign]
+    # ``prepare_compaction`` assembles the summarizer's input by running
+    # ``_format_for_summary`` over the to-summarize window; spy there so the
+    # window is observable **before** that budget applies, which is the
+    # truncation this test is about. ``_summarize_formatted`` is stubbed only
+    # to keep the LLM out of it.
+    cm._format_for_summary = _capture  # type: ignore[method-assign]
+    cm._summarize_formatted = lambda _formatted: ""  # type: ignore[method-assign]
     cm.compress_messages(msgs, is_auto=True)
 
     assert "contents" in seen, "microcompaction must still run on the kept half"

--- a/tests/test_finish_reason_missing.py
+++ b/tests/test_finish_reason_missing.py
@@ -381,6 +381,26 @@ class TestSdkAssumption:
 # ---------------------------------------------------------------------------
 
 
+def _failed_outcome(msgs, reason):
+    """A compaction that attempted and returned history unchanged.
+
+    The compaction entry points go through ``CompactionCoordinator`` now, so
+    the stub has to sit at ``_run_compaction`` — the seam that produces the
+    outcome — rather than at ``compress_messages``, which is the legacy
+    wrapper and no longer on this path.
+    """
+    from agentao.compaction.types import CompactionOutcome
+
+    return CompactionOutcome(
+        status="failed",
+        trigger="auto" if reason != "manual_cli" else "manual",
+        kind="full",
+        reason=reason,
+        messages=msgs,
+        detail="summary_empty",
+    )
+
+
 class TestDownstreamCoverage:
     def test_compaction_summary_without_finish_reason_flags_the_turn(self):
         """The summarization call bypasses the chat loop's detector.
@@ -394,15 +414,15 @@ class TestDownstreamCoverage:
 
         cm = agent.context_manager
 
-        def _compress(msgs, is_auto=False):
-            # What `_summarize_messages` does when its own provider call ends
+        def _compact(msgs, *, is_auto=True, reason="compression_threshold", decide=None):
+            # What `_summarize_formatted` does when its own provider call ends
             # without a finish_reason. Set *inside* the turn on purpose:
             # `run_turn` clears this attribute at turn start, so seeding it
             # beforehand would prove nothing (and would have hidden the reset).
             cm.last_summary_finish_reason_missing = True
-            return msgs
+            return _failed_outcome(msgs, reason)
 
-        cm.compress_messages = _compress
+        cm._run_compaction = _compact
         cm.needs_compression = lambda *a, **k: True
         cm.needs_microcompaction = lambda *a, **k: False
 
@@ -427,16 +447,19 @@ class TestDownstreamCoverage:
         cm.needs_compression = lambda *a, **k: True
         cm.needs_microcompaction = lambda *a, **k: False
 
-        def _compress_and_flag(msgs, is_auto=False):
+        def _compact_and_flag(msgs, *, is_auto=True, reason="compression_threshold", decide=None):
             cm.last_summary_finish_reason_missing = True
-            return msgs
+            return _failed_outcome(msgs, reason)
 
-        cm.compress_messages = _compress_and_flag
+        cm._run_compaction = _compact_and_flag
         agent.chat("turn one, summary came back truncated")
         assert agent.last_turn.finish_reason_missing is True
 
         # Turn 2 compacts again, but nothing re-summarizes this time.
-        cm.compress_messages = lambda msgs, is_auto=False: msgs
+        cm._run_compaction = (
+            lambda msgs, *, is_auto=True, reason="compression_threshold", decide=None:
+            _failed_outcome(msgs, reason)
+        )
         agent.chat("turn two, nothing new to summarize")
 
         assert agent.last_turn.finish_reason_missing is False

--- a/tests/test_hooks_pre_compact_trigger_provenance.py
+++ b/tests/test_hooks_pre_compact_trigger_provenance.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 
 import json
 import stat
+from types import SimpleNamespace
 
 from agentao.cancellation import CancellationToken
-from agentao.cli.commands.compact import _dispatch_pre_compact as dispatch_manual
+from agentao.cli.commands.compact import handle_compact_command
+from agentao.compaction.types import CompactionOutcome
 from agentao.plugins.models import ParsedHookRule
 from agentao.runtime.chat_loop import ChatLoopRunner
 
@@ -90,14 +92,25 @@ def _neutralize(agent, monkeypatch):
     """Stub the parts of a compaction that need an LLM or a real prompt.
 
     Everything up to and including the hook dispatch stays real — that is
-    what is under test. ``compress_messages`` is the summarizing call and
-    is replaced with the identity, which is also exactly what it returns
-    today on every failure path.
+    what is under test. Only the summarizing transform is replaced, with a
+    ``failed`` outcome: history stays byte-identical, no LLM is reached, and
+    the hook has already fired by the time it is consulted.
     """
     monkeypatch.setattr(agent, "_build_system_prompt", lambda: "")
     monkeypatch.setattr(agent, "_emit_session_summary_if_new", lambda *_a, **_k: None)
     monkeypatch.setattr(
-        agent.context_manager, "compress_messages", lambda msgs, is_auto=True: msgs,
+        agent.context_manager,
+        "_run_compaction",
+        lambda msgs, *, is_auto=True, reason="compression_threshold", decide=None: (
+            CompactionOutcome(
+                status="failed",
+                trigger="auto" if is_auto else "manual",
+                kind="full",
+                reason=reason,
+                messages=msgs,
+                detail="summary_empty",
+            )
+        ),
     )
 
 
@@ -149,8 +162,15 @@ def _drive_overflow(tmp_path, monkeypatch, rules):
 
 
 def _drive_manual(tmp_path, monkeypatch, rules):
+    """The real ``/compact`` handler, through the real coordinator.
+
+    Only the summarizing step is stubbed — as a ``failed`` outcome, so the
+    hook still fires and history stays put.
+    """
     agent, transport = _agent(tmp_path, rules)
-    dispatch_manual(agent)
+    _neutralize(agent, monkeypatch)
+    cli = SimpleNamespace(agent=agent, _cached_ctx_pct=0.0)
+    handle_compact_command(cli, "")
     return transport
 
 

--- a/tests/test_memory_session.py
+++ b/tests/test_memory_session.py
@@ -325,7 +325,7 @@ def test_context_manager_crystallizes_from_raw_user_messages(tmp_path):
     msgs.append({"role": "user", "content": "trailing user msg"})
 
     with patch.object(cm, "estimate_tokens", return_value=150_000):
-        with patch.object(cm, "_summarize_messages", return_value="LLM narration with words like 'I prefer X'"):
+        with patch.object(cm, "_summarize_formatted", return_value="LLM narration with words like 'I prefer X'"):
             cm.compress_messages(msgs)
 
     items = mgr.list_review_items()

--- a/tests/test_replay_redact.py
+++ b/tests/test_replay_redact.py
@@ -344,10 +344,17 @@ def test_recorder_event_line_has_per_event_redaction_hits(tmp_path):
 
 
 def test_header_declares_latest_schema_version():
-    """SCHEMA_VERSION tracks the highest supported version."""
-    from agentao.replay.events import SCHEMA_VERSION
+    """SCHEMA_VERSION tracks the highest supported version.
 
-    assert SCHEMA_VERSION == "1.2"
+    Asserted against ``SUPPORTED_VERSIONS`` rather than a literal: the point
+    is the *relation*, and a literal makes every minor bump edit this test
+    without ever being able to catch the mistake it exists to catch —
+    adding a kind and forgetting the bump.
+    """
+    from agentao.replay.events import SCHEMA_VERSION
+    from agentao.replay.schema import SUPPORTED_VERSIONS
+
+    assert SCHEMA_VERSION == SUPPORTED_VERSIONS[-1]
 
 
 def test_header_records_capture_flags_when_provided(tmp_path):

--- a/tests/test_replay_schema.py
+++ b/tests/test_replay_schema.py
@@ -62,6 +62,7 @@ _VERSION_KINDS = {
     "1.0": EventKind.V1_0,
     "1.1": EventKind.V1_1,
     "1.2": EventKind.V1_2,
+    "1.3": EventKind.V1_3,
 }
 
 


### PR DESCRIPTION
Implements **PR-3** of `docs/design/compaction-orchestration-plan.md` (§4.2, §4.2.1). Second in the plan's dependency order **PR-1 → PR-3 → PR-2 → PR-4**.

> **Stacked on #187.** Review that first; this branch contains it.

## The defect

Compaction was orchestrated in four unrelated places. They disagreed about whether a failure counts and — worse — about whether "compacted" means history actually changed:

- The **API-overflow path emitted `CONTEXT_COMPRESSED` unconditionally**, immediately after `compress_messages`. With the circuit breaker open that call returns the list untouched, so it announced a compaction with `pre_msgs == post_msgs`, no summary and nothing written. PR #181 gave the *threshold* path exactly this treatment; the overflow path was missed.
- **Manual `/compact` inferred success by sniffing `messages[0]`** for a freshly prepended `[Compact Boundary]` marker — a heuristic that existed only because `compress_messages` returns a bare list.
- **The overflow rung rode `compress_messages(is_auto=True)`'s default**, so at the `ContextManager` boundary it was indistinguishable from a threshold compaction — and reported `compression_threshold` two lines after its own hook payload said `api_overflow`.

## What changed

All five entries go through `CompactionCoordinator` and every attempt returns one `CompactionOutcome`:

> `skipped` = nothing was attempted; `failed` = attempted and did not succeed; `cancelled` = vetoed. `skipped` never counts against the breaker.

**`CONTEXT_COMPRESSED` is emitted only on `success`.** This is the one observable change to an existing event, and it is turning a lying event into a truthful one — **its payload does not change by a single key**, and both its token fields keep their system-**inclusive** unit.

**New `COMPACTION_SETTLED`** (replay schema **1.3**) is the terminal event for one attempt whatever the outcome, carrying `trigger` / `kind` / `reason` / `status` / `detail`. Its `pre_tokens_history` / `post_tokens_history` are named apart from the old pair *because they exclude the system prompt* — two units, two names, so they cannot be wired to each other by accident. Both stay `null` on the two overflow rungs and on microcompaction: filling them in means full-history estimates exactly where they cost most.

**`skipped` emits nothing at all.** Three of its four cases re-trigger on every loop iteration, so one event each would replace the storm this design removes with a different one.

**Neither event may be gated on message count.** A successful microcompaction leaves the count identical by construction (`microcompact_messages` builds a fresh list and only shortens `content`), and at `len(messages) == 5` a successful full compaction *raises* it.

### The seam

`compress_messages` splits at the summarization call:

| Phase | Does | Side effects |
|---|---|---|
| `prepare_compaction` | guard, cut point, microcompaction of the surviving half, pinned + recently-read extraction, summary-input assembly | one flag + one log line; **no SQLite write, no touch of `agent.messages`** |
| decide | (the hook / controller step — PR-4 supplies it) | none |
| summarize | `_summarize_formatted` | one LLM request |
| `commit_compaction` | crystallize, session-summary write, message assembly | SQLite + history rewrite |

`_run_compaction` strings them together and owns **all three counting points**. They cannot live in commit (which never runs when summarization returns nothing — today's increment would silently vanish) and cannot live in the coordinator (the legacy `compress_messages` has none in hand).

### Second deliberate behaviour change

**A failed summarization no longer writes to the memory store.** `crystallize_user_messages` ran *before* summarization, so a summarization that then returned nothing had already crystallized. It belongs to commit now — "no irreversible side effect before commit" *is* the definition of that boundary.

### Layering

`ContextManager` neither imports nor holds a coordinator. The shared contract lives in a **standard-library-only** `agentao/compaction/types.py` that both sides import, so both edges point down. `__init__.py` must never re-export `coordinator`: `agentao.host` re-exports the public subset, and dragging `coordinator → context_manager →` the LLM stack in behind it would trip import-layering rule 5.

### Also fixed on the way through

- `minimal_history`'s `messages[-2:]` slice moves behind `ContextManager.apply_minimal_history` — one line, but the ladder's most destructive step now has a named, unit-testable seam instead of a slice buried in an exception handler.
- The duplicated `PreCompact` dispatch in the CLI is gone; one implementation serves all five entries.
- `/compact` reports *why* it made no change (open breaker / too little history / no safe split / empty summary) instead of one catch-all sentence.

## Compatibility

`ContextManager.compress_messages()` keeps its signature, its return type and its breaker gate — documented in its docstring and pinned by a test that calls it directly. It is now a thin wrapper. It returns a bare list, so it cannot say why nothing changed, and it bypasses the host control plane and the breaker's probe policy; new code goes through the coordinator.

`schema_version` on `AgentEvent` does **not** move: no field of `CONTEXT_COMPRESSED` changes shape or meaning, and adding a new event type is not such a change. The **replay** schema does bump — 1.2 → 1.3 — because a new `EventKind` is a minor bump under `docs/reference/replay-schema-policy.md`; 1.0/1.1/1.2 are byte-identical and stay frozen.

## Deviation from the plan, stated

The plan reserves the `cancel` / host-summary branches of `_run_compaction` for PR-4. They are implemented here instead: leaving a `decide` parameter whose `cancel` return is not honoured is a worse half-state than a slightly larger PR, and §4.2's status table is explicitly "pinned before PR-3, because it is a publicly observable contract". **No caller supplies `decide`** — that, the hook decision protocol, `compaction_controller=`, the suppression latch and the entry-point cancellation semantics all remain PR-4's.

Replay projection for `COMPACTION_SETTLED` is also not in the plan's PR-3 list. It is here because without it PR-3 would *remove* audit records (the overflow path's unconditional `CONTEXT_COMPRESSED`) without adding the replacement.

## Gates

`uv run ruff check .` clean. `uv run python scripts/write_replay_schema.py --check` clean. `uv run python -m pytest tests/` — **4063 passed, 1 skipped**, no failures.

New: `tests/test_compaction_coordinator.py` (18 tests) covering the status → event mapping, the silent `skipped` rule, "success is not a message count", `CONTEXT_COMPRESSED`'s frozen key set and unit, the prepare/commit boundary and both crystallize behaviours, the three counting points, `[PIN]` appearing exactly once and never in the summary input, and the legacy wrapper's gate and `reason` mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
