### PR TITLE
compact: make the circuit breaker recoverable (PR-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,52 @@ _Targeting 0.4.20. Add entries under the relevant heading as work lands._
 
 ### Changed
 
+- **The compaction circuit breaker is recoverable.** It was a one-way latch:
+  three consecutive failures set a counter, the counter's only reset was a
+  successful compaction, and the short-circuit sat *above* every branch — so
+  the one action a user could take to recover, `/compact`, was itself blocked.
+  `/clear` did not help either; it clears messages, skills, todos, the token
+  anchor and the token counters, but never the failure count. A session that
+  tripped it could not auto-compact again, at all, ever.
+
+  Now three failures pause the **threshold** tier only. Manual `/compact` and
+  an API overflow run as **half-open probes** — neither is what the breaker
+  describes, which is "stop re-entering every iteration", and blocking an
+  overflow leaves the recovery ladder with nothing to fall back on but
+  `messages[-2:]`. A successful probe closes the breaker immediately; a
+  failed one leaves it exactly as it was.
+
+  **`/clear` now closes it too** (via `ContextManager.reset_compaction_circuit()`,
+  called from `clear_history()`): the count measures *this* conversation's
+  failures, so replacing the conversation invalidates the evidence behind it.
+
+  **Behaviour change: a failed summarization on the manual path no longer
+  counts.** The increment was unconditional, so three manual retries could
+  disable automatic compaction for the rest of the session. It now carries the
+  same `is_auto` exemption the structural-failure path already had, for the
+  same stated reason — a user-driven compaction does not loop, so there is no
+  runaway to arrest.
+
+- **`/context` reports the breaker as a state, not a tally.** It showed
+  `Compact failures: 3/3 (circuit open — auto-compact disabled)`, which was
+  true and useless. It now names the state (`open` / `closed`), the class of
+  the last failure (`no_safe_split` / `summary_empty` — they need different
+  answers), and how to get out of it. `get_usage_stats()` gains
+  `circuit_breaker_open` and `last_compaction_failure`; the existing
+  `circuit_breaker_failures` key is unchanged.
+
+### Added
+
+- **`Agentao.compact(*, reason="manual_cli") -> CompactionOutcome`** — the
+  public compaction entry. There was none: all three call sites reached
+  straight into `context_manager`, which is how five entry points came to
+  disagree about what a compaction had done. `reason` selects which policy
+  applies — `manual_cli` and `api_overflow` probe through an open breaker,
+  `compression_threshold` is paused by it — and the returned outcome says
+  `success | cancelled | failed | skipped` with a `detail`. History is
+  byte-identical on every status but `success`.
+
+
 - **All five compaction entry points now go through one `CompactionCoordinator`,
   and every attempt returns one `CompactionOutcome`.** Microcompaction, the
   threshold tier, both rungs of the API-overflow ladder and manual `/compact`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,14 @@ SQLite writes and the new list). `_run_compaction` strings those together and
 owns all three failure-counting points — they cannot live in commit, which
 never runs when summarization returns nothing.
 
+**The circuit breaker is a recoverable state machine, and its state stays in
+`ContextManager`.** Three consecutive *automatic* failures pause the threshold
+tier; manual `/compact` and `api_overflow` run as half-open **probes** through
+an open breaker (`_PROBE_REASONS` in `coordinator.py`), and a successful probe
+closes it. `clear_history()` / `/clear` closes it too. The coordinator only
+applies policy — it never touches the counter. `Agentao.compact()` is the
+public entry.
+
 **`skipped` emits no event.** Three of its four cases re-trigger on every loop
 iteration; one event each would be a storm. `CONTEXT_COMPRESSED` fires only on
 `success`; `COMPACTION_SETTLED` fires for `success | cancelled | failed`.

--- a/agentao/agent.py
+++ b/agentao/agent.py
@@ -38,6 +38,7 @@ from .sandbox import SandboxPolicy
 from .transport import NullTransport, build_compat_transport
 
 if TYPE_CHECKING:
+    from .compaction.types import CompactionOutcome
     from .agents.bg_store import BackgroundTaskStore  # noqa: F401
     from .capabilities import FileSystem, MCPRegistry, ShellExecutor
     from .mcp import McpClientManager  # type-only; MCP SDK is heavy
@@ -1132,6 +1133,34 @@ class Agentao:
             self._compaction_coordinator = CompactionCoordinator(self)
         return self._compaction_coordinator
 
+    def compact(self, *, reason: str = "manual_cli") -> "CompactionOutcome":
+        """Compact conversation history now, and say what happened.
+
+        The public compaction entry. Before it existed every caller reached
+        straight into ``context_manager``, which is how five entry points came
+        to disagree about what a compaction had done — a bare list cannot say
+        whether it changed, why it did not, or whether the failure counted.
+
+        ``reason`` picks which entry point this is on behalf of and therefore
+        which policy applies: ``manual_cli`` (the default) and
+        ``api_overflow`` are allowed through an open circuit breaker as
+        half-open probes, ``compression_threshold`` is not.
+
+        Returns the :class:`~agentao.compaction.types.CompactionOutcome`;
+        ``outcome.status`` is ``success | cancelled | failed | skipped`` and
+        ``outcome.detail`` says which case. History is left byte-identical on
+        every status but ``success``.
+        """
+        from .compaction.coordinator import CompactionRequest
+        run = self.compaction_coordinator.run(
+            CompactionRequest(
+                "manual" if reason == "manual_cli" else "auto", "full", reason,
+            ),
+            system_prompt=self._build_system_prompt(),
+            measure_system_tokens=True,
+        )
+        return run.outcome
+
     def _emit_context_compressed(
         self,
         *,
@@ -1183,6 +1212,12 @@ class Agentao:
         self.todo_tool.clear()
         # Reset context and session token counters for the fresh session
         self.context_manager.invalidate_token_anchor()
+        # The compaction breaker counts *this* conversation's failures, so
+        # replacing the conversation invalidates its evidence. Without this a
+        # session that tripped it stayed unable to auto-compact across
+        # ``/clear``, because the only other reset is a successful compaction
+        # and the open breaker is what prevents one on the automatic path.
+        self.context_manager.reset_compaction_circuit()
         self.llm.total_prompt_tokens = 0
         self.llm.total_completion_tokens = 0
 

--- a/agentao/cli/commands/compact.py
+++ b/agentao/cli/commands/compact.py
@@ -31,11 +31,10 @@ _MIN_MESSAGES_TO_COMPACT = 5
 
 # Why nothing happened, in the user's terms. ``detail`` values come from
 # ``CompactionOutcome``; anything unlisted falls back to the log pointer.
+# ``circuit_open`` is deliberately absent: an open breaker no longer blocks
+# this command. ``/compact`` is a half-open probe — user-driven, non-looping,
+# and the one action a user can take to close the breaker again.
 _FAILURE_HINTS = {
-    "circuit_open": (
-        "auto-compaction is disabled after repeated failures "
-        "(circuit breaker open)"
-    ),
     "history_too_short": "there is not enough history to summarize yet",
     "no_safe_split": (
         "no safe split point — every candidate boundary would orphan a tool "
@@ -69,8 +68,18 @@ def handle_compact_command(cli: AgentaoCLI, args: str) -> None:
     if outcome.status != "success":
         hint = _FAILURE_HINTS.get(outcome.detail or "")
         detail = f" — {hint}" if hint else " (see agentao.log)"
+        note = ""
+        if cm.compaction_circuit_open:
+            # The probe was allowed and did not succeed, so nothing closed
+            # the breaker. Say so, or the user reads "no change" and has no
+            # idea automatic compaction is still paused.
+            note = (
+                "\n[dim]The compaction circuit breaker is still open — "
+                "automatic compaction stays paused until a compaction "
+                "succeeds (or /clear).[/dim]"
+            )
         console.print(
-            f"\n[warning]Compaction made no change{detail}.[/warning]\n"
+            f"\n[warning]Compaction made no change{detail}.[/warning]{note}\n"
         )
         return
 

--- a/agentao/cli/commands/context.py
+++ b/agentao/cli/commands/context.py
@@ -32,12 +32,26 @@ def handle_context_command(cli: AgentaoCLI, args: str) -> None:
 
         failures = stats.get("circuit_breaker_failures", 0)
         if failures > 0:
-            fb_color = "yellow" if failures < cm.CIRCUIT_BREAKER_LIMIT else "red"
+            is_open = stats.get("circuit_breaker_open", failures >= cm.CIRCUIT_BREAKER_LIMIT)
+            fb_color = "red" if is_open else "yellow"
+            state = "open" if is_open else "closed"
+            why = stats.get("last_compaction_failure")
             console.print(
-                f"  Compact failures: [{fb_color}]{failures}/{cm.CIRCUIT_BREAKER_LIMIT}[/{fb_color}]"
-                + (" [dim](circuit open — auto-compact disabled)[/dim]"
-                   if failures >= cm.CIRCUIT_BREAKER_LIMIT else "")
+                f"  Compact breaker:  [{fb_color}]{state}[/{fb_color}] "
+                f"[dim]({failures}/{cm.CIRCUIT_BREAKER_LIMIT} consecutive failures"
+                + (f", last: {why}" if why else "")
+                + ")[/dim]"
             )
+            if is_open:
+                # Say how to get out of it. The old line said "auto-compact
+                # disabled" and stopped there, which was true and useless:
+                # the state is recoverable and the user is the one who can
+                # recover it.
+                console.print(
+                    "  [dim]                  automatic compaction is paused; "
+                    "/compact runs as a probe and a success resets it "
+                    "(so does /clear)[/dim]"
+                )
 
         lc = stats.get("last_compact")
         if lc:

--- a/agentao/compaction/coordinator.py
+++ b/agentao/compaction/coordinator.py
@@ -35,6 +35,14 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from ..agent import Agentao
 
 
+#: Reasons allowed through an open breaker as a half-open probe. Both are
+#: outside what the breaker describes: it exists to stop the *threshold* tier
+#: re-entering every iteration. Manual compaction is user-driven and does not
+#: loop; an API overflow has already been rejected by the provider, so
+#: blocking it leaves the recovery ladder with nothing but ``messages[-2:]``.
+_PROBE_REASONS = frozenset({"manual_cli", "api_overflow"})
+
+
 @dataclass(frozen=True)
 class CompactionRequest:
     """Which compaction is being asked for.
@@ -222,22 +230,35 @@ class CompactionCoordinator:
         cm = agent.context_manager
 
         if request.kind == "full" and cm.compaction_circuit_open:
-            # Announcing this would fork a PreCompact hook subprocess per
-            # iteration for something that never happens, and emit a
-            # CONTEXT_COMPRESSED reporting pre == post. Stand down and let
-            # the API-overflow recovery path own it from here.
-            #
-            # Still log it: standing down before the transform skips the
-            # breaker warning it used to emit, and that line is the only
-            # signal that auto-compaction is dead for the rest of the session
-            # (the counter has no reset path).
-            self._warn(
-                "Compact circuit breaker open "
-                f"({cm.circuit_breaker_failures} consecutive failures) — "
-                "skipping compaction; context stays over threshold until the "
-                "API-overflow path recovers it"
-            )
-            return self._skipped(request, "circuit_open")
+            if request.reason in _PROBE_REASONS:
+                # Half-open. The breaker describes *threshold* behaviour —
+                # "stop re-entering every iteration" — and neither of these
+                # is that. Manual compaction is user-driven and does not
+                # loop; an API overflow has already happened, so blocking it
+                # leaves the ladder with nothing to fall back on but
+                # ``messages[-2:]``. One attempt is allowed; a success
+                # closes the breaker (``_run_compaction`` resets on commit),
+                # a failure leaves it exactly as it was.
+                self._info(
+                    f"Compact circuit breaker open ({cm.circuit_breaker_failures} "
+                    f"consecutive failures) — allowing {request.reason} as a probe"
+                )
+            else:
+                # Announcing this would fork a PreCompact hook subprocess per
+                # iteration for something that never happens, and emit a
+                # CONTEXT_COMPRESSED reporting pre == post. Stand down and let
+                # the probes above own recovery from here.
+                #
+                # Still log it: standing down before the transform skips the
+                # breaker warning it used to emit, and that line is the only
+                # signal that automatic compaction is paused.
+                self._warn(
+                    "Compact circuit breaker open "
+                    f"({cm.circuit_breaker_failures} consecutive failures) — "
+                    "pausing automatic compaction; /compact or an API overflow "
+                    "runs as a probe and a success resets it"
+                )
+                return self._skipped(request, "circuit_open")
 
         if request.kind == "microcompact" and not cm.microcompact_would_mutate(
             agent.messages

--- a/agentao/context_manager.py
+++ b/agentao/context_manager.py
@@ -160,6 +160,13 @@ class ContextManager:
         # Circuit breaker: stop auto-compact after too many consecutive failures
         self._consecutive_compact_failures: int = 0
 
+        # Why the last counted failure happened ("no_safe_split" /
+        # "summary_empty" / …). The count alone tells a user that compaction
+        # stopped but not what to do about it, and the two classes need
+        # different answers: a structural failure will recur until history
+        # changes, an empty summary is usually the provider.
+        self.last_compaction_failure: Optional[str] = None
+
         # True when the most recent ``_summarize_messages`` call ended without
         # the provider reporting a finish_reason. That call does not go through
         # ``ChatLoopRunner`` — it is issued straight against ``llm_client`` —
@@ -488,6 +495,18 @@ class ContextManager:
     # -----------------------------------------------------------------------
     # Full compression
     # -----------------------------------------------------------------------
+
+    def reset_compaction_circuit(self) -> None:
+        """Close the breaker and forget the last failure class.
+
+        The counter measures *this* conversation's compaction failures, so
+        anything that replaces the conversation invalidates the evidence
+        behind it. Before this existed the only reset was a successful
+        compaction — which the open breaker itself prevented on the automatic
+        path, so ``/clear`` left a session permanently unable to auto-compact.
+        """
+        self._consecutive_compact_failures = 0
+        self.last_compaction_failure = None
 
     @property
     def circuit_breaker_failures(self) -> int:
@@ -899,6 +918,7 @@ class ContextManager:
                 # rest of the session with no reset path.
                 if is_auto:
                     self._consecutive_compact_failures += 1
+                    self.last_compaction_failure = prep.detail
                     tally = f" ({self._consecutive_compact_failures} consecutive failures)"
                 else:
                     # The manual path does not increment, so reporting the
@@ -994,7 +1014,15 @@ class ContextManager:
             internal_reason = (
                 f"{internal_reason}+summary_empty" if internal_reason else "summary_empty"
             )
-            self._consecutive_compact_failures += 1
+            # Same exemption the structural failure above has, and for the
+            # same reason: a user-driven compaction does not loop, so there
+            # is no runaway to arrest — and the breaker it would trip pauses
+            # *automatic* compaction, which is not the thing that just
+            # failed. This increment used to be unconditional, which is how
+            # three manual retries could disable auto-compaction.
+            if is_auto:
+                self._consecutive_compact_failures += 1
+                self.last_compaction_failure = internal_reason
             return CompactionOutcome(
                 status="failed",
                 trigger=trigger,
@@ -1007,7 +1035,7 @@ class ContextManager:
             )
 
         result = self.commit_compaction(prep, summary)
-        self._consecutive_compact_failures = 0  # reset on success
+        self.reset_compaction_circuit()  # a success closes the breaker
         return CompactionOutcome(
             status="success",
             trigger=trigger,
@@ -1599,6 +1627,8 @@ class ContextManager:
             "message_count": len(messages),
             "token_breakdown": breakdown,
             "circuit_breaker_failures": self._consecutive_compact_failures,
+            "circuit_breaker_open": self.compaction_circuit_open,
+            "last_compaction_failure": self.last_compaction_failure,
         }
         if self._last_compact_stats:
             stats["last_compact"] = self._last_compact_stats

--- a/docs/reference/host-api.md
+++ b/docs/reference/host-api.md
@@ -127,6 +127,31 @@ v1 supports calling these methods **between** turns only (not from a concurrent
 task, nor from inside a tool's `execute()` mid-turn — see
 [`runtime-tool-injection.md`](../design/runtime-tool-injection.md) §7).
 
+## Compaction (`Agentao.compact`)
+
+```python
+outcome = agent.compact()                              # a manual compaction
+outcome = agent.compact(reason="api_overflow")         # on behalf of the ladder
+```
+
+Returns a `CompactionOutcome`
+(`agentao.compaction.types`) — `status` is
+`success | cancelled | failed | skipped`, with `detail` naming the case
+(`circuit_open`, `history_too_short`, `no_safe_split`, `summary_empty`, …).
+**History is byte-identical on every status but `success`.** Both token
+fields exclude the system prompt and are `None` where no estimate exists.
+
+`reason` selects which policy applies, not just a label. `manual_cli` (the
+default) and `api_overflow` are allowed through an open circuit breaker as
+half-open probes; `compression_threshold` is paused by it.
+
+**`ContextManager.compress_messages()` is an internal transform, not this.**
+It keeps its signature and its return type, but it hands back a bare list —
+it cannot tell you whether anything changed or why it did not — and it
+bypasses both the host control plane (`PreCompact` dispatch) and the
+breaker's probe policy. It is not deprecated; it is simply the wrong level
+for host code.
+
 ## Capability protocols (`agentao.host.protocols`)
 
 Embedded hosts override IO by injecting these `Protocol` types into

--- a/docs/reference/host-api.zh.md
+++ b/docs/reference/host-api.zh.md
@@ -89,6 +89,28 @@ if isinstance(ev, SubagentLifecycleEvent) and ev.phase == "failed":
 同步变化，所以 `check_background_agent` 对"没答出来"同样报 `failed`
 ——并且会把这次跑出来的部分结果一并带上。
 
+## 压缩（`Agentao.compact`）
+
+```python
+outcome = agent.compact()                              # 一次手动压缩
+outcome = agent.compact(reason="api_overflow")         # 代表溢出恢复阶梯
+```
+
+返回 `CompactionOutcome`（`agentao.compaction.types`）—— `status` 取
+`success | cancelled | failed | skipped`，`detail` 指明具体是哪一种
+（`circuit_open`、`history_too_short`、`no_safe_split`、`summary_empty` …）。
+**除 `success` 外，任何状态下历史都逐字节不变。** 两个 token 字段都**不含**
+system prompt，没有估算的路径上为 `None`。
+
+`reason` 选的是**适用哪条策略**，不只是一个标签：`manual_cli`（默认）与
+`api_overflow` 会以半开探针的身份穿过已打开的熔断器；`compression_threshold`
+则被它暂停。
+
+**`ContextManager.compress_messages()` 是内部变换，不是这个。** 它的签名和返回
+类型都保留，但它只交回一个裸列表——说不出有没有变、也说不出为什么没变——而且
+**绕过** host 控制面（`PreCompact` 分发）与熔断器的探针策略。它没有被废弃，只是
+对 host 代码来说层级不对。
+
 ## 能力协议（`agentao.host.protocols`）
 
 嵌入宿主通过向 `Agentao(filesystem=..., shell=..., mcp_registry=..., memory_manager=...)`

--- a/tests/test_compact_command.py
+++ b/tests/test_compact_command.py
@@ -112,15 +112,32 @@ def test_compact_command_skips_short_history():
     agent._emit_context_compressed.assert_not_called()
 
 
-def test_compact_command_reports_an_open_breaker_in_words(monkeypatch):
-    """The gate's ``skipped`` outcome reaches the user as a reason.
+def test_compact_runs_as_a_probe_through_an_open_breaker(monkeypatch):
+    """An open breaker must not block the one action that can close it.
 
-    Before, an open breaker produced "Compaction made no change — nothing to
-    summarize (or summarization failed; see agentao.log)", which named
-    neither the cause nor the fact that it will keep happening.
+    The breaker exists to stop the *threshold* tier re-entering every
+    iteration. Manual ``/compact`` is user-driven and does not loop, so
+    blocking it left the user with no way back: the only other reset is a
+    successful compaction, and the open breaker is what prevents one.
     """
     messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
-    cli, agent, cm = _cli_with_messages(messages)
+    compacted = [{"role": "system", "content": "[Compact Boundary]"}] + messages[-2:]
+    cli, agent, cm = _cli_with_messages(
+        messages, _outcome("success", compacted, pre_tokens=900, post_tokens=100),
+    )
+    cm.compaction_circuit_open = True
+    cm.circuit_breaker_failures = 3
+
+    handle_compact_command(cli, "")
+
+    cm._run_compaction.assert_called_once()
+    assert agent.messages == compacted
+
+
+def test_a_failed_probe_says_the_breaker_is_still_open(monkeypatch):
+    """Otherwise "no change" hides that automatic compaction stays paused."""
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+    cli, agent, cm = _cli_with_messages(messages, _outcome("failed", messages))
     cm.compaction_circuit_open = True
     cm.circuit_breaker_failures = 3
     printed: list[str] = []
@@ -134,5 +151,4 @@ def test_compact_command_reports_an_open_breaker_in_words(monkeypatch):
 
     handle_compact_command(cli, "")
 
-    cm._run_compaction.assert_not_called()
-    assert any("circuit breaker" in line for line in printed), printed
+    assert any("circuit breaker is still open" in line for line in printed), printed

--- a/tests/test_compaction_circuit_recovery.py
+++ b/tests/test_compaction_circuit_recovery.py
@@ -1,0 +1,277 @@
+"""The compaction circuit breaker is a recoverable state machine.
+
+It used to be a one-way latch. Three consecutive failures set a counter, the
+counter's only reset was a successful compaction, and the short-circuit sat
+*above* every branch — including the manual one — so the single action a user
+could take to recover was itself blocked. ``/clear`` did not help either: it
+clears messages, skills, todos, the token anchor and the token counters, but
+never the failure count.
+
+What replaces it:
+
+* three failures pause the **threshold** tier only;
+* manual ``/compact`` and an API overflow are allowed through as half-open
+  probes — neither is what the breaker describes;
+* a successful probe closes it, a failed one leaves it exactly as it was;
+* ``/clear`` closes it, because the count measures a conversation that no
+  longer exists;
+* and a failed summarization on the manual path stops counting at all.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from agentao.compaction.coordinator import CompactionCoordinator, CompactionRequest
+from agentao.context_manager import ContextManager
+
+
+def _make_cm(max_tokens=200_000):
+    llm = Mock()
+    llm.logger = Mock()
+    llm.model = "test-model"
+    return ContextManager(llm, Mock(), max_tokens=max_tokens)
+
+
+def _history(n=12):
+    out = []
+    for i in range(n):
+        out.append({"role": "user", "content": f"user {i} " + "x" * 200})
+        out.append({"role": "assistant", "content": f"assistant {i} " + "y" * 200})
+    return out
+
+
+def _agent(cm, messages):
+    events = []
+    agent = SimpleNamespace(
+        messages=messages,
+        context_manager=cm,
+        transport=SimpleNamespace(emit=events.append),
+        llm=SimpleNamespace(logger=Mock()),
+        _plugin_hook_rules=[],
+        _last_session_summary_id=None,
+        _turn_finish_reason_missing=False,
+        _build_system_prompt=lambda: "sys",
+        _emit_session_summary_if_new=lambda _prev: None,
+        _emit_context_compressed=lambda **kw: events.append(
+            SimpleNamespace(type="context_compressed", data=kw)
+        ),
+    )
+    agent.compaction_coordinator = CompactionCoordinator(agent)
+    return agent, events
+
+
+def _trip(cm):
+    """Three consecutive failed summarizations on the automatic path."""
+    cm._summarize_formatted = lambda _f: ""
+    for _ in range(cm.CIRCUIT_BREAKER_LIMIT):
+        cm._run_compaction(_history(), is_auto=True, reason="compression_threshold")
+    assert cm.compaction_circuit_open is True
+
+
+# ---------------------------------------------------------------------------
+# Who is paused and who probes
+# ---------------------------------------------------------------------------
+
+def test_threshold_attempts_pause_once_the_breaker_is_open():
+    cm = _make_cm()
+    _trip(cm)
+    agent, events = _agent(cm, _history())
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"),
+        system_prompt="sys",
+    )
+
+    assert run.outcome.status == "skipped"
+    assert run.outcome.detail == "circuit_open"
+    assert events == []
+
+
+@pytest.mark.parametrize(
+    "trigger,reason",
+    [("manual", "manual_cli"), ("auto", "api_overflow")],
+)
+def test_manual_and_overflow_are_allowed_through_as_probes(trigger, reason):
+    cm = _make_cm()
+    _trip(cm)
+    cm._summarize_formatted = lambda _f: "a fresh summary"
+    agent, events = _agent(cm, _history())
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest(trigger, "full", reason),
+        system_prompt="sys",
+    )
+
+    assert run.outcome.status == "success", run.outcome.detail
+    # A successful probe closes the breaker immediately.
+    assert cm.compaction_circuit_open is False
+    assert cm.circuit_breaker_failures == 0
+    assert cm.last_compaction_failure is None
+
+
+def test_a_failed_probe_leaves_the_breaker_exactly_as_it_was():
+    cm = _make_cm()
+    _trip(cm)
+    before = cm.circuit_breaker_failures
+    agent, _events = _agent(cm, _history())
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("manual", "full", "manual_cli"),
+        system_prompt="sys",
+    )
+
+    assert run.outcome.status == "failed"
+    assert cm.compaction_circuit_open is True
+    # Not incremented either: the manual path does not count failures.
+    assert cm.circuit_breaker_failures == before
+
+
+def test_threshold_resumes_after_a_probe_succeeds():
+    """The whole point — the pause has to be exitable."""
+    cm = _make_cm()
+    _trip(cm)
+    agent, _events = _agent(cm, _history())
+
+    paused = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"),
+        system_prompt="sys",
+    )
+    assert paused.outcome.status == "skipped"
+
+    cm._summarize_formatted = lambda _f: "a fresh summary"
+    probe = agent.compaction_coordinator.run(
+        CompactionRequest("manual", "full", "manual_cli"), system_prompt="sys",
+    )
+    assert probe.outcome.status == "success"
+
+    agent.messages = _history()
+    resumed = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"),
+        system_prompt="sys",
+    )
+    assert resumed.outcome.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# Counting
+# ---------------------------------------------------------------------------
+
+def test_a_manual_summarization_failure_no_longer_counts():
+    """The deliberate behaviour change: the ``:590`` increment was
+    unconditional, so three manual retries disabled automatic compaction."""
+    cm = _make_cm()
+    cm._summarize_formatted = lambda _f: ""
+
+    for _ in range(cm.CIRCUIT_BREAKER_LIMIT + 2):
+        out = cm._run_compaction(_history(), is_auto=False, reason="manual_cli")
+        assert out.status == "failed"
+
+    assert cm.circuit_breaker_failures == 0
+    assert cm.compaction_circuit_open is False
+
+
+def test_an_automatic_summarization_failure_still_counts_and_is_classified():
+    cm = _make_cm()
+    cm._summarize_formatted = lambda _f: ""
+
+    cm._run_compaction(_history(), is_auto=True, reason="compression_threshold")
+
+    assert cm.circuit_breaker_failures == 1
+    assert cm.last_compaction_failure == "summary_empty"
+
+
+def test_a_structural_failure_is_classified_separately():
+    cm = _make_cm()
+    msgs = [{"role": "user", "content": "go"}] + [
+        {"role": "tool", "name": "read_file", "content": f"r{i}"} for i in range(10)
+    ]
+
+    cm._run_compaction(msgs, is_auto=True, reason="compression_threshold")
+
+    assert cm.circuit_breaker_failures == 1
+    assert cm.last_compaction_failure == "no_safe_split"
+
+
+# ---------------------------------------------------------------------------
+# Reset paths
+# ---------------------------------------------------------------------------
+
+def test_reset_closes_the_breaker_and_forgets_the_class():
+    cm = _make_cm()
+    _trip(cm)
+    assert cm.last_compaction_failure == "summary_empty"
+
+    cm.reset_compaction_circuit()
+
+    assert cm.compaction_circuit_open is False
+    assert cm.circuit_breaker_failures == 0
+    assert cm.last_compaction_failure is None
+
+
+def test_clear_history_closes_the_breaker(tmp_path):
+    """``/clear`` reaches it through ``clear_history``.
+
+    The counter measures *this* conversation's failures, so replacing the
+    conversation invalidates the evidence behind it. Before, a session that
+    tripped the breaker stayed unable to auto-compact across ``/clear``.
+    """
+    from tests.support.stop_precompact import make_bare_agent
+
+    agent = make_bare_agent(tmp_path)
+    cm = agent.context_manager
+    _trip(cm)
+
+    agent.clear_history()
+
+    assert cm.compaction_circuit_open is False
+    assert cm.last_compaction_failure is None
+
+
+def test_usage_stats_exports_the_state_and_the_class():
+    cm = _make_cm()
+    _trip(cm)
+
+    stats = cm.get_usage_stats(_history())
+
+    assert stats["circuit_breaker_failures"] == cm.CIRCUIT_BREAKER_LIMIT
+    assert stats["circuit_breaker_open"] is True
+    assert stats["last_compaction_failure"] == "summary_empty"
+
+
+# ---------------------------------------------------------------------------
+# The public entry
+# ---------------------------------------------------------------------------
+
+def test_agent_compact_returns_an_outcome(tmp_path):
+    from tests.support.stop_precompact import make_bare_agent
+
+    agent = make_bare_agent(tmp_path)
+    agent.messages = _history()
+    agent.context_manager._summarize_formatted = lambda _f: "a summary"
+
+    outcome = agent.compact()
+
+    assert outcome.status == "success"
+    assert outcome.trigger == "manual"
+    assert outcome.kind == "full"
+    assert outcome.reason == "manual_cli"
+    assert agent.messages == outcome.messages
+
+
+def test_agent_compact_reports_a_paused_breaker_rather_than_raising(tmp_path):
+    from tests.support.stop_precompact import make_bare_agent
+
+    agent = make_bare_agent(tmp_path)
+    agent.messages = _history()
+    _trip(agent.context_manager)
+
+    # The threshold reason is the paused one; the default manual_cli probes.
+    outcome = agent.compact(reason="compression_threshold")
+
+    assert outcome.status == "skipped"
+    assert outcome.detail == "circuit_open"
+    assert outcome.messages is agent.messages


### PR DESCRIPTION
Implements **PR-2** of `docs/design/compaction-orchestration-plan.md` (§4.3). Third in the plan's dependency order **PR-1 → PR-3 → PR-2 → PR-4** — it comes after PR-3 because making overflow an emergency probe requires the coordinator to know it *is* overflow, and before PR-3 it could not.

> **Stacked on #188** (which is stacked on #187). Review those first; this branch contains both.

## The defect

The compaction circuit breaker was a **one-way latch**:

- Three consecutive failures set `_consecutive_compact_failures`.
- Its only reset was a successful compaction (`context_manager.py:593`).
- The short-circuit sat at `:507`, **above every `is_auto` branch** — so manual `/compact`, the one action a user could take to recover, was blocked by the very state it would have cleared.
- `/clear` did not help: `clear_history()` clears messages, skills, todos, the token anchor and the token counters, and never touched the count.

A session that tripped it could not auto-compact again, at all, for the rest of its life. This is the second of the two P1s from `docs/design/pi-mono-compaction-vs-agentao.md` (§9.2, "the circuit breaker has no reset path").

## What changed

**Three failures pause the *threshold* tier only.** Manual `/compact` and `api_overflow` run as **half-open probes**. Neither is what the breaker describes — it exists to stop the threshold tier re-entering every iteration. Manual compaction is user-driven and does not loop; an overflow has already been rejected by the provider, so blocking it leaves the recovery ladder with nothing to fall back on but `messages[-2:]`.

**A successful probe closes the breaker immediately; a failed one leaves it exactly as it was** — not incremented, not escalated.

**`/clear` closes it**, through a new public `ContextManager.reset_compaction_circuit()` called from `clear_history()`. The count measures *this* conversation's failures, so replacing the conversation invalidates the evidence behind it. Putting it in `clear_history()` rather than in `/clear` means an embedded host gets the same behaviour.

### Behaviour change

**A failed summarization on the manual path no longer counts.** That increment (`:590`) was unconditional while the structural-failure increment (`:540`) was already `is_auto`-gated — so three manual retries could disable automatic compaction for the session. It now carries the same exemption, for the reason `:535-539` already gave: a user-driven compaction does not loop, so there is no runaway to arrest, and the breaker it would trip pauses *automatic* compaction, which is not the thing that just failed.

### State ownership

**The counter does not move.** It stays on `ContextManager`, which is the single source of truth. Moving it would mean rewiring three existing public surfaces (`get_usage_stats()['circuit_breaker_failures']`, `/context`'s rendering, `/clear`) and buys nothing: the coordinator only needs to read `compaction_circuit_open`, decide whether this attempt is a probe, and call the reset. Of `closed / open / probing`, only `probing` is coordinator-transient — and it never lands in `ContextManager`.

## Display

`/context` said:

```
Compact failures: 3/3 (circuit open — auto-compact disabled)
```

True, and useless — the state is recoverable and the user is the one who can recover it. Now:

```
Compact breaker:  open (3/3 consecutive failures, last: summary_empty)
                  automatic compaction is paused; /compact runs as a probe
                  and a success resets it (so does /clear)
```

`no_safe_split` and `summary_empty` need different answers (one recurs until history changes, the other is usually the provider), which is why the class is stored and shown. `get_usage_stats()` gains `circuit_breaker_open` and `last_compaction_failure`; the existing `circuit_breaker_failures` key is unchanged.

`/compact` additionally says when a probe ran and did not succeed, so "no change" does not silently hide that automatic compaction is still paused.

## New public API

```python
outcome = agent.compact()                        # manual; probes an open breaker
outcome = agent.compact(reason="api_overflow")   # on behalf of the ladder
```

There was no public compaction API: all three call sites reached straight into `context_manager`, which is how five entry points came to disagree about what a compaction had done. `reason` selects which policy applies, not just a label. Documented in `docs/reference/host-api.md` (+ zh twin), alongside why `ContextManager.compress_messages()` is the wrong level for host code — it hands back a bare list and bypasses both the host control plane and the probe policy.

## Gates

`uv run ruff check .` clean. `uv run python -m pytest tests/` — **4076 passed, 1 skipped**; the single failure is the pre-existing `test_model_switching_flow`, which reaches a live endpoint from a home-directory `.env` and is green in CI (it passes on an isolated run here too).

New: `tests/test_compaction_circuit_recovery.py` (13 tests) — who is paused and who probes, a successful probe closing it, a failed probe leaving it untouched, the threshold tier resuming afterwards, the manual-path counting exemption, both failure classes, both reset paths, the stats export, and `Agentao.compact()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
