### PR TITLE
chore: open 0.4.22 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+_Targeting 0.4.22. Add entries under the relevant heading as work lands._
+
+### Added
+
+### Changed
+
+### Fixed
+
+---
+
 ## [0.4.21] — 2026-08-30
 
 ### Added

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.21"
+__version__ = "0.4.22.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Bumps `__version__` to `0.4.22.dev0` and restores the `[Unreleased]` block after the 0.4.21 ship.

**The cut removed the block outright**, the same shape as 0.4.20's, so this restores the header and the `_Targeting_` line as well as the three `###` headings. Reading what the cut actually left is the point — a cycle-open diff copied from a cycle whose cut only *emptied* the headings would leave the file with no `[Unreleased]` header at all.

**PEP 440 canonical `.dev0`**, not the hyphenated `X.Y.Z-dev`: hatchling normalizes the hyphen to `.dev0` in the distribution metadata either way, so the hyphen form leaves `agentao.__version__` exposing a string that differs from the version PyPI reports.

0.4.21 is live: `pypi.org/pypi/agentao/json` → `info.version` `0.4.21`, wheel + sdist, version-specific endpoint HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCPjY5yoLWgf6HD6pPkbUi
