### PR TITLE
compact: validate the context window against the provider (PR-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,44 @@ _Targeting 0.4.20. Add entries under the relevant heading as work lands._
 
 ### Added
 
+- **The context window is validated against the provider, and self-heals.**
+  `max_tokens` is a documented host-owned knob on four surfaces, and this does
+  not take that ownership away: it stays exactly what the host configured and
+  reads back unchanged. What is new is a second, lower ceiling learned from
+  the provider's own overflow errors — `effective_max_tokens = min(configured,
+  observed)` — which every internal budget is now denominated in
+  (`needs_compression`, the microcompaction band, the summary-input budget,
+  and `usage_percent`, which otherwise reported 70% while the API was already
+  rejecting).
+
+  **The parse is provider-asserted, not a number scrape, and when it is not
+  certain it adopts nothing.** Of the 21 overflow patterns roughly half carry
+  no number, and most of the ones that do carry **two** — Anthropic's
+  `213462 tokens > 200000 maximum` has the request size *and* the limit.
+  Adopting the wrong one permanently shrinks the window until the next model
+  switch: a silent degradation with no warning, which is the failure class
+  this exists to remove. So every pattern is anchored to the phrase that
+  *names* the limit, a value outside sanity bounds is refused, and **two
+  patterns disagreeing adopts nothing**. Ollama's `exceeded max context length
+  by 1200 tokens` is the case that proves it: 1200 is a delta, and nothing
+  matches it.
+
+  The observed limit is discarded on a model or endpoint switch — joining the
+  existing clear-on-switch family (thinking artifacts, tiktoken encoding,
+  token anchor, capability latches) — with a warning that the window is
+  unverified for the new model. A pure credential rotation leaves it alone.
+  `/context` shows configured, effective, and the provenance string the limit
+  was read from. `get_usage_stats()` keeps `max_tokens` meaning *configured*,
+  so old readers are unaffected, and gains `effective_max_tokens`,
+  `observed_limit` and `observed_limit_provenance`. ACP's
+  `session/set_model` echo still returns the configured value — it is a
+  setter, and its echo must equal what was just written.
+
+  **What this cannot do, stated plainly:** an overflow error is its only
+  input, so **the first fall into the recovery ladder is its input, not
+  something it can prevent**. It reduces how often you fall in again.
+
+
 - **`PreCompact` can now say no.** It was notify-only: `dispatch_pre_compact`
   fired the hook through `_dispatch_lifecycle` and threw the output away, so a
   host watching its own context about to be rewritten had no way to stop it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,16 @@ falling through to `messages[-2:]`.
 `COMPACTION_SETTLED`'s `pre_tokens_history` / `post_tokens_history` exclude
 it. Never wire one into the other.
 
+**Two windows, and they are not interchangeable.** `max_tokens` is the
+host's configured knob and reads back what the host wrote;
+`effective_max_tokens` is `min(configured, observed)`, where `observed` is
+learned from a provider overflow error via `parse_observed_context_limit`.
+**Every internal budget uses effective**; `get_usage_stats()['max_tokens']`
+and ACP's `session/set_model` echo keep returning configured. The parse is
+provider-asserted and refuses to adopt anything it is not certain of — most
+overflow messages carry *two* numbers and picking the request size instead of
+the limit is a permanent silent degradation.
+
 `ContextManager.compress_messages()` survives as the legacy wrapper (its
 signature is documented and pinned by tests that call it directly). It returns
 a bare list and so cannot say *why* nothing changed; it also bypasses the

--- a/agentao/cli/commands/context.py
+++ b/agentao/cli/commands/context.py
@@ -19,7 +19,23 @@ def handle_context_command(cli: AgentaoCLI, args: str) -> None:
         stats = cm.get_usage_stats(cli.agent.messages)
         console.print("\n[info]Context Window Status:[/info]")
         console.print(f"  Estimated tokens: [cyan]{stats['estimated_tokens']:,}[/cyan]")
-        console.print(f"  Max tokens:       [cyan]{stats['max_tokens']:,}[/cyan]")
+        console.print(f"  Max tokens:       [cyan]{stats['max_tokens']:,}[/cyan] [dim](configured)[/dim]")
+        observed = stats.get("observed_limit")
+        effective = stats.get("effective_max_tokens", stats["max_tokens"])
+        if observed is not None and effective != stats["max_tokens"]:
+            # The mismatch is the whole point of showing this: budgets are
+            # denominated in the effective window, and a user reading only
+            # the configured one would not know why compaction fires early.
+            console.print(
+                f"  Effective:        [yellow]{effective:,}[/yellow] "
+                f"[dim](provider asserted {observed:,} — "
+                f"{stats.get('observed_limit_provenance')})[/dim]"
+            )
+        elif observed is not None:
+            console.print(
+                f"  Effective:        [cyan]{effective:,}[/cyan] "
+                f"[dim](provider asserted {observed:,}, at or above configured)[/dim]"
+            )
 
         pct = stats["usage_percent"]
         # Read the tiers off the constants — hard-coded 55/65 silently lied

--- a/agentao/context_manager.py
+++ b/agentao/context_manager.py
@@ -177,6 +177,15 @@ class ContextManager:
         self.max_tokens = max_tokens
         self.memory_manager = memory_manager
 
+        # The window the *provider* asserted, learned from an overflow error.
+        # ``max_tokens`` above stays exactly what the host configured — it is
+        # a documented host-owned knob on four surfaces and reads back what
+        # the host wrote. This is a separate, lower ceiling that only ever
+        # narrows the budgets below, and it is cleared on a model or provider
+        # switch because it describes the model that rejected the request.
+        self._observed_limit: Optional[int] = None
+        self._observed_limit_provenance: Optional[str] = None
+
         # Circuit breaker: stop auto-compact after too many consecutive failures
         self._consecutive_compact_failures: int = 0
 
@@ -361,7 +370,7 @@ class ContextManager:
         computed twice (T1.3). Omit it to estimate locally.
         """
         est = tokens if tokens is not None else self._threshold_token_estimate(messages)
-        return est > self.max_tokens * self.COMPRESSION_THRESHOLD
+        return est > self.effective_max_tokens * self.COMPRESSION_THRESHOLD
 
     def needs_microcompaction(
         self, messages: List[Dict[str, Any]], tokens: Optional[int] = None
@@ -372,8 +381,8 @@ class ContextManager:
         """
         est = tokens if tokens is not None else self._threshold_token_estimate(messages)
         return (
-            est > self.max_tokens * self.MICROCOMPACT_THRESHOLD
-            and est <= self.max_tokens * self.COMPRESSION_THRESHOLD
+            est > self.effective_max_tokens * self.MICROCOMPACT_THRESHOLD
+            and est <= self.effective_max_tokens * self.COMPRESSION_THRESHOLD
         )
 
     # -----------------------------------------------------------------------
@@ -515,6 +524,96 @@ class ContextManager:
     # -----------------------------------------------------------------------
     # Full compression
     # -----------------------------------------------------------------------
+
+    @property
+    def effective_max_tokens(self) -> int:
+        """The window every internal budget is actually denominated in.
+
+        ``min(configured, observed)``. Read-only: a host that wants to change
+        the window sets :attr:`max_tokens`, which this can only narrow, never
+        widen — a provider that rejected a request at N is evidence about N,
+        not permission to exceed the host's own ceiling.
+        """
+        if self._observed_limit is None:
+            return self.max_tokens
+        return min(self.max_tokens, self._observed_limit)
+
+    @property
+    def observed_limit(self) -> Optional[int]:
+        """The provider-asserted window, or ``None`` if none has been learned."""
+        return self._observed_limit
+
+    @property
+    def observed_limit_provenance(self) -> Optional[str]:
+        """Which pattern :attr:`observed_limit` was read from."""
+        return self._observed_limit_provenance
+
+    def observe_overflow_error(self, exc: Exception) -> bool:
+        """Learn the provider's window from an overflow error, if it is certain.
+
+        Returns True when a limit was adopted. **This cannot prevent the
+        first fall into the recovery ladder** — an overflow error is its only
+        input, so by the time it can act, the ladder has already engaged. It
+        reduces how often you fall in again afterwards; it does not stand
+        between a mis-set window and the ladder.
+
+        A parse that is not certain adopts nothing: see
+        :func:`parse_observed_context_limit`.
+        """
+        parsed = parse_observed_context_limit(exc)
+        if parsed is None:
+            return False
+        limit, provenance = parsed
+        if self._observed_limit == limit:
+            return False
+        previous = self._observed_limit
+        self._observed_limit = limit
+        self._observed_limit_provenance = provenance
+        try:
+            if limit < self.max_tokens:
+                self.llm_client.logger.warning(
+                    f"Provider asserted a context window of {limit:,} tokens "
+                    f"({provenance}); the configured window is "
+                    f"{self.max_tokens:,}. Compaction budgets now use "
+                    f"{self.effective_max_tokens:,}."
+                )
+            else:
+                self.llm_client.logger.info(
+                    f"Provider asserted a context window of {limit:,} tokens "
+                    f"({provenance}); at or above the configured "
+                    f"{self.max_tokens:,}, so budgets are unchanged."
+                )
+            if previous is not None and previous != limit:
+                self.llm_client.logger.info(
+                    f"Observed context limit changed {previous:,} -> {limit:,}"
+                )
+        except Exception:
+            pass
+        return True
+
+    def clear_observed_limit(self, reason: str = "model switch") -> None:
+        """Forget the provider-asserted window.
+
+        Joins the existing clear-on-switch family (thinking artifacts, the
+        tiktoken encoding, the token anchor, the capability latches): the
+        limit describes the model that rejected the request, and the next
+        model's window is simply unverified. Never silently overwrite the
+        host's configured value — the point is that it was never overwritten
+        in the first place.
+        """
+        if self._observed_limit is None:
+            return
+        previous = self._observed_limit
+        self._observed_limit = None
+        self._observed_limit_provenance = None
+        try:
+            self.llm_client.logger.warning(
+                f"Discarding the observed context limit of {previous:,} tokens "
+                f"({reason}); the window is unverified for the new model until "
+                "it rejects a request."
+            )
+        except Exception:
+            pass
 
     def reset_compaction_circuit(self) -> None:
         """Close the breaker and forget the last failure class.
@@ -1456,7 +1555,7 @@ class ContextManager:
         """Token ceiling for the assembled summary transcript."""
         return max(
             self._SUMMARY_INPUT_BUDGET_FLOOR,
-            int(self.max_tokens * self._SUMMARY_INPUT_BUDGET_RATIO),
+            int(self.effective_max_tokens * self._SUMMARY_INPUT_BUDGET_RATIO),
         )
 
     def _block_cost(self, block: List[str]) -> int:
@@ -1669,11 +1768,19 @@ class ContextManager:
         else:
             estimated = breakdown["total"]
             source = "local"
-        usage_percent = (estimated / self.max_tokens * 100) if self.max_tokens > 0 else 0.0
+        # Denominated in the effective window, or ``/context`` reports 70%
+        # while the API is already rejecting the request.
+        _window = self.effective_max_tokens
+        usage_percent = (estimated / _window * 100) if _window > 0 else 0.0
         stats: Dict[str, Any] = {
             "estimated_tokens": estimated,
             "token_count_source": source,
+            # Unchanged meaning: what the host configured. Old readers are
+            # unaffected; the two keys below are additive.
             "max_tokens": self.max_tokens,
+            "effective_max_tokens": self.effective_max_tokens,
+            "observed_limit": self._observed_limit,
+            "observed_limit_provenance": self._observed_limit_provenance,
             "usage_percent": round(usage_percent, 1),
             "message_count": len(messages),
             "token_breakdown": breakdown,
@@ -1731,6 +1838,86 @@ _NON_OVERFLOW_PATTERNS = [
         r"service unavailable",  # 503
     )
 ]
+
+
+# Patterns that read the provider's **stated limit** out of an overflow error.
+#
+# This is deliberately not a number scrape. Of the 21 detection patterns above,
+# roughly half carry no number at all, and most of the ones that do carry
+# **two** — Anthropic's "213462 tokens > 200000 maximum" has the request size
+# and the limit, and so does OpenAI's. Picking the wrong one permanently
+# shrinks the effective window until the next model switch: a silent
+# degradation with no warning, which is the exact failure class this work
+# exists to remove.
+#
+# So every pattern here is anchored to the phrase that *names* the limit and
+# captures exactly one group. Ollama's "exceeded max context length by 1200
+# tokens" is the case that proves the rule: 1200 is a delta, and no pattern
+# below can match it.
+_OBSERVED_LIMIT_PATTERNS = [
+    (re.compile(p, re.IGNORECASE), name)
+    for p, name in (
+        # Anthropic: "prompt is too long: 213462 tokens > 200000 maximum"
+        (r"\d[\d,]*\s*tokens?\s*>\s*([\d,]+)\s*maximum", "anthropic:tokens>maximum"),
+        # OpenAI / LiteLLM / OpenRouter: "maximum context length is|of N tokens"
+        (r"maximum context length\s+(?:is|of)\s+([\d,]+)", "maximum_context_length_is"),
+        # OpenAI paren form: "exceeds model's maximum context length (262144)"
+        (r"maximum context length\s*\(\s*([\d,]+)", "maximum_context_length_paren"),
+        # Mistral: "too large for model with 32768 maximum context length"
+        (r"model with\s+([\d,]+)\s+maximum context length", "model_with_n_maximum_context_length"),
+        # xAI: "This model's maximum prompt length is 131072 but ..."
+        (r"maximum prompt length is\s+([\d,]+)", "maximum_prompt_length_is"),
+        # OpenRouter / Poolside: "maximum allowed input length of 4096 tokens"
+        (r"maximum allowed input length of\s+([\d,]+)", "maximum_allowed_input_length_of"),
+        # Google: "exceeds the maximum number of tokens allowed (1048575)"
+        (r"maximum number of tokens allowed\s*\(\s*([\d,]+)", "maximum_number_of_tokens_allowed"),
+        # Together AI: "is longer than the model's context length (8192 tokens)"
+        (r"longer than the model'?s context length\s*\(\s*([\d,]+)", "longer_than_model_context_length"),
+        # Kimi: "Your request exceeded model token limit: 131072 (requested: ...)"
+        (r"exceeded model token limit:\s*([\d,]+)", "exceeded_model_token_limit"),
+    )
+]
+
+# Sanity bounds. A parsed window below the floor or above the ceiling is a
+# misparse by definition, and adopting one would be worse than adopting
+# nothing: the fallback is the two-rung recovery ladder, which works.
+_OBSERVED_LIMIT_FLOOR = 1_024
+_OBSERVED_LIMIT_CEILING = 100_000_000
+
+
+def parse_observed_context_limit(exc: Exception) -> Optional[tuple]:
+    """Read the provider's stated context limit out of an overflow error.
+
+    Returns ``(limit, provenance)`` or ``None``. **If the parse is not
+    certain, it returns ``None``** — three ways it can be uncertain, and all
+    three are treated the same:
+
+    * no anchored pattern matched at all;
+    * the value is outside the sanity bounds;
+    * two different patterns matched and disagreed. That last one is the
+      strongest guard, because it is exactly what a number scrape would get
+      wrong silently.
+
+    Falling back to the recovery ladder is the safe outcome; a wrong limit is
+    a permanent silent degradation.
+    """
+    msg = str(exc)
+    found = {}
+    for pattern, name in _OBSERVED_LIMIT_PATTERNS:
+        m = pattern.search(msg)
+        if not m:
+            continue
+        try:
+            value = int(m.group(1).replace(",", ""))
+        except (ValueError, IndexError):
+            continue
+        if not (_OBSERVED_LIMIT_FLOOR <= value <= _OBSERVED_LIMIT_CEILING):
+            continue
+        found[value] = found.get(value) or name
+    if len(found) != 1:
+        return None
+    value, provenance = next(iter(found.items()))
+    return value, provenance
 
 
 def is_context_too_long_error(exc: Exception) -> bool:

--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -1159,6 +1159,11 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                 agent.messages.append({"role": "assistant", "content": err_msg})
                 return ChatLoopRunner._LlmOutcome(error_return=err_msg)
             agent.llm.logger.warning(f"Context overflow from API, forcing compression: {e}")
+            # The provider just told us its real window, if it named one.
+            # This is the only place that information exists, and it is why
+            # PR-5 cannot prevent the *first* fall into this ladder — an
+            # overflow error is its sole input.
+            agent.context_manager.observe_overflow_error(e)
             # Rung 1 of the ladder. It goes through the coordinator like every
             # other entry — which is what finally lets it pass its real
             # ``api_overflow`` reason instead of riding ``compress_messages``'s
@@ -1204,6 +1209,7 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                     agent.llm.logger.warning(
                         "Context still too long after compression, keeping minimal history"
                     )
+                    agent.context_manager.observe_overflow_error(e2)
                     run = agent.compaction_coordinator.run(
                         CompactionRequest(
                             "auto", "minimal_history", "api_overflow_after_compression",

--- a/agentao/runtime/model.py
+++ b/agentao/runtime/model.py
@@ -134,6 +134,11 @@ def set_provider(
     if model is not None and model != _old_model:
         agent.context_manager._encoding = _get_tiktoken_encoding(agent.llm.model)
         agent.context_manager.invalidate_token_anchor()
+        agent.context_manager.clear_observed_limit("model switch")
+    elif agent.llm.base_url != _old_base:
+        # Same model name behind a different endpoint is a different
+        # deployment, and deployments differ in what they will accept.
+        agent.context_manager.clear_observed_limit("provider switch")
     # Also purge on an endpoint change with the model name unchanged: the same
     # name behind a different backend is a different signer, so its thinking
     # artifacts are just as stale. A pure credential rotation (same model, same
@@ -170,6 +175,9 @@ def set_model(agent: "Agentao", model: str) -> str:
     agent.context_manager._encoding = _get_tiktoken_encoding(model)
     agent.context_manager.invalidate_token_anchor()
     if model != old_model:
+        # Joins the clear-on-switch family beside the encoding and the anchor:
+        # the observed limit describes the model that rejected the request.
+        agent.context_manager.clear_observed_limit("model switch")
         _purge_and_log(agent, "set_model")
     agent.llm.logger.info(f"Model changed from {old_model} to {model}")
     try:

--- a/docs/reference/host-api.md
+++ b/docs/reference/host-api.md
@@ -218,6 +218,36 @@ list where `tool_calls[*].id` must round-trip byte-for-byte, and a host
 returning an orphaned tool result would produce a request the provider refuses
 at a point where history has already been destroyed.
 
+### Two context windows
+
+| | Meaning | Who writes it |
+|---|---|---|
+| `context_manager.max_tokens` | what the host **configured** | the host (`max_context_tokens=`, `/context limit`, ACP `contextLength`) |
+| `context_manager.effective_max_tokens` | `min(configured, observed)` | derived, read-only |
+| `context_manager.observed_limit` | what the **provider asserted**, learned from an overflow error | agentao |
+
+**Every internal budget** — the compaction thresholds, the microcompaction
+band, the summary-input budget, `usage_percent` — is denominated in the
+*effective* window. **`get_usage_stats()['max_tokens']` and ACP's
+`session/set_model` echo keep returning the configured value**: the first so
+existing readers are unaffected, the second because `session/set_model` is a
+setter and its echo must equal what was just written, or a client reads
+agentao's self-healing as a failed write. `effective_max_tokens`,
+`observed_limit` and `observed_limit_provenance` are additive keys on
+`get_usage_stats()`.
+
+The observed limit can only **narrow**: a provider rejecting at N is evidence
+about N, not permission to exceed the host's ceiling. It is discarded on a
+model or endpoint switch (with a warning that the window is unverified for the
+new model); a pure credential rotation leaves it alone.
+
+**The parse refuses to guess.** Most overflow messages carry two numbers —
+the request size and the limit — so every pattern is anchored to the phrase
+that *names* the limit, values outside sanity bounds are refused, and two
+patterns disagreeing adopts nothing. An overflow error is its only input, so
+it cannot prevent the **first** fall into the recovery ladder; it reduces how
+often you fall in again.
+
 ## Capability protocols (`agentao.host.protocols`)
 
 Embedded hosts override IO by injecting these `Protocol` types into

--- a/docs/reference/host-api.zh.md
+++ b/docs/reference/host-api.zh.md
@@ -167,6 +167,30 @@ host 摘要在提交前会被校验（非空、是 `str`、不超过 `ctx.max_su
 必须逐字节往返；host 交回一条孤儿 tool result 就会造出 provider 拒收的请求，
 而那时历史已经被销毁了。
 
+### 两个上下文窗口
+
+| | 含义 | 谁写 |
+|---|---|---|
+| `context_manager.max_tokens` | host **配置的**值 | host（`max_context_tokens=`、`/context limit`、ACP `contextLength`） |
+| `context_manager.effective_max_tokens` | `min(configured, observed)` | 派生，只读 |
+| `context_manager.observed_limit` | **provider 自己声明的**窗口，从溢出错误里学到 | agentao |
+
+**所有内部预算**——压缩阈值、微压缩带、摘要输入预算、`usage_percent`——都以
+**effective** 窗口计。**`get_usage_stats()['max_tokens']` 与 ACP
+`session/set_model` 的回显仍返回 configured**：前者是为了不动既有读者，后者是因为
+`session/set_model` 是 setter，回显必须等于刚写进去的值，否则客户端会把 agentao 的
+自愈读成一次写入失败。`effective_max_tokens`、`observed_limit`、
+`observed_limit_provenance` 都是 `get_usage_stats()` 上的**新增**键。
+
+observed 只能**收窄**：provider 在 N 上拒绝，是关于 N 的证据，不是越过 host 上限的
+许可。切模型或切端点时它会被丢弃（并告警：新模型的窗口尚未验证）；单纯轮换凭据则
+保持不动。
+
+**这个解析拒绝猜。** 大多数溢出消息带**两个**数字——请求大小和上限——所以每条模式
+都锚在**点名上限**的那句话上；越界值不采纳；**两条模式给出不同答案时什么都不采纳**。
+它唯一的输入就是一次溢出错误，所以它**挡不住第一次**掉进恢复阶梯，只能减少之后再掉
+进去的次数。
+
 ## 能力协议（`agentao.host.protocols`）
 
 嵌入宿主通过向 `Agentao(filesystem=..., shell=..., mcp_registry=..., memory_manager=...)`

--- a/tests/test_context_window_validation.py
+++ b/tests/test_context_window_validation.py
@@ -1,0 +1,254 @@
+"""The context window can be validated against the provider, and self-heal.
+
+`max_tokens` is a **documented host-owned knob** on four surfaces, and this
+does not take that ownership away: it stays exactly what the host wrote and
+reads back unchanged. What is new is a second, lower ceiling learned from the
+provider's own overflow errors — `effective_max_tokens = min(configured,
+observed)` — which every internal budget is now denominated in.
+
+The hard part is the parse, not the plumbing. Of the 21 detection patterns
+roughly half carry no number, and most that do carry **two**: Anthropic's
+"213462 tokens > 200000 maximum" has the request size *and* the limit.
+Adopting the wrong one permanently shrinks the window until the next model
+switch — a silent degradation with no warning, which is the exact failure
+class this work exists to remove. So the parse is provider-asserted, and
+**when it is not certain it adopts nothing**.
+
+State plainly what this cannot do: an overflow error is its only input, so
+**the first fall into the recovery ladder is its input, not something it can
+prevent**. It reduces how often you fall in again.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from agentao.context_manager import (
+    ContextManager,
+    parse_observed_context_limit,
+)
+
+
+def _cm(max_tokens=200_000):
+    llm = Mock()
+    llm.logger = Mock()
+    llm.model = "test-model"
+    return ContextManager(llm, Mock(), max_tokens=max_tokens)
+
+
+# ---------------------------------------------------------------------------
+# The parse
+# ---------------------------------------------------------------------------
+
+# Every row is a real provider string from the detection regression table,
+# paired with the number that is genuinely **the limit** — never the request
+# size, which is the adjacent number in most of them.
+PARSEABLE = [
+    ("anthropic", "prompt is too long: 213462 tokens > 200000 maximum", 200_000),
+    ("openai_of", "Requested token count exceeds the model's maximum context "
+                  "length of 131072 tokens", 131_072),
+    ("openai_paren", "Input length (265330) exceeds model's maximum context "
+                     "length (262144).", 262_144),
+    ("google", "The input token count (1196265) exceeds the maximum number of "
+               "tokens allowed (1048575)", 1_048_575),
+    ("xai", "This model's maximum prompt length is 131072 but the request "
+            "contains 537812 tokens", 131_072),
+    ("openrouter", "This endpoint's maximum context length is 32768 tokens. "
+                   "However, you requested more", 32_768),
+    ("poolside", "Input length 5000 exceeds the maximum allowed input length "
+                 "of 4096 tokens.", 4_096),
+    ("together", "The input (9000 tokens) is longer than the model's context "
+                 "length (8192 tokens).", 8_192),
+    ("mistral", "Prompt contains 40000 tokens, too large for model with 32768 "
+                "maximum context length", 32_768),
+    ("kimi", "Your request exceeded model token limit: 131072 (requested: 200000)",
+     131_072),
+]
+
+
+@pytest.mark.parametrize("label,msg,expected", PARSEABLE, ids=[c[0] for c in PARSEABLE])
+def test_the_limit_is_read_not_the_request_size(label, msg, expected):
+    parsed = parse_observed_context_limit(Exception(msg))
+    assert parsed is not None, msg
+    assert parsed[0] == expected, f"{label}: picked the wrong number"
+
+
+# Errors that carry no usable limit. The Ollama row is the one that proves
+# the rule: 1200 is a *delta*, and a bare number scrape would adopt it.
+UNPARSEABLE = [
+    ("ollama_delta", "prompt too long; exceeded max context length by 1200 tokens"),
+    ("generic_code", "Error code: context_length_exceeded"),
+    ("groq", "Please reduce the length of the messages or completion"),
+    ("lm_studio", "tokens to keep from the initial prompt is greater than the "
+                  "context length"),
+    ("bedrock", "input is too long for requested model"),
+    ("dashscope", "Range of input length should be ..."),
+    ("anthropic_413", '413 {"error":{"type":"request_too_large"}}'),
+]
+
+
+@pytest.mark.parametrize("label,msg", UNPARSEABLE, ids=[c[0] for c in UNPARSEABLE])
+def test_an_uncertain_parse_adopts_nothing(label, msg):
+    assert parse_observed_context_limit(Exception(msg)) is None
+
+
+def test_two_patterns_disagreeing_adopts_nothing():
+    """The strongest guard, and the one a number scrape gets wrong silently."""
+    msg = ("maximum context length is 32768 tokens; "
+           "this model's maximum prompt length is 131072")
+    assert parse_observed_context_limit(Exception(msg)) is None
+
+
+@pytest.mark.parametrize("value", ["12", "999999999999"])
+def test_a_value_outside_the_sanity_bounds_adopts_nothing(value):
+    msg = f"maximum context length is {value} tokens"
+    assert parse_observed_context_limit(Exception(msg)) is None
+
+
+def test_thousands_separators_are_tolerated():
+    parsed = parse_observed_context_limit(
+        Exception("maximum context length is 131,072 tokens")
+    )
+    assert parsed is not None and parsed[0] == 131_072
+
+
+# ---------------------------------------------------------------------------
+# Ownership: configured is the host's, effective is derived
+# ---------------------------------------------------------------------------
+
+def test_the_configured_window_is_never_overwritten():
+    cm = _cm(200_000)
+    cm.observe_overflow_error(Exception("maximum context length is 32768 tokens"))
+
+    assert cm.max_tokens == 200_000, "the host's knob reads back what the host wrote"
+    assert cm.observed_limit == 32_768
+    assert cm.effective_max_tokens == 32_768
+
+
+def test_an_observed_limit_can_only_narrow():
+    """A provider rejecting at N is evidence about N, not permission to
+    exceed the host's own ceiling."""
+    cm = _cm(32_768)
+    cm.observe_overflow_error(Exception("maximum context length is 200000 tokens"))
+
+    assert cm.observed_limit == 200_000
+    assert cm.effective_max_tokens == 32_768
+
+
+def test_internal_budgets_use_the_effective_window():
+    cm = _cm(200_000)
+    msgs = [{"role": "user", "content": "x" * 400_000}]  # ~100k tokens
+    assert cm.needs_compression(msgs) is False
+
+    cm.observe_overflow_error(Exception("maximum context length is 32768 tokens"))
+
+    assert cm.needs_compression(msgs) is True
+    assert cm._summary_input_budget() < 200_000 * cm._SUMMARY_INPUT_BUDGET_RATIO
+
+
+def test_usage_percent_uses_the_effective_window():
+    """Or /context reports 70% while the API is already rejecting."""
+    cm = _cm(200_000)
+    msgs = [{"role": "user", "content": "x" * 40_000}]
+    before = cm.get_usage_stats(msgs)["usage_percent"]
+
+    cm.observe_overflow_error(Exception("maximum context length is 32768 tokens"))
+    after = cm.get_usage_stats(msgs)["usage_percent"]
+
+    assert after > before
+
+
+def test_usage_stats_keeps_max_tokens_meaning_configured():
+    cm = _cm(200_000)
+    cm.observe_overflow_error(Exception("maximum context length is 32768 tokens"))
+    stats = cm.get_usage_stats([{"role": "user", "content": "hi"}])
+
+    # The old key does not change meaning — old hosts are unaffected.
+    assert stats["max_tokens"] == 200_000
+    assert stats["effective_max_tokens"] == 32_768
+    assert stats["observed_limit"] == 32_768
+    assert stats["observed_limit_provenance"] == "maximum_context_length_is"
+
+
+# ---------------------------------------------------------------------------
+# Clear on switch
+# ---------------------------------------------------------------------------
+
+def test_a_model_switch_discards_the_observed_limit(tmp_path):
+    """It describes the model that rejected the request. The next model's
+    window is simply unverified — and it is never silently overwritten."""
+    from agentao.runtime.model import set_model
+    from tests.support.stop_precompact import make_bare_agent
+
+    agent = make_bare_agent(tmp_path)
+    cm = agent.context_manager
+    cm.observe_overflow_error(Exception("maximum context length is 32768 tokens"))
+    assert cm.effective_max_tokens == 32_768
+
+    set_model(agent, "another-model")
+
+    assert cm.observed_limit is None
+    assert cm.effective_max_tokens == cm.max_tokens
+
+
+def test_a_credential_rotation_leaves_it_alone(tmp_path):
+    """Same model, same endpoint — nothing about the window changed."""
+    from agentao.runtime.model import set_provider
+    from tests.support.stop_precompact import make_bare_agent
+
+    agent = make_bare_agent(tmp_path)
+    cm = agent.context_manager
+    cm.observe_overflow_error(Exception("maximum context length is 32768 tokens"))
+
+    set_provider(agent, api_key="rotated")
+
+    assert cm.observed_limit == 32_768
+
+
+def test_an_endpoint_switch_discards_it(tmp_path):
+    """The same model name behind a different deployment is a different
+    deployment, and deployments differ in what they accept."""
+    from agentao.runtime.model import set_provider
+    from tests.support.stop_precompact import make_bare_agent
+
+    agent = make_bare_agent(tmp_path)
+    cm = agent.context_manager
+    cm.observe_overflow_error(Exception("maximum context length is 32768 tokens"))
+
+    set_provider(agent, api_key="k", base_url="https://other.local/v1")
+
+    assert cm.observed_limit is None
+
+
+def test_the_ladder_records_what_the_provider_said(tmp_path, monkeypatch):
+    """The observation point is the overflow branch — its only input."""
+    from agentao.cancellation import CancellationToken
+    from agentao.compaction.types import CompactionOutcome
+    from agentao.runtime.chat_loop import ChatLoopRunner
+    from tests.support.stop_precompact import make_bare_agent
+
+    agent = make_bare_agent(tmp_path)
+    agent.messages = [{"role": "user", "content": f"m{i}"} for i in range(6)]
+    agent._last_session_summary_id = None
+    monkeypatch.setattr(agent, "_build_system_prompt", lambda: "")
+    monkeypatch.setattr(agent, "_emit_session_summary_if_new", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        agent.context_manager, "_run_compaction",
+        lambda msgs, **kw: CompactionOutcome(
+            status="failed", trigger="auto", kind="full",
+            reason="api_overflow", messages=msgs, detail="summary_empty",
+        ),
+    )
+
+    def _overflow(*_a, **_k):
+        raise RuntimeError("prompt is too long: 213462 tokens > 200000 maximum")
+
+    monkeypatch.setattr(agent, "_llm_call", _overflow)
+    ChatLoopRunner(agent)._call_llm_with_overflow_recovery(
+        [{"role": "system", "content": ""}] + agent.messages, "", [], CancellationToken(),
+    )
+
+    assert agent.context_manager.observed_limit == 200_000
+    assert agent.context_manager.observed_limit_provenance == "anthropic:tokens>maximum"

--- a/tests/test_model_switch_thinking_purge.py
+++ b/tests/test_model_switch_thinking_purge.py
@@ -108,7 +108,13 @@ class _FakeAgent:
             reconfigure=self._reconfigure,
         )
         self.context_manager = SimpleNamespace(
-            _encoding=None, invalidate_token_anchor=lambda: None,
+            _encoding=None,
+            invalidate_token_anchor=lambda: None,
+            # Part of the same clear-on-switch family; stubbed rather than
+            # spied on because asserting it here would be a spy nobody reads.
+            # It is covered against the real ContextManager in
+            # tests/test_context_window_validation.py.
+            clear_observed_limit=lambda *_a, **_k: None,
         )
         self.transport = SimpleNamespace(emit=lambda _e: None)
 


### PR DESCRIPTION
Implements **PR-5** of `docs/design/compaction-orchestration-plan.md` (§5.1). First of batch 2 (P2/P3 quality work). Its priority rose when the full-compaction threshold moved to 80%: at 0.65 there were 35 points of window between "we compact" and "the API rejects"; at 0.80 there are 20, and that margin is what absorbs a mis-set window.

> **Stacked on #190 → #189 → #188 → #187.**

## What this is not

It does **not** take `max_tokens` away from the host. That is a documented host-owned knob on four surfaces (`agent.py`, `embedding/factory.py`, `/context limit`, ACP `contextLength`), it stays exactly what the host configured, and it reads back what the host wrote. It also introduces **no model-window catalogue** to maintain.

## What it adds

A second, lower ceiling learned from the provider's own overflow errors:

```
effective_max_tokens = min(configured, observed)
```

**Every internal budget switches to effective** — the compaction thresholds, the microcompaction band, the summary-input budget, and `usage_percent`, which otherwise reported 70% while the API was already rejecting the request.

**The external surfaces do not move.** `get_usage_stats()['max_tokens']` keeps meaning *configured*, so old readers are unaffected; `effective_max_tokens` / `observed_limit` / `observed_limit_provenance` are additive keys. ACP's `session/set_model` echo still returns configured — it is a **setter**, and its echo must equal what was just written or a client reads agentao's self-healing as a failed write.

## The parse is the hard part

Of the 21 patterns in `_OVERFLOW_PATTERNS`, roughly half carry no number at all, and **most of the ones that do carry two**:

```
prompt is too long: 213462 tokens > 200000 maximum
                    ^ request size  ^ the limit
```

Adopting the wrong one permanently shrinks the effective window until the next model switch — *a silent degradation with no warning*, which is the exact failure class this whole plan exists to remove. So:

- **Provider-asserted, never a bare number scrape.** Every pattern is anchored to the phrase that *names* the limit and captures exactly one group.
- **Sanity-bounded.** A value outside `[1024, 100_000_000]` is refused.
- **Two patterns disagreeing adopts nothing.** This is the guard a number scrape gets wrong silently.
- **If the parse is not certain, do not adopt it.** Falling back to the ladder is the safe outcome.

Ollama's `prompt too long; exceeded max context length by 1200 tokens` is the case that proves the rule: 1200 is a *delta*, and nothing here can match it.

The parse table is verified against the real provider strings in `tests/test_context_overflow_detection.py` — 10 rows where it must pick the limit and not the adjacent request size, and 7 where it must adopt nothing.

## Ownership and clearing

- The observed limit can only **narrow**: a provider rejecting at N is evidence about N, not permission to exceed the host's ceiling.
- Discarded on a model or endpoint switch, with a warning that the window is unverified for the new model — joining the existing clear-on-switch family (thinking artifacts, tiktoken encoding, token anchor, capability latches). **A pure credential rotation leaves it alone.**
- `/context` shows configured, effective, and the provenance string the limit was read from.

## What it cannot do

Stated in the code, the docs and here: **an overflow error is its only input**, so the *first* fall into the recovery ladder is its input, not something it can prevent. It reduces how often you fall in again. What the 0.80 threshold raised is two different risks — estimation error under a *correct* configuration, and some mid-size window mismatches — and this can do nothing about the first and only post-first-failure work about the second.

## Gates

`uv run ruff check .` clean. `uv run python -m pytest tests/` — **4136 passed, 1 skipped**; the single failure is the pre-existing `test_model_switching_flow` live-endpoint flake, green in CI.

New: `tests/test_context_window_validation.py` (30 tests). One touched test: `test_model_switch_thinking_purge.py`'s fake context manager gains the new method as an explicit no-op, with a pointer to where the real behaviour is covered — a spy nobody reads is worse than a stub that says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
