### PR TITLE
chore: open 0.4.21 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+_Targeting 0.4.21. Add entries under the relevant heading as work lands._
+
+### Added
+
+### Changed
+
+### Fixed
+
+---
+
 ## [0.4.20] — 2026-08-24
 
 ### Added

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.20"
+__version__ = "0.4.21.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Routine cycle-open after v0.4.20 shipped to PyPI.

- `__version__` → `0.4.21.dev0`
- `[Unreleased]` block restored above `[0.4.20]`

## Two things that are easy to get wrong here

**The 0.4.20 cut deleted the whole block, not just its headings.** Some previous cuts kept `## [Unreleased]` and retargeted its `_Targeting_` line, leaving the cycle-open to re-add three empty `###` headings. This one removed the block outright, so the header and the targeting line had to come back too. Copying the previous cycle-open's diff would have left the file with no `[Unreleased]` header at all.

**PEP 440 canonical `.dev0`, not `0.4.21-dev`.** Hatchling normalizes the hyphen form to `.dev0` in wheel and sdist metadata either way, so both build identically — but `agentao.__version__` then exposes a string that differs from the version PyPI reports. The 0.4.10 and 0.4.11 cycle-opens drifted this way and had to be re-normalized in #97.

Verified: `import agentao; agentao.__version__` → `0.4.21.dev0`. `ruff check .` clean.

## v0.4.20 ship record

| Step | Result |
|---|---|
| Release | https://github.com/jin-bo/agentao/releases/tag/v0.4.20 |
| `publish.yml` | run 32746962365 — success |
| PyPI `info.version` | `0.4.20` |
| `/pypi/agentao/0.4.20/json` | HTTP 200 |
| Artifacts | `agentao-0.4.20-py3-none-any.whl` + `agentao-0.4.20.tar.gz` |

All three PyPI endpoints re-requested with `Cache-Control: no-cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)