### PR TITLE
docs(guides): session summaries are written on success, not on trigger

### DIFF
--- a/docs/guides/memory-management.md
+++ b/docs/guides/memory-management.md
@@ -56,7 +56,7 @@ schema_meta        — 版本元数据
 
 **产生时机：** 由上下文压缩管道写入——
 - **Microcompaction**（55% 用量）：截断大型工具结果，不生成摘要文本
-- **Full LLM summarization**（80% 用量）：将早期消息浓缩为结构化摘要，调用 `MemoryManager.save_session_summary()` 持久化
+- **Full LLM summarization**（80% 用量）：将早期消息浓缩为结构化摘要，调用 `MemoryManager.save_session_summary()` 持久化。**仅在压缩成功时写入**——0.4.20 起,一次被跳过、被否决或摘要失败的压缩不再落一条摘要（此前是压缩尝试后无条件写入）
 
 **关键字段：**
 
@@ -225,5 +225,12 @@ AI: [调用 save_memory，key 相同时自动覆盖]
 
 ### 会话摘要丢失
 
-- 摘要仅在触发全量 LLM 压缩（80% 用量）时写入，短会话不会生成
+- 摘要仅在全量 LLM 压缩（80% 用量）**成功**时写入,短会话不会生成
+- **熔断器打开时自动压缩已暂停**,因此不会再产生摘要。`/context` 会在有失败记录时打印
+  `Compact breaker: open (3/3 consecutive failures, last: …)`,并给出恢复方式:
+  `/compact` 以半开探针身份运行,成功即复位(`/clear` 同样复位)
+- 压缩也可能被**否决**:一个 `PreCompact` 命令钩子返回
+  `{"hookSpecificOutput": {"compactionDecision": "cancel"}}`,或宿主传入的
+  `compaction_controller=` 返回 `cancel`。这种情况不计入熔断器,`/context` 的
+  breaker 那行也不会出现——查 `agentao.log` 里的 `Compaction cancelled:`
 - `/memory clear` 会同时清空会话摘要；`/clear` 仅清空对话历史，不清空摘要


### PR DESCRIPTION
I swept `docs/guides/` for drift against 0.4.20. **One real defect**, in `memory-management.md`.

## What was wrong

The guide said summaries are persisted when full LLM compaction **triggers**:

> 摘要仅在触发全量 LLM 压缩（80% 用量）时写入

That was accurate before the orchestration stack — the threshold path called the emit unconditionally after the attempt (`_compaction.py:124` at `af94b11`). Now both SQLite writes live in `commit_compaction` (`agentao/context_manager.py:1032`), which does not run unless a summary exists. A compaction that is **skipped**, **cancelled**, or whose **summarization fails** leaves no row.

## Why the troubleshooting section matters more than the one-word fix

The section titled **会话摘要丢失** ("session summary missing") is exactly where a user lands with this symptom, and 0.4.20 introduced two new causes it did not name:

| Cause | How to see it | How to recover |
|---|---|---|
| **Breaker open** — automatic compaction is paused | `/context` prints `Compact breaker: open (3/3 consecutive failures, last: …)` whenever failures > 0, plus the recovery line | `/compact` runs as a half-open probe; a success resets it. So does `/clear` |
| **Vetoed** by a `PreCompact` hook returning `compactionDecision: cancel`, or a host's `compaction_controller=` | **Not** on the `/context` breaker line — a cancel does not count against the breaker, and that line only prints when failures > 0 | `agentao.log`: `Compaction cancelled: kind=… reason=… (<detail>)` |

The second row is the one worth having written down: it is invisible in the place a user would naturally look.

## Verified, not assumed

- `save_session_summary` is called only from `context_manager.py:1032`, inside `commit_compaction` (confirmed by walking back to the enclosing `def`) — so the guide names the right function and the right path.
- The `Compaction cancelled:` string is produced by `coordinator.py:233-237`, an f-string interpolating `outcome.status`, logged via `agent.llm.logger.info` — the logger that writes `agentao.log`.
- `/context` gates the whole breaker block on `failures > 0` (`cli/commands/context.py:50`), which is why a cancel never shows there.

## Scope of the sweep

Everything else in `docs/guides/` came back clean:

- Only `memory-management.md` and `acp.md` mention compaction at all; `acp.md`'s hits are "compact JSON" and permission storage — unrelated.
- No guide hardcodes the replay schema version (`session-replay.md` refers to the `schema_version` field, not a literal), so the 1.2 → 1.3 bump needs nothing.
- No guide lists event kinds, so `COMPACTION_SETTLED` adds no obligation.
- `65%` appears nowhere; the 65% → 80% threshold change is already reflected.
- `embedding.md` / `embed-for-agents.md` show construction *examples* rather than enumerating kwargs, so `compaction_controller=` creates no stale claim. It is documented in `docs/reference/host-api.md` (both twins). Adding it to the embedding guide would be an enhancement, not a fix — flagging rather than doing it.

## No CHANGELOG entry

The behaviour is already covered by the 0.4.20 entry *"a failed summarization no longer writes to the memory store"*. This is documentation catch-up.

`ruff check .` clean (doc-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)