### PR TITLE
compact: let PreCompact say no (PR-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,70 @@ _Targeting 0.4.20. Add entries under the relevant heading as work lands._
 
 ### Added
 
+- **`PreCompact` can now say no.** It was notify-only: `dispatch_pre_compact`
+  fired the hook through `_dispatch_lifecycle` and threw the output away, so a
+  host watching its own context about to be rewritten had no way to stop it.
+  Two layers, consulted in that order:
+
+  1. **Command hooks** — a hook that prints
+     `{"hookSpecificOutput": {"compactionDecision": "cancel", "compactionDecisionReason": "..."}}`
+     cancels the compaction. First cancel wins and stops the remaining forks.
+     The key is deliberately **not** `permissionDecision`: `compactionDecision`
+     has never existed in agentao, so no existing script can produce it by
+     accident — which is why this needs no opt-in gate. Everything that is not
+     an explicit `cancel` means allow, including an unknown value (with a
+     warning): a typo must not be able to pause compaction until the context
+     blows up. Exit code 2 stays unhonoured, matching `PreToolUse`.
+  2. **`compaction_controller=`**, a new keyword-only constructor argument for
+     trusted embedded hosts. It gets a `CompactionDecisionContext` — counts,
+     budgets and file paths, **never message text** — and returns `allow`,
+     `cancel`, or `provide_summary(text)`. Synchronous; v1 does not accept a
+     coroutine. **A controller that raises is caught, warned about and treated
+     as `allow`**, as is any unknown return: two of the five entry points *are*
+     the API-overflow recovery ladder, so an exception escaping a controller
+     would turn "context too long" into "the turn crashes".
+
+  A host summary is validated before it is committed (non-empty, a `str`,
+  within half the summary-input budget, and free of `SUMMARY_END_MARKER`,
+  which would break the *next* compaction's carry-stripping). An invalid one
+  is **not** a terminal state: it is rejected, logged, and the built-in
+  summarizer runs once as if the host had said `allow`. What the breaker
+  counts is always the built-in summarizer's failure, so a bad controller
+  costs one extra summarization and can never disable auto-compaction.
+
+  **Arbitrary message-list replacement is out of scope.** agentao's history is
+  a flat list where `tool_calls[*].id` must round-trip byte-for-byte; a host
+  returning an orphaned tool result would produce a request the provider
+  refuses, at a point where history has already been destroyed.
+
+- **Cancellation semantics, which is what made this shippable.** The 2026-05
+  plan deferred the gate because "a host denied and it is still too long"
+  looked like unrecoverable runaway. It is not, because a cancel is honoured
+  *and reported*:
+
+  - A cancelled **threshold** compaction is not re-dispatched for the rest of
+    the turn — a coordinator-owned latch keyed `(kind, reason)`, cleared at the
+    start of each turn. Without it, honouring a cancel would mean forking the
+    hook again on the very next iteration, which is the cost the stand-down
+    gates exist to remove. A latch hit is silent: no hook, no controller, no
+    event.
+  - If the API then really overflows, the host is asked **again** with
+    `reason=api_overflow`. That is a different question and gets its own
+    answer — the latch key carries the reason.
+  - A cancelled **overflow** returns the provider's context-length error to
+    the caller. It does **not** quietly fall through to `messages[-2:]`. Rung 2
+    is a separate dispatch site and behaves the same way.
+  - `manual_cli` never enters the latch: `/compact` is user-driven, does not
+    loop, and runs outside a turn, so a turn-reset latch would mean "cancel
+    once and every immediate retry stays suppressed until you first run an
+    ordinary turn".
+  - A cancelled **microcompaction** simply skips that pass and returns no
+    error — it was never the step you cannot proceed without.
+
+  `PLUGIN_HOOK_FIRED`'s `outcome` for `PreCompact` can now be `cancel` as well
+  as `allow`.
+
+
 - **`PreCompact` hooks can finally match on where a compaction came from.**
   `build_pre_compact` takes a required `trigger` argument and each of the five
   compaction entry points states its own provenance, so manual `/compact`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,19 @@ public entry.
 iteration; one event each would be a storm. `CONTEXT_COMPRESSED` fires only on
 `success`; `COMPACTION_SETTLED` fires for `success | cancelled | failed`.
 
+**The control plane has two layers and one merge rule.** Command hooks first
+(`dispatch_pre_compact_decision`, wire key `hookSpecificOutput.compactionDecision`,
+first-cancel-wins), then — only if they all allowed — `compaction_controller=`,
+a keyword-only constructor argument. A cancel in either layer is a cancel;
+`provide_summary` can only come from the controller. **Everything that is not
+an explicit cancel means allow, including a raise**: two entry points are the
+overflow recovery ladder, so a control-plane error must never be able to end
+the turn it exists to save. A cancelled threshold compaction enters a
+coordinator-owned latch keyed `(kind, reason)`, cleared per turn in
+`runtime/turn.py`; `manual_cli` and both overflow reasons never enter it. A
+cancelled **overflow** returns the provider's context-length error rather than
+falling through to `messages[-2:]`.
+
 **Two token units, deliberately named apart.** `CONTEXT_COMPRESSED`'s
 `pre_est_tokens` / `post_est_tokens` **include** the system prompt;
 `COMPACTION_SETTLED`'s `pre_tokens_history` / `post_tokens_history` exclude

--- a/agentao/agent.py
+++ b/agentao/agent.py
@@ -38,7 +38,7 @@ from .sandbox import SandboxPolicy
 from .transport import NullTransport, build_compat_transport
 
 if TYPE_CHECKING:
-    from .compaction.types import CompactionOutcome
+    from .compaction.types import CompactionController, CompactionOutcome
     from .agents.bg_store import BackgroundTaskStore  # noqa: F401
     from .capabilities import FileSystem, MCPRegistry, ShellExecutor
     from .mcp import McpClientManager  # type-only; MCP SDK is heavy
@@ -124,6 +124,11 @@ class Agentao:
         # (see _validate_construction_args).
         extra_body: Optional[Dict[str, Any]] = None,
         extra_mcp_servers: Optional[Dict[str, Dict[str, Any]]] = None,
+        # Host compaction control plane. KEYWORD-ONLY for the same reason as
+        # ``extra_body`` above — inserting it into the older group would shift
+        # the legacy positional callback arguments. At most one: this is not a
+        # list, and it is consulted only after every command hook has allowed.
+        compaction_controller: Optional["CompactionController"] = None,
         # ── Host tool injection ───────────────────────────────────────────
         extra_tools: Optional[Sequence["RegistrableTool"]] = None,
         disable_tools: Optional[Iterable[str]] = None,
@@ -315,6 +320,7 @@ class Agentao:
         # rather than rebuilt per call because it is where per-turn
         # compaction state lives.
         self._compaction_coordinator = None
+        self.compaction_controller = compaction_controller
 
         # Session-scoped state (session id, host event stream, conversation
         # history, plan session, project instructions) must land before

--- a/agentao/cli/commands/compact.py
+++ b/agentao/cli/commands/compact.py
@@ -65,6 +65,15 @@ def handle_compact_command(cli: AgentaoCLI, args: str) -> None:
     )
     outcome = run.outcome
 
+    if outcome.status == "cancelled":
+        why = f" — {outcome.detail}" if outcome.detail else ""
+        console.print(
+            f"\n[warning]Compaction cancelled by the host{why}.[/warning]\n"
+            "[dim]History is unchanged. A PreCompact hook or the configured "
+            "compaction controller vetoed it.[/dim]\n"
+        )
+        return
+
     if outcome.status != "success":
         hint = _FAILURE_HINTS.get(outcome.detail or "")
         detail = f" — {hint}" if hint else " (see agentao.log)"

--- a/agentao/compaction/coordinator.py
+++ b/agentao/compaction/coordinator.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from .types import (
+    CompactionDecision,
+    CompactionDecisionContext,
     CompactionKind,
     CompactionOutcome,
     CompactionReason,
@@ -41,6 +43,19 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 #: loop; an API overflow has already been rejected by the provider, so
 #: blocking it leaves the recovery ladder with nothing but ``messages[-2:]``.
 _PROBE_REASONS = frozenset({"manual_cli", "api_overflow"})
+
+#: Reasons a cancellation is remembered for, until the start of the next turn.
+#: Exactly the two the loop **re-checks on every iteration** — without a latch,
+#: honouring a cancel would mean asking again next iteration, which is the
+#: per-iteration hook fork the stand-down gates exist to prevent.
+#:
+#: ``manual_cli`` is deliberately absent: it is user-driven, does not loop, and
+#: **runs outside a turn**, so a turn-reset latch would mean "cancel manually
+#: once and every immediate retry stays suppressed until you first run an
+#: ordinary turn". Neither overflow reason is here either — a cancelled
+#: overflow returns the context-length error and ends the turn on the spot, so
+#: there is no re-dispatch to suppress.
+_LATCHED_REASONS = frozenset({"microcompact_threshold", "compression_threshold"})
 
 
 @dataclass(frozen=True)
@@ -85,6 +100,10 @@ class CompactionCoordinator:
 
     def __init__(self, agent: "Agentao") -> None:
         self._agent = agent
+        # ``(kind, reason)`` pairs cancelled during this turn. Owned here and
+        # not on ``ContextManager``: unlike the breaker's counter, this has no
+        # existing public surface to serve, and its lifetime is one turn.
+        self._cancel_latch: set = set()
 
     # ------------------------------------------------------------------
     # The one entry point
@@ -140,7 +159,11 @@ class CompactionCoordinator:
         self._info(
             f"Compaction triggered: kind={request.kind} reason={request.reason}"
         )
-        self.dispatch_pre_compact(request)
+        # Command hooks run **first**, and a cancel from either layer is a
+        # cancel. Dispatched here rather than inside the decide step so the
+        # hook still fires exactly where it always has: before anything is
+        # touched, and once per attempt.
+        hook_result = self.dispatch_pre_compact(request)
 
         t0 = time.monotonic()
         pre_msgs = len(agent.messages)
@@ -150,7 +173,14 @@ class CompactionCoordinator:
             cm.estimate_tokens(messages_with_system) if measure_system_tokens else None
         )
 
-        outcome = self._transform(request, keep_tail=keep_tail)
+        outcome = self._transform(
+            request,
+            keep_tail=keep_tail,
+            decide=self._compose_decide(request, hook_result),
+        )
+
+        if outcome.status == "cancelled" and request.reason in _LATCHED_REASONS:
+            self._cancel_latch.add((request.kind, request.reason))
 
         if request.kind == "full" and request.trigger == "auto":
             # The summarization LLM call goes straight to ``llm_client`` and
@@ -229,6 +259,12 @@ class CompactionCoordinator:
         agent = self._agent
         cm = agent.context_manager
 
+        if (request.kind, request.reason) in self._cancel_latch:
+            # Silent: no hook dispatch, no controller call, no event. This
+            # hits on every iteration for the rest of the turn, which is the
+            # entire reason the latch exists.
+            return self._skipped(request, "suppressed_by_latch")
+
         if request.kind == "full" and cm.compaction_circuit_open:
             if request.reason in _PROBE_REASONS:
                 # Half-open. The breaker describes *threshold* behaviour —
@@ -275,7 +311,7 @@ class CompactionCoordinator:
     # ------------------------------------------------------------------
 
     def _transform(
-        self, request: CompactionRequest, *, keep_tail: int,
+        self, request: CompactionRequest, *, keep_tail: int, decide=None,
     ) -> CompactionOutcome:
         agent = self._agent
         cm = agent.context_manager
@@ -285,14 +321,29 @@ class CompactionCoordinator:
             # ``compress_messages`` wrapper: it is the only layer that can
             # produce an authoritative ``status`` for this kind, and it owns
             # the failure counter, which the coordinator must never touch.
+            # It runs ``decide`` itself, after prepare and before summarize —
+            # the only point where a host summary can replace the LLM call.
             return cm._run_compaction(
                 agent.messages,
                 is_auto=(request.trigger == "auto"),
                 reason=request.reason,
-                decide=None,
+                decide=decide,
             )
 
+        # The other two kinds call no summarizer, write no SQLite and never
+        # touch the breaker counter, so they do not go through
+        # ``_run_compaction`` — but history is still rewritten behind a
+        # ``ContextManager`` method, never here.
         if request.kind == "microcompact":
+            prep = cm.prepare_microcompact(agent.messages)
+            cancelled = self._ask(
+                request,
+                decide,
+                messages_to_keep=len(agent.messages),
+                tool_results_to_clip=prep.tool_results_to_clip,
+            )
+            if cancelled is not None:
+                return cancelled
             return CompactionOutcome(
                 status="success",
                 trigger=request.trigger,
@@ -307,6 +358,12 @@ class CompactionCoordinator:
                 post_tokens=None,
             )
 
+        prep = cm.prepare_minimal_history(agent.messages, keep_tail=keep_tail)
+        cancelled = self._ask(
+            request, decide, messages_to_keep=prep.keep_tail,
+        )
+        if cancelled is not None:
+            return cancelled
         return CompactionOutcome(
             status="success",
             trigger=request.trigger,
@@ -319,22 +376,74 @@ class CompactionCoordinator:
             post_tokens=None,
         )
 
+    def _ask(
+        self,
+        request: CompactionRequest,
+        decide,
+        *,
+        messages_to_keep: int,
+        tool_results_to_clip: Optional[int] = None,
+    ) -> Optional[CompactionOutcome]:
+        """Run the decision step for a non-``full`` kind.
+
+        Returns a ``cancelled`` outcome, or ``None`` to proceed.
+        ``provide_summary`` is not legal here — ``can_provide_summary`` is
+        ``False`` — and an offer of one is downgraded to ``allow`` inside
+        ``_consult_controller``, so nothing is dropped silently.
+        """
+        if decide is None:
+            return None
+        ctx = CompactionDecisionContext(
+            trigger=request.trigger,
+            kind=request.kind,
+            reason=request.reason,
+            pre_tokens=None,
+            messages_to_summarize=0,
+            messages_to_keep=messages_to_keep,
+            recently_read_files=(),
+            summary_input_budget=None,
+            max_summary_tokens=None,
+            can_provide_summary=False,
+            tool_results_to_clip=tool_results_to_clip,
+        )
+        decision = decide(ctx)
+        if decision.action != "cancel":
+            return None
+        return CompactionOutcome(
+            status="cancelled",
+            trigger=request.trigger,
+            kind=request.kind,
+            reason=request.reason,
+            messages=self._agent.messages,
+            pre_tokens=None,
+            post_tokens=None,
+            detail=decision.reason,
+        )
+
     # ------------------------------------------------------------------
     # Host dispatch
     # ------------------------------------------------------------------
 
-    def dispatch_pre_compact(self, request: CompactionRequest) -> None:
-        """Fire matching ``PreCompact`` command hooks (side-effect only).
+    def dispatch_pre_compact(self, request: CompactionRequest) -> Optional[str]:
+        """Fire matching ``PreCompact`` command hooks; return a cancel reason.
 
         One implementation for all five entry points. There used to be two —
         the chat loop's and the CLI's — which is how manual ``/compact`` came
         to emit a replay event saying ``manual`` beside a hook payload saying
         ``auto`` for the same compaction.
+
+        Returns the reason string if any hook cancelled (``""`` when it gave
+        none), or ``None`` for allow. Everything that is not an explicit
+        ``{"hookSpecificOutput": {"compactionDecision": "cancel"}}`` on stdout
+        means allow, **including a raised exception here**: this whole method
+        is wrapped, because two of the five entry points are the API-overflow
+        recovery ladder and a control-plane error must never be able to end
+        the turn it exists to save.
         """
         agent = self._agent
         rules = getattr(agent, "_plugin_hook_rules", None)
         if not rules:
-            return
+            return None
         try:
             from ..plugins.hooks import ClaudeHookPayloadAdapter, PluginHookDispatcher
             from ..transport import AgentEvent, EventType
@@ -351,17 +460,121 @@ class CompactionCoordinator:
             dispatcher = PluginHookDispatcher(cwd=cwd)
             matched = dispatcher.select_matching_rules("PreCompact", payload, rules)
             if not matched:
-                return
-            dispatcher.dispatch_pre_compact(payload=payload, rules=matched)
+                return None
+            result = dispatcher.dispatch_pre_compact_decision(
+                payload=payload, rules=matched,
+            )
+            cancelled = result.decision == "cancel"
             agent.transport.emit(AgentEvent(EventType.PLUGIN_HOOK_FIRED, {
                 "hook_name": "PreCompact",
-                "outcome": "allow",
+                "outcome": "cancel" if cancelled else "allow",
                 "compaction_type": request.kind,
                 "trigger": request.trigger,
                 "matched_rule_count": len(matched),
             }))
+            return (result.reason or "") if cancelled else None
         except Exception:
-            pass
+            return None
+
+    # ------------------------------------------------------------------
+    # The control plane
+    # ------------------------------------------------------------------
+
+    def _compose_decide(self, request: CompactionRequest, hook_reason: Optional[str]):
+        """Merge the two control layers into one ``decide`` callable.
+
+        Ordering: command hooks first (already run — ``hook_reason`` is their
+        verdict), then, **only if they all allowed**, the host controller.
+        Asking a trusted host to compute a summary that is about to be thrown
+        away is pure waste.
+
+        The merge rule in one line: a cancel in either layer is a cancel, and
+        ``provide_summary`` can only come from the controller layer. Command
+        hooks cannot provide summary text — they have no trust boundary, and
+        summary text permanently rewrites history.
+        """
+        controller = getattr(self._agent, "compaction_controller", None)
+        if hook_reason is None and controller is None:
+            return None
+
+        def _decide(ctx: CompactionDecisionContext) -> CompactionDecision:
+            if hook_reason is not None:
+                return CompactionDecision("cancel", reason=hook_reason or None)
+            return self._consult_controller(controller, ctx)
+
+        return _decide
+
+    def _consult_controller(self, controller, ctx: CompactionDecisionContext):
+        """Call the host controller, and survive anything it does.
+
+        Every failure mode lands on ``allow``: a raise, an awaitable, an
+        unknown ``action``, ``provide_summary`` with no text, or
+        ``provide_summary`` where it has no legal meaning. Same direction as
+        the hook layer's "any other value is allow", and for the same reason —
+        **no control-plane error may be able to drive the context into the
+        overflow ladder, let alone end the turn.**
+
+        There is no timeout. It is a synchronous in-process callback; if it
+        hangs, it hangs the turn, exactly like the host's other callbacks.
+        """
+        allow = CompactionDecision("allow")
+        try:
+            decision = controller(ctx)
+        except Exception as exc:
+            self._warn(f"compaction_controller raised ({exc!r}); treating as allow")
+            return allow
+
+        if not isinstance(decision, CompactionDecision):
+            if hasattr(decision, "__await__"):
+                # Closed, not just dropped: an un-awaited coroutine warns at
+                # GC time, in whatever unrelated code happens to be running.
+                try:
+                    decision.close()
+                except Exception:
+                    pass
+                self._warn(
+                    "compaction_controller returned an awaitable; v1 does not "
+                    "support an async controller — treating as allow"
+                )
+            else:
+                self._warn(
+                    f"compaction_controller returned {type(decision).__name__}, "
+                    "not a CompactionDecision — treating as allow"
+                )
+            return allow
+
+        if decision.action == "cancel":
+            return decision
+        if decision.action == "allow":
+            return decision
+        if decision.action == "provide_summary":
+            if not ctx.can_provide_summary:
+                self._warn(
+                    f"compaction_controller offered a summary for kind={ctx.kind}, "
+                    "where provide_summary has no meaning — treating as allow"
+                )
+                return allow
+            if decision.summary is None:
+                self._warn(
+                    "compaction_controller returned provide_summary with no "
+                    "summary — treating as allow"
+                )
+                return allow
+            return decision
+
+        self._warn(
+            f"compaction_controller returned an unknown action {decision.action!r} "
+            "— treating as allow"
+        )
+        return allow
+
+    def reset_cancellation_latch(self) -> None:
+        """Forget this turn's cancellations. Called at the start of each turn.
+
+        The latch is what makes "not re-dispatched for the rest of the turn"
+        a mechanism rather than a promise; this is the other half of it.
+        """
+        self._cancel_latch.clear()
 
     # ------------------------------------------------------------------
     # Observability

--- a/agentao/context_manager.py
+++ b/agentao/context_manager.py
@@ -117,6 +117,26 @@ class PreparedCompaction:
     pre_tokens: int
 
 
+@dataclass(frozen=True)
+class PreparedMicrocompact:
+    """What a microcompaction pass is about to do, in counts.
+
+    ``tool_results_to_clip`` is this kind's whole decision signal: for
+    microcompaction ``messages_to_summarize`` is 0 and ``messages_to_keep``
+    is the entire list, so neither tells a host anything. ``pre_tokens`` is
+    deliberately absent — see :meth:`ContextManager.prepare_microcompact`.
+    """
+
+    tool_results_to_clip: int
+
+
+@dataclass(frozen=True)
+class PreparedMinimalHistory:
+    """The ladder's last rung, in counts. Nothing is estimated here."""
+
+    keep_tail: int
+
+
 PrepareResult = Union[PreparedCompaction, PrepareRejected]
 
 
@@ -832,6 +852,37 @@ class ContextManager:
             pass
 
         return result
+
+    def prepare_microcompact(
+        self,
+        messages: List[Dict[str, Any]],
+    ) -> "PreparedMicrocompact":
+        """Count what a microcompaction pass would shorten, without doing it.
+
+        Exists so the coordinator can populate a decision context **without
+        reaching into a private member** — it wraps
+        ``_microcompactable_indices``, the same index set the transform
+        rewrites, so the count and the transform can never disagree.
+
+        No token estimate. Microcompaction runs on every iteration inside its
+        band, and the only estimate that path has today measures
+        ``[system] + messages`` — the wrong unit for a field declared
+        system-exclusive. Computing a fresh history-only one means another
+        full-history encode per iteration, precisely when the history is
+        largest.
+        """
+        return PreparedMicrocompact(
+            tool_results_to_clip=len(self._microcompactable_indices(messages)),
+        )
+
+    def prepare_minimal_history(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        keep_tail: int = 2,
+    ) -> "PreparedMinimalHistory":
+        """Describe the last rung. It makes no token estimate — nor does this."""
+        return PreparedMinimalHistory(keep_tail=keep_tail)
 
     def apply_minimal_history(
         self,

--- a/agentao/plugins/hooks/_dispatcher.py
+++ b/agentao/plugins/hooks/_dispatcher.py
@@ -26,6 +26,7 @@ from ..models import (
     CLAUDE_FLAT_EVENTS,
     HookAttachmentRecord,
     ParsedHookRule,
+    PreCompactHookResult,
     PreToolUseHookResult,
     StopHookResult,
     UserPromptSubmitResult,
@@ -162,6 +163,89 @@ class PluginHookDispatcher(_OutputParsingMixin):
         rules: list[ParsedHookRule],
     ) -> list[HookAttachmentRecord]:
         return self._dispatch_lifecycle("PreCompact", payload, rules)
+
+    def dispatch_pre_compact_decision(
+        self,
+        *,
+        payload: dict[str, Any],
+        rules: list[ParsedHookRule],
+    ) -> PreCompactHookResult:
+        """Run matching PreCompact hooks; aggregate a cancel/allow decision.
+
+        Sibling of :meth:`dispatch_pre_compact`, which is side-effect only
+        and does not read stdout at all. This one parses each hook's stdout
+        for ``hookSpecificOutput.compactionDecision`` and merges: the first
+        ``cancel`` wins and stops the remaining forks; ``allow`` is a no-op.
+
+        Everything that is not an explicit ``cancel`` means allow — a missing
+        key, a missing ``hookSpecificOutput``, non-JSON stdout, a script that
+        prints nothing, a non-zero exit, an unknown value. A control plane
+        that fails must not be able to pause compaction indefinitely.
+        """
+        result = PreCompactHookResult()
+        matched = self.select_matching_rules("PreCompact", payload, rules)
+        result.matched_rule_count = len(matched)
+        for rule in matched:
+            if rule.hook_type != "command":
+                continue
+            self._run_pre_compact_command(rule, payload, result)
+            if result.decision == "cancel":
+                break
+        return result
+
+    def _run_pre_compact_command(
+        self,
+        rule: ParsedHookRule,
+        payload: dict[str, Any],
+        result: PreCompactHookResult,
+    ) -> None:
+        """Run one PreCompact command hook and fold its verdict into ``result``."""
+        proc, _timed_out = self._run_subprocess(rule, payload)
+        if proc is None:  # empty / timed out / failed to start — already logged
+            return
+
+        if proc.returncode != 0:
+            # Exit-code 2 is not honoured here either — only the JSON shape,
+            # matching ``dispatch_pre_tool_use_decision``. Any JSON on stdout
+            # is still parsed below.
+            logger.warning(
+                "PreCompact hook exited %d: %s (stderr: %s)",
+                proc.returncode, rule.command, (proc.stderr or "")[:200],
+            )
+
+        stdout = (proc.stdout or "").strip()
+        if not stdout:
+            return
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(data, dict):
+            return
+
+        hook_specific = data.get("hookSpecificOutput")
+        if not isinstance(hook_specific, dict):
+            return
+        raw = hook_specific.get("compactionDecision")
+        if raw is None:
+            return
+        if raw != "cancel":
+            if raw != "allow":
+                logger.warning(
+                    "PreCompact hook returned an unknown compactionDecision %r: %s "
+                    "— treating as allow",
+                    raw, rule.command,
+                )
+            return
+
+        reason: str | None = None
+        for key in ("compactionDecisionReason", "reason"):
+            rv = hook_specific.get(key)
+            if isinstance(rv, str):
+                reason = rv
+                break
+        result.decision = "cancel"
+        result.reason = reason
 
     def select_matching_rules(
         self,

--- a/agentao/plugins/models.py
+++ b/agentao/plugins/models.py
@@ -323,6 +323,34 @@ class PreToolUseHookResult:
 
 
 @dataclass
+class PreCompactHookResult:
+    """Aggregated decision from all PreCompact hooks for one compaction.
+
+    ``decision`` is ``"cancel"`` or ``None`` (allow). The wire key is
+    ``hookSpecificOutput.compactionDecision`` — deliberately **not**
+    ``permissionDecision``. That choice is the whole argument for needing no
+    opt-in gate: "a script that prints nothing means allow" only proves that
+    *silent* scripts are safe, and says nothing about a private script that
+    writes ``hookSpecificOutput`` for some other purpose. A key that has
+    never existed in agentao cannot be produced by accident.
+
+    Merge rule: **first cancel wins**, and the caller stops forking once one
+    is seen. One tier, not the two PreToolUse has ("first deny, else first
+    ask"), because there is no ``ask`` here — a compaction has no third
+    answer.
+
+    Any value outside ``allow`` / ``cancel`` is treated as ``allow`` with a
+    warning: a typo must not be able to block compaction permanently and
+    drive the context into the overflow ladder. Exit-code 2 stays
+    unhonoured, matching the PreToolUse precedent.
+    """
+
+    decision: Literal["cancel"] | None = None
+    reason: str | None = None
+    matched_rule_count: int = 0
+
+
+@dataclass
 class StopHookResult:
     """Aggregated result of all hooks for a single Stop event.
 

--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -1176,6 +1176,20 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                 # already blown up.
                 measure_system_tokens=False,
             )
+            if run.outcome.status == "cancelled":
+                # The host said no to the *overflow* question, which is a
+                # separate question from the threshold one it may have
+                # already declined. Return the provider's own error rather
+                # than quietly falling through to the next rung: the runaway
+                # the earlier design feared comes from a cancel that is
+                # ignored, not from one that is honoured and reported.
+                err_msg = f"[LLM API error: {e}]"
+                agent.llm.logger.warning(
+                    "Compaction cancelled by the host on an API overflow; "
+                    "returning the context-length error"
+                )
+                agent.messages.append({"role": "assistant", "content": err_msg})
+                return ChatLoopRunner._LlmOutcome(error_return=err_msg)
             system_prompt = run.system_prompt
             messages_with_system = run.messages_with_system
             try:
@@ -1198,6 +1212,22 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                         messages_with_system=messages_with_system,
                         measure_system_tokens=False,
                     )
+                    if run.outcome.status == "cancelled":
+                        # A separate dispatch site from the rung above, and
+                        # reachable only once that one was allowed, compacted
+                        # successfully, and the request *still* overflowed —
+                        # so it gets its own answer, with the same semantics:
+                        # honoured and reported, never a quiet fall-through to
+                        # ``messages[-2:]``.
+                        err_msg = f"[LLM API error: {e2}]"
+                        agent.llm.logger.warning(
+                            "Minimal-history compaction cancelled by the host; "
+                            "returning the context-length error"
+                        )
+                        agent.messages.append(
+                            {"role": "assistant", "content": err_msg}
+                        )
+                        return ChatLoopRunner._LlmOutcome(error_return=err_msg)
                     messages_with_system = run.messages_with_system
                     try:
                         response = agent._llm_call(messages_with_system, tools, token)

--- a/agentao/runtime/turn.py
+++ b/agentao/runtime/turn.py
@@ -104,6 +104,14 @@ def run_turn(
         agent.context_manager.last_summary_finish_reason_missing = False
     except Exception:
         pass
+    # Compaction cancellations are remembered for the rest of the turn (the
+    # loop re-checks both thresholds every iteration, so honouring a cancel
+    # without a latch would mean asking again next iteration). This is the
+    # other half of that: read off the attribute rather than the property so
+    # a turn that never compacts does not construct a coordinator.
+    _coordinator = getattr(agent, "_compaction_coordinator", None)
+    if _coordinator is not None:
+        _coordinator.reset_cancellation_latch()
     # Snapshot the latest session-summary id so the inner loop can
     # fire SESSION_SUMMARY_WRITTEN each time compress_messages writes
     # a new one. Held on the instance so compression paths inside the

--- a/docs/reference/host-api.md
+++ b/docs/reference/host-api.md
@@ -152,6 +152,72 @@ bypasses both the host control plane (`PreCompact` dispatch) and the
 breaker's probe policy. It is not deprecated; it is simply the wrong level
 for host code.
 
+### Vetoing or replacing a compaction
+
+Two layers, consulted in that order. A cancel in either is a cancel.
+
+**Command hooks** — a `PreCompact` hook that prints this on stdout cancels it:
+
+```json
+{"hookSpecificOutput": {"compactionDecision": "cancel",
+                        "compactionDecisionReason": "mid-refactor"}}
+```
+
+First cancel wins and stops the remaining forks. The key is
+`compactionDecision`, not `permissionDecision` — a key that has never existed,
+so no script can produce it by accident, which is why no opt-in flag is
+needed. **Anything that is not an explicit `cancel` means allow**, including
+an unknown value (logged): a typo must not be able to pause compaction until
+the context blows up. Exit code 2 stays unhonoured. Hooks cannot supply
+summary text — they have no trust boundary, and summary text permanently
+rewrites history.
+
+**`compaction_controller=`** (keyword-only constructor argument, at most one):
+
+```python
+def controller(ctx: CompactionDecisionContext) -> CompactionDecision:
+    if ctx.kind == "full" and ctx.messages_to_summarize > 200:
+        return CompactionDecision("provide_summary", summary=my_summary())
+    return CompactionDecision("allow")
+
+agent = Agentao(..., compaction_controller=controller)
+```
+
+`ctx` carries counts, budgets and recently-read paths — **never message
+text**. It is a redaction boundary and it is never serialized; a host that
+needs the text reads `agent.messages`. `provide_summary` is legal only when
+`ctx.can_provide_summary` (i.e. `kind == "full"`).
+
+The contract is **fail-open, and that is a hard rule**: a raise, an awaitable
+(v1 is synchronous), an unknown `action`, or `provide_summary` with no text
+are all treated as `allow` with a warning. Two of the five compaction entry
+points *are* the API-overflow recovery ladder, so an exception escaping a
+controller would turn "context too long" into "the turn crashes". There is no
+timeout — if it hangs, it hangs the turn, exactly like the host's other
+callbacks.
+
+A host summary is validated before it is committed (non-empty, a `str`, at
+most `ctx.max_summary_tokens`, free of the summary end marker). An invalid one
+is rejected and the built-in summarizer runs **once**, as if the host had said
+`allow`; `outcome.detail` records which check failed. What the circuit breaker
+counts is always the built-in summarizer's failure, so a bad controller can
+never disable automatic compaction.
+
+**What a cancel means, per entry point.** History is byte-identical in every
+case.
+
+| Cancelled | Result |
+|---|---|
+| Microcompaction | that pass is skipped; no error; not re-asked this turn |
+| Threshold | not re-asked this turn; if the API then overflows the host is asked **again**, with `reason=api_overflow` — a different question |
+| API overflow (either rung) | the provider's context-length error is returned to the caller. It does **not** fall through to `messages[-2:]` |
+| Manual `/compact` | reported as cancelled; an immediate retry dispatches normally (it never latches) |
+
+Arbitrary message-list replacement is **out**: agentao's history is a flat
+list where `tool_calls[*].id` must round-trip byte-for-byte, and a host
+returning an orphaned tool result would produce a request the provider refuses
+at a point where history has already been destroyed.
+
 ## Capability protocols (`agentao.host.protocols`)
 
 Embedded hosts override IO by injecting these `Protocol` types into

--- a/docs/reference/host-api.zh.md
+++ b/docs/reference/host-api.zh.md
@@ -111,6 +111,62 @@ system prompt，没有估算的路径上为 `None`。
 **绕过** host 控制面（`PreCompact` 分发）与熔断器的探针策略。它没有被废弃，只是
 对 host 代码来说层级不对。
 
+### 否决或替换一次压缩
+
+两层，按此顺序征询。**任一层否决即否决。**
+
+**命令 hook** —— `PreCompact` hook 在 stdout 打印下面这段即可取消：
+
+```json
+{"hookSpecificOutput": {"compactionDecision": "cancel",
+                        "compactionDecisionReason": "重构做到一半"}}
+```
+
+**第一个 cancel 生效**，随后的 hook 不再 fork。键名是 `compactionDecision`，
+不是 `permissionDecision`——一个 agentao 里从未存在过的键，任何脚本都不可能
+误产出它，这正是**不需要任何 opt-in 开关**的完整理由。**凡不是显式 `cancel`
+的一律按 allow 处理**，包括未知取值（会记日志）：一个笔误不该能把压缩一直
+拦到上下文炸掉。exit code 2 仍不予采纳。hook **不能**提供摘要文本——它没有
+信任边界，而摘要文本会永久改写历史。
+
+**`compaction_controller=`**（仅关键字构造参数，至多一个）：
+
+```python
+def controller(ctx: CompactionDecisionContext) -> CompactionDecision:
+    if ctx.kind == "full" and ctx.messages_to_summarize > 200:
+        return CompactionDecision("provide_summary", summary=my_summary())
+    return CompactionDecision("allow")
+
+agent = Agentao(..., compaction_controller=controller)
+```
+
+`ctx` 带的是计数、预算和近期读过的路径，**从不带消息正文**。它是一道脱敏边界，
+且永不序列化；需要正文的 host 自己读 `agent.messages`。`provide_summary` 只在
+`ctx.can_provide_summary`（即 `kind == "full"`）时合法。
+
+契约是 **fail-open，而且这是硬规则**：抛异常、返回 awaitable（v1 是同步的）、
+未知 `action`、或 `provide_summary` 不带文本，一律按 allow 处理并告警。五个压缩
+入口里有**两个就是 API 溢出恢复阶梯**，controller 里逸出一个异常会把「上下文太长」
+变成「这一轮直接崩」。没有超时——它挂住就挂住这一轮，和 host 其它回调一样。
+
+host 摘要在提交前会被校验（非空、是 `str`、不超过 `ctx.max_summary_tokens`、
+不含摘要结束标记）。不合格的会被拒绝，然后**内建摘要器照跑一次**，就当 host 说了
+`allow`；`outcome.detail` 记下是哪一项没过。**熔断器计的永远是内建摘要器的失败**，
+所以一个坏 controller 绝无可能把自动压缩关掉。
+
+**取消在各入口分别意味着什么。** 所有情况下历史都逐字节不变。
+
+| 被取消的 | 结果 |
+|---|---|
+| 微压缩 | 跳过这一趟；不报错；本轮不再问 |
+| 阈值压缩 | 本轮不再问；若 API 随后真的溢出，会**再问一次**，`reason=api_overflow`——那是另一个问题 |
+| API 溢出（两级都是） | 把 provider 自己的 context-length 错误返回给调用方，**不会**悄悄落到 `messages[-2:]` |
+| 手动 `/compact` | 报 cancelled；紧接着重试会照常分发（它从不进闩锁） |
+
+**不接受任意替换消息列表**：agentao 的历史是扁平列表，`tool_calls[*].id`
+必须逐字节往返；host 交回一条孤儿 tool result 就会造出 provider 拒收的请求，
+而那时历史已经被销毁了。
+
 ## 能力协议（`agentao.host.protocols`）
 
 嵌入宿主通过向 `Agentao(filesystem=..., shell=..., mcp_registry=..., memory_manager=...)`

--- a/tests/test_compaction_control_plane.py
+++ b/tests/test_compaction_control_plane.py
@@ -1,0 +1,464 @@
+"""The PreCompact control plane: hooks and the host controller can say no.
+
+``PreCompact`` was notify-only. `_dispatch_lifecycle` fired it and threw the
+output away, so a host watching its own context being rewritten had no way to
+stop it — which is why the 2026-05 plan deferred the gate entirely: "accepting
+a host deny with no fallback for *host denied and still too long* produces
+unrecoverable runaway."
+
+The answer these tests pin: a cancel is **honoured and reported**, never
+ignored and never quietly fallen through. A cancelled threshold compaction is
+not re-dispatched for the rest of the turn (the latch); if the API then really
+overflows, the host is asked **again**, as a separate question; and a cancelled
+overflow returns the provider's context-length error rather than cutting
+history to the last two messages.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from agentao.compaction.coordinator import CompactionCoordinator, CompactionRequest
+from agentao.compaction.types import CompactionDecision
+from agentao.context_manager import ContextManager
+from agentao.plugins.hooks import ClaudeHookPayloadAdapter, PluginHookDispatcher
+from agentao.plugins.models import ParsedHookRule
+
+
+def _make_cm():
+    llm = Mock()
+    llm.logger = Mock()
+    llm.model = "test-model"
+    return ContextManager(llm, Mock(), max_tokens=200_000)
+
+
+def _history(n=12):
+    out = []
+    for i in range(n):
+        out.append({"role": "user", "content": f"user {i} " + "x" * 200})
+        out.append({"role": "assistant", "content": f"assistant {i} " + "y" * 200})
+    return out
+
+
+def _agent(cm, messages, *, rules=None, controller=None, cwd=None):
+    events = []
+    agent = SimpleNamespace(
+        messages=messages,
+        context_manager=cm,
+        transport=SimpleNamespace(emit=events.append),
+        llm=SimpleNamespace(logger=Mock()),
+        working_directory=cwd,
+        compaction_controller=controller,
+        _plugin_hook_rules=rules or [],
+        _session_id="s",
+        _last_session_summary_id=None,
+        _turn_finish_reason_missing=False,
+        _build_system_prompt=lambda: "sys",
+        _emit_session_summary_if_new=lambda _prev: None,
+        _emit_context_compressed=lambda **kw: events.append(
+            SimpleNamespace(type="context_compressed", data=kw)
+        ),
+        active_permissions=lambda: SimpleNamespace(mode="workspace-write"),
+    )
+    agent.compaction_coordinator = CompactionCoordinator(agent)
+    return agent, events
+
+
+def _hook(tmp_path, body, name="hook.sh"):
+    script = tmp_path / name
+    script.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IRUSR | stat.S_IWUSR)
+    return ParsedHookRule(
+        event="PreCompact", hook_type="command",
+        command=f"sh '{script}'", plugin_name="t",
+    )
+
+
+def _emits(payload):
+    return "cat <<'JSON'\n" + json.dumps(payload) + "\nJSON\nexit 0"
+
+
+# ---------------------------------------------------------------------------
+# The wire shape
+# ---------------------------------------------------------------------------
+
+def test_a_hook_cancels_with_the_dedicated_key(tmp_path):
+    """``compactionDecision``, not ``permissionDecision``.
+
+    The key choice is the whole argument for needing no opt-in gate: it has
+    never existed in agentao, so no existing script can produce it by
+    accident. "Silence means allow" only proves *silent* scripts are safe.
+    """
+    rule = _hook(tmp_path, _emits({
+        "hookSpecificOutput": {
+            "compactionDecision": "cancel",
+            "compactionDecisionReason": "mid-refactor",
+        }
+    }))
+    payload = ClaudeHookPayloadAdapter().build_pre_compact(
+        cwd=tmp_path, trigger="auto", compaction_type="full",
+        reason="compression_threshold",
+    )
+    result = PluginHookDispatcher(cwd=tmp_path).dispatch_pre_compact_decision(
+        payload=payload, rules=[rule],
+    )
+    assert result.decision == "cancel"
+    assert result.reason == "mid-refactor"
+
+
+@pytest.mark.parametrize("body", [
+    "exit 0",                                                  # prints nothing
+    "echo 'not json'; exit 0",                                 # non-JSON stdout
+    _emits({"hookSpecificOutput": {}}),                        # key absent
+    _emits({"hookSpecificOutput": {"permissionDecision": "deny"}}),  # wrong key
+    _emits({"hookSpecificOutput": {"compactionDecision": "CANCEL"}}),  # typo
+    _emits({"hookSpecificOutput": {"compactionDecision": "deny"}}),    # unknown
+    "echo '{\"hookSpecificOutput\": {\"compactionDecision\": \"cancel\"}}'; exit 2",
+])
+def test_everything_that_is_not_an_explicit_cancel_means_allow(tmp_path, body):
+    """A typo must not be able to pause compaction until the context blows up.
+
+    The last case is deliberate: exit code 2 stays unhonoured (matching the
+    PreToolUse precedent) but the JSON on stdout is still read — so that one
+    *does* cancel, on the strength of the JSON alone.
+    """
+    rule = _hook(tmp_path, body, name=f"h{abs(hash(body))}.sh")
+    payload = ClaudeHookPayloadAdapter().build_pre_compact(
+        cwd=tmp_path, trigger="auto", compaction_type="full",
+        reason="compression_threshold",
+    )
+    result = PluginHookDispatcher(cwd=tmp_path).dispatch_pre_compact_decision(
+        payload=payload, rules=[rule],
+    )
+    expected = "cancel" if body.endswith("exit 2") else None
+    assert result.decision == expected
+
+
+def test_first_cancel_wins_and_stops_the_remaining_forks(tmp_path):
+    marker = tmp_path / "second_ran"
+    first = _hook(tmp_path, _emits({
+        "hookSpecificOutput": {"compactionDecision": "cancel", "reason": "no"}
+    }), name="first.sh")
+    second = _hook(tmp_path, f"touch '{marker}'; exit 0", name="second.sh")
+    payload = ClaudeHookPayloadAdapter().build_pre_compact(
+        cwd=tmp_path, trigger="auto", compaction_type="full",
+        reason="compression_threshold",
+    )
+    result = PluginHookDispatcher(cwd=tmp_path).dispatch_pre_compact_decision(
+        payload=payload, rules=[first, second],
+    )
+    assert result.decision == "cancel"
+    assert not marker.exists(), "forking stopped once a cancel was seen"
+
+
+# ---------------------------------------------------------------------------
+# End to end through the coordinator
+# ---------------------------------------------------------------------------
+
+def test_a_cancelled_compaction_leaves_history_byte_identical(tmp_path):
+    cm = _make_cm()
+    msgs = _history()
+    before = [dict(m) for m in msgs]
+    rule = _hook(tmp_path, _emits({
+        "hookSpecificOutput": {"compactionDecision": "cancel", "reason": "busy"}
+    }))
+    agent, events = _agent(cm, msgs, rules=[rule], cwd=tmp_path)
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"),
+        system_prompt="sys",
+    )
+
+    assert run.outcome.status == "cancelled"
+    assert run.outcome.detail == "busy"
+    assert agent.messages == before
+    settled = [e for e in events if getattr(e.type, "value", e.type) == "compaction_settled"]
+    assert len(settled) == 1 and settled[0].data["status"] == "cancelled"
+    # A cancel is not a compaction: the old event stays silent.
+    assert not [e for e in events if getattr(e, "type", None) == "context_compressed"]
+
+
+def test_a_cancelled_threshold_is_not_re_dispatched_this_turn(tmp_path):
+    """The latch — otherwise honouring a cancel means asking every iteration."""
+    cm = _make_cm()
+    calls = tmp_path / "calls"
+    rule = _hook(tmp_path, (
+        f"echo x >> '{calls}'\n"
+        + _emits({"hookSpecificOutput": {"compactionDecision": "cancel"}})
+    ))
+    agent, events = _agent(cm, _history(), rules=[rule], cwd=tmp_path)
+    coordinator = agent.compaction_coordinator
+
+    first = coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    )
+    second = coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    )
+
+    assert first.outcome.status == "cancelled"
+    assert second.outcome.status == "skipped"
+    assert second.outcome.detail == "suppressed_by_latch"
+    assert calls.read_text().count("x") == 1, "the hook was forked twice"
+    # A latch hit is silent, exactly like the other skipped cases.
+    assert len([e for e in events if getattr(e.type, "value", e.type) == "compaction_settled"]) == 1
+
+
+def test_a_later_overflow_in_the_same_turn_is_still_asked(tmp_path):
+    """The latch key carries ``reason``: overflow is a different question."""
+    cm = _make_cm()
+    rule = _hook(tmp_path, _emits({
+        "hookSpecificOutput": {"compactionDecision": "cancel"}
+    }))
+    agent, _events = _agent(cm, _history(), rules=[rule], cwd=tmp_path)
+    coordinator = agent.compaction_coordinator
+
+    coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    )
+    overflow = coordinator.run(
+        CompactionRequest("auto", "full", "api_overflow"), system_prompt="sys",
+    )
+
+    assert overflow.outcome.status == "cancelled", "overflow must be asked separately"
+
+
+def test_manual_cancellation_never_latches(tmp_path):
+    """``/compact`` runs outside a turn, so a turn-reset latch would strand it."""
+    cm = _make_cm()
+    rule = _hook(tmp_path, _emits({
+        "hookSpecificOutput": {"compactionDecision": "cancel"}
+    }))
+    agent, _events = _agent(cm, _history(), rules=[rule], cwd=tmp_path)
+    coordinator = agent.compaction_coordinator
+
+    first = coordinator.run(
+        CompactionRequest("manual", "full", "manual_cli"), system_prompt="sys",
+    )
+    second = coordinator.run(
+        CompactionRequest("manual", "full", "manual_cli"), system_prompt="sys",
+    )
+
+    assert first.outcome.status == "cancelled"
+    assert second.outcome.status == "cancelled", "an immediate retry must dispatch"
+
+
+def test_the_latch_is_cleared_at_the_start_of_the_next_turn(tmp_path):
+    cm = _make_cm()
+    rule = _hook(tmp_path, _emits({
+        "hookSpecificOutput": {"compactionDecision": "cancel"}
+    }))
+    agent, _events = _agent(cm, _history(), rules=[rule], cwd=tmp_path)
+    coordinator = agent.compaction_coordinator
+
+    coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    )
+    assert coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    ).outcome.detail == "suppressed_by_latch"
+
+    coordinator.reset_cancellation_latch()
+
+    assert coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    ).outcome.status == "cancelled"
+
+
+@pytest.mark.parametrize("kind,reason", [
+    ("microcompact", "microcompact_threshold"),
+    ("minimal_history", "api_overflow_after_compression"),
+])
+def test_the_other_two_kinds_are_cancellable_too(tmp_path, kind, reason):
+    cm = _make_cm()
+    # An oversized tool result, so microcompaction has something to clip and
+    # the "no targets" gate does not fire before the decision step.
+    msgs = _history() + [
+        {"role": "tool", "name": "read_file", "content": "z" * 50_000},
+    ] + [{"role": "tool", "name": "read_file", "content": "s"} for _ in range(6)]
+    before = [dict(m) for m in msgs]
+    seen = []
+
+    def _controller(ctx):
+        seen.append(ctx)
+        return CompactionDecision("cancel", reason="not now")
+
+    agent, _events = _agent(cm, msgs, controller=_controller, cwd=tmp_path)
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", kind, reason), system_prompt="sys",
+    )
+
+    assert run.outcome.status == "cancelled"
+    assert agent.messages == before
+    ctx = seen[0]
+    assert ctx.can_provide_summary is False
+    assert ctx.pre_tokens is None
+    if kind == "microcompact":
+        assert ctx.tool_results_to_clip is not None
+    else:
+        assert ctx.messages_to_keep == 2
+
+
+# ---------------------------------------------------------------------------
+# The controller
+# ---------------------------------------------------------------------------
+
+def test_a_controller_can_provide_the_summary(tmp_path):
+    cm = _make_cm()
+    called = []
+    cm._summarize_formatted = lambda _f: called.append(1) or "built-in"
+
+    agent, _events = _agent(
+        cm, _history(),
+        controller=lambda ctx: CompactionDecision(
+            "provide_summary", summary="the host's own summary",
+        ),
+        cwd=tmp_path,
+    )
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    )
+
+    assert run.outcome.status == "success"
+    assert not called, "the built-in summarizer must be skipped"
+    assert any("the host's own summary" in str(m.get("content", "")) for m in agent.messages)
+
+
+@pytest.mark.parametrize("summary,check", [
+    ("", "empty"),
+    ("   ", "empty"),
+    (12345, "not_a_string"),
+    ("x " + ContextManager.SUMMARY_END_MARKER, "contains_end_marker"),
+])
+def test_an_invalid_host_summary_degrades_to_the_built_in_one(tmp_path, summary, check):
+    """Reject, log, and run the built-in summarizer once — not "failed and
+    also continuing". A bad controller costs one extra summarization and can
+    never disable auto-compaction in three calls."""
+    cm = _make_cm()
+    cm._summarize_formatted = lambda _f: "the built-in summary"
+    agent, _events = _agent(
+        cm, _history(),
+        controller=lambda ctx: CompactionDecision("provide_summary", summary=summary),
+        cwd=tmp_path,
+    )
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    )
+
+    assert run.outcome.status == "success"
+    assert run.outcome.detail == f"host_summary_rejected:{check}"
+    assert cm.circuit_breaker_failures == 0, "an invalid host summary never counts"
+
+
+def test_an_invalid_host_summary_and_a_failing_built_in_is_one_failure(tmp_path):
+    cm = _make_cm()
+    cm._summarize_formatted = lambda _f: ""
+    agent, _events = _agent(
+        cm, _history(),
+        controller=lambda ctx: CompactionDecision("provide_summary", summary=""),
+        cwd=tmp_path,
+    )
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    )
+
+    assert run.outcome.status == "failed"
+    assert run.outcome.detail == "host_summary_rejected:empty+summary_empty"
+    # What the breaker counts is always the built-in summarizer's failure.
+    assert cm.circuit_breaker_failures == 1
+
+
+@pytest.mark.parametrize("bad", [
+    lambda ctx: (_ for _ in ()).throw(AttributeError("boom")),
+    lambda ctx: None,
+    lambda ctx: "allow",
+    lambda ctx: CompactionDecision("maybe"),
+    lambda ctx: CompactionDecision("provide_summary", summary=None),
+])
+def test_a_broken_controller_is_treated_as_allow(tmp_path, bad):
+    """Fail-open is a hard rule, and the reason is the overflow path.
+
+    Two of the five entry points *are* the recovery ladder, so an
+    ``AttributeError`` escaping a controller would turn "context too long"
+    into "the turn crashes" — killing the path this design exists to protect.
+    """
+    cm = _make_cm()
+    cm._summarize_formatted = lambda _f: "a summary"
+    agent, _events = _agent(cm, _history(), controller=bad, cwd=tmp_path)
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    )
+
+    assert run.outcome.status == "success"
+
+
+def test_an_async_controller_is_refused_rather_than_awaited(tmp_path):
+    async def _async_controller(ctx):  # pragma: no cover - never awaited
+        return CompactionDecision("cancel")
+
+    cm = _make_cm()
+    cm._summarize_formatted = lambda _f: "a summary"
+    agent, _events = _agent(cm, _history(), controller=_async_controller, cwd=tmp_path)
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    )
+
+    assert run.outcome.status == "success", "an awaitable is an unknown return, not a cancel"
+
+
+def test_a_hook_cancel_short_circuits_the_controller(tmp_path):
+    """Asking a trusted host for a summary that is about to be thrown away
+    is pure waste."""
+    cm = _make_cm()
+    consulted = []
+    rule = _hook(tmp_path, _emits({
+        "hookSpecificOutput": {"compactionDecision": "cancel", "reason": "hook says no"}
+    }))
+    agent, _events = _agent(
+        cm, _history(), rules=[rule],
+        controller=lambda ctx: consulted.append(ctx) or CompactionDecision("allow"),
+        cwd=tmp_path,
+    )
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    )
+
+    assert run.outcome.status == "cancelled"
+    assert run.outcome.detail == "hook says no"
+    assert consulted == []
+
+
+def test_the_controller_context_carries_counts_not_text(tmp_path):
+    cm = _make_cm()
+    cm._summarize_formatted = lambda _f: "a summary"
+    seen = []
+    agent, _events = _agent(
+        cm, _history(),
+        controller=lambda ctx: seen.append(ctx) or CompactionDecision("allow"),
+        cwd=tmp_path,
+    )
+
+    agent.compaction_coordinator.run(
+        CompactionRequest("auto", "full", "compression_threshold"), system_prompt="sys",
+    )
+
+    ctx = seen[0]
+    assert ctx.can_provide_summary is True
+    assert ctx.messages_to_summarize > 0 and ctx.messages_to_keep > 0
+    assert ctx.pre_tokens is not None
+    assert ctx.max_summary_tokens == ctx.summary_input_budget // 2
+    # No message text anywhere on it.
+    assert not any(
+        isinstance(v, (list, dict)) and v and not isinstance(v, tuple)
+        for v in vars(ctx).values()
+    )


### PR DESCRIPTION
Implements **PR-4** of `docs/design/compaction-orchestration-plan.md` (§4.4). Last of batch 1 — order **PR-1 → PR-3 → PR-2 → PR-4**. It migrates no entry point; it switches `decide` on over paths PR-3 already wired.

> **Stacked on #189 → #188 → #187.** Review those first; this branch contains all three.

## The defect

`PreCompact` was **notify-only**. `dispatch_pre_compact` fired the hook through `_dispatch_lifecycle` and threw the output away, so a host watching its own context about to be permanently rewritten had no way to stop it. This is the first of the two P1s from `docs/design/pi-mono-compaction-vs-agentao.md` (§8), against pi-mono's cancel-or-replace `session_before_compact`.

It was deferred for a stated reason (`docs/history/implementation/stop-precompact-hooks-plan.md:1081`): accepting a host "deny" with no fallback for *denied and still too long* produces unrecoverable runaway. **That is the part this PR actually answers.**

## Two layers, one merge rule

**1. Command hooks.** A `PreCompact` hook that prints this cancels the compaction:

```json
{"hookSpecificOutput": {"compactionDecision": "cancel",
                        "compactionDecisionReason": "mid-refactor"}}
```

First cancel wins, and the remaining forks stop. **The key is deliberately not `permissionDecision`.** The old argument for needing no opt-in gate was "a script that prints nothing means allow" — but that only proves *silent* scripts are safe and says nothing about a private script writing `hookSpecificOutput` for some other purpose. `compactionDecision` has never existed in agentao, so no existing script can produce it by accident. That is the complete argument, and a grep could never have covered a user's local private scripts anyway.

**2. `compaction_controller=`** — a new keyword-only constructor argument (after the `*`, or it would shift the legacy positional callbacks). It gets a `CompactionDecisionContext` and may `allow`, `cancel`, or `provide_summary(text)`.

Hooks **cannot** provide summary text: they have no trust boundary, and summary text permanently rewrites history. A hook cancel short-circuits the controller — asking a trusted host to compute a summary that is about to be thrown away is pure waste.

## Fail-open, and why it is a hard rule

Everything that is not an explicit cancel means allow: a missing key, non-JSON stdout, a script that prints nothing, an unknown value, a raise, an awaitable (v1 is synchronous), an `action` outside the vocabulary, `provide_summary` with no text, `provide_summary` where it has no legal meaning.

Two of the five entry points **are** the API-overflow recovery ladder. An `AttributeError` escaping a controller would turn "context too long" into "the turn crashes" — killing precisely the recovery path this design exists to protect. No control-plane error may be able to drive the context into the ladder, let alone end the turn.

There is **no timeout**: it is a synchronous in-process callback, and if it hangs it hangs the turn, exactly like `confirmation_callback` and friends. This PR does not invent a timeout mechanism.

## An invalid host summary is not a terminal state

Validated before it is committed (non-empty, a `str`, within `ctx.max_summary_tokens`, and free of `SUMMARY_END_MARKER` — which would break the *next* compaction's carry-stripping, surfacing one compaction later and attributed to the wrong place). An invalid one is rejected and logged, and **the built-in summarizer runs once as if the host had said `allow`**.

So: what the breaker counts is always the built-in summarizer's failure. An invalid host summary never counts on its own, a bad controller costs at most one extra summarization, and it can never disable auto-compaction in three calls.

## The runaway answer

A cancel is **honoured and reported**, never ignored and never quietly fallen through. History is byte-identical in every case.

| Cancelled | Result |
|---|---|
| Microcompaction | that pass is skipped; **no error** — it was never the step you cannot proceed without |
| Threshold | not re-dispatched this turn; if the API then overflows, the host is asked **again** with `reason=api_overflow` — a different question, its own answer |
| API overflow (rung 1) | the provider's context-length error is returned to the caller. **Not** a quiet fall-through to the next rung |
| API overflow (rung 2) | the same. A separate dispatch site, reachable only once rung 1 was allowed and succeeded and the request *still* overflowed, so it needs its own answer |
| Manual `/compact` | reported as cancelled; an immediate retry dispatches normally |

**The latch** makes "not re-dispatched for the rest of the turn" a mechanism rather than a promise. The loop re-checks both thresholds every iteration, so without it, honouring a cancel means forking the hook again on the very next iteration — the exact cost the stand-down gates exist to remove. Coordinator-owned, keyed `(kind, reason)`, covering exactly `microcompact_threshold` and `compression_threshold`, cleared at the start of each turn. A latch hit is **silent**: no hook, no controller, no event.

`manual_cli` never enters it — `/compact` is user-driven, does not loop, and **runs outside a turn**, so a turn-reset latch would mean "cancel manually once, and every immediate retry stays suppressed until you first run an ordinary turn". Neither overflow reason enters it either: a cancelled overflow ends the turn on the spot, so there is no re-dispatch to suppress.

## Out of scope, by design

Arbitrary message-list replacement. agentao's history is a flat list where `tool_calls[*].id` must round-trip byte-for-byte or strict APIs reject the request; a host returning an orphaned tool result, an unknown role or a bad boundary would produce a request the provider refuses, at a point where history has already been destroyed. pi-mono can afford the richer contract because its `CompactionResult` addresses a persisted session tree by `firstKeptEntryId`; agentao has no analogue.

## Also

`PLUGIN_HOOK_FIRED`'s `outcome` for `PreCompact` can now be `cancel` as well as `allow` — an additive value in an existing field.

## Gates

`uv run ruff check .` clean. `uv run python -m pytest tests/` — **4106 passed, 1 skipped**; the single failure is the pre-existing `test_model_switching_flow`, which reaches a live endpoint from a home-directory `.env` and is green in CI.

New: `tests/test_compaction_control_plane.py` (30 tests) — the wire shape and its seven not-a-cancel cases, first-cancel-wins stopping the forks, byte-identical history, the latch (including that a later overflow in the same turn is still asked, that manual never latches, and that a turn boundary clears it), cancellation for the two non-`full` kinds, `provide_summary` and all four validation rejections, the degrade-and-retry ladder, five broken-controller shapes including an async one, and that the context carries counts rather than text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
