### PR TITLE
fix(shell): run bash, as the tool description has always promised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,44 @@ _Targeting 0.4.22. Add entries under the relevant heading as work lands._
 
 ### Fixed
 
+- **`run_shell_command` promised the model `bash -c` and delivered `/bin/sh
+  -c`. It is bash now.** The tool executes through
+  `subprocess.Popen(command, shell=True)`, and Python hardcodes `/bin/sh` on
+  POSIX — there was no `executable=` anywhere. On most Linux distributions
+  that is dash, so bashisms the model reaches for by default died with a
+  syntax error; macOS hid most of it because `/bin/sh` there is bash 3.2 in
+  POSIX mode, which still rejects process substitution. `LocalShellExecutor`
+  now passes `executable=` at **both** `Popen` sites (foreground and
+  background — the background one is a separate call and would otherwise
+  have run a different shell than the tool advertises).
+
+  **bash is resolved, not assumed.** `capabilities/shell.py::
+  resolve_shell_executable()` prefers `/bin/bash`, then `bash` on PATH, then
+  returns `None` — Python's default — because Alpine and distroless images
+  ship `/bin/sh` and no bash, where a hardcoded `executable` would turn every
+  shell command into a `FileNotFoundError`. `/bin/bash` wins over the PATH
+  lookup so the choice does not shift when a newer bash is installed under
+  `/opt/homebrew`. The description is built from the resolver rather than a
+  literal, so it degrades with it; the regression test asks the live
+  interpreter what `$0` is and requires the description to name *that*.
+
+  macOS `--sandbox` re-enters a second shell inside `sandbox-exec`, and that
+  one moved too. Left on `/bin/sh` it would have meant the same command
+  parsing on a plain run and failing under `--sandbox`.
+
+  Windows is unchanged: `shell=True` there means `%COMSPEC% /c`, and
+  `executable=` would replace cmd.exe rather than select a dialect.
+  **Plugin hooks are also unchanged** and stay on `/bin/sh` deliberately —
+  Claude Code 2.1.251 was measured running command hooks under `sh`
+  (`docs/reference/hooks-probe-2.1.251.md` §A), so agentao's baseline there
+  is conformant and moving it would be a divergence, not a fix.
+
+  One consequence worth stating: the hardline scanner's known
+  variable-indirection blind spot (`D=rm; $D -rf /etc`, already reachable
+  under dash) gains one more bash-only member on Linux — `${D//X/}`. Same
+  class, not a new one; `$'...'` decoding and `<(...)` were already covered,
+  verified by probe.
+
 ---
 
 ## [0.4.21] — 2026-08-30

--- a/agentao/capabilities/shell.py
+++ b/agentao/capabilities/shell.py
@@ -14,17 +14,63 @@ byte-equivalent.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 import threading
 import time
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Protocol, runtime_checkable
 
 from .process import build_child_env, kill_process_tree
 
 IS_WINDOWS = sys.platform == "win32"
+
+
+@lru_cache(maxsize=1)
+def resolve_shell_executable() -> Optional[str]:
+    """Path to pass as ``Popen(shell=True, executable=...)``, or ``None``.
+
+    Python hardcodes ``/bin/sh`` for ``shell=True`` on POSIX, so without
+    this every ``run_shell_command`` ran under a POSIX shell — dash on most
+    Linux distributions — while the tool description promised the model
+    bash. Resolving bash explicitly makes the promise true rather than
+    walking it back: bashisms the model reaches for by default (process
+    substitution ``<(...)``, ``${var//x/y}``) now work everywhere instead
+    of only where ``/bin/sh`` happens to be bash.
+
+    ``None`` means "keep Python's default", and it is the whole reason this
+    returns an Optional instead of a constant: minimal images (Alpine,
+    distroless) ship ``/bin/sh`` and no bash at all, where a hardcoded
+    ``executable`` would turn every shell command into a
+    ``FileNotFoundError``. Degrading to ``/bin/sh`` is correct there — but
+    the *description* has to degrade with it, which is why
+    :class:`agentao.tools.shell.ShellTool` builds its text from this
+    function rather than from a literal.
+
+    ``/bin/bash`` wins over a PATH lookup so the choice does not shift when
+    a user installs a newer bash under ``/opt/homebrew`` or ``/usr/local``.
+    Windows is untouched: ``shell=True`` there means ``%COMSPEC% /c``, and
+    ``executable=`` would replace cmd.exe rather than select a dialect.
+    """
+    if IS_WINDOWS:
+        return None
+    if os.path.isfile("/bin/bash") and os.access("/bin/bash", os.X_OK):
+        return "/bin/bash"
+    return shutil.which("bash")
+
+
+def shell_display_name() -> str:
+    """The shell that will actually interpret a command, for display.
+
+    Never ``None`` — falls back to the POSIX default that
+    :func:`resolve_shell_executable` returning ``None`` selects.
+    """
+    if IS_WINDOWS:
+        return "cmd"
+    return resolve_shell_executable() or "/bin/sh"
 
 
 @dataclass(frozen=True)
@@ -94,6 +140,7 @@ class LocalShellExecutor:
     def run(self, request: ShellRequest) -> ShellResult:
         popen_kwargs: Dict[str, Any] = dict(
             shell=True,
+            executable=resolve_shell_executable(),
             cwd=request.cwd,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
@@ -165,6 +212,7 @@ class LocalShellExecutor:
     def run_background(self, request: ShellRequest) -> BackgroundHandle:
         popen_kwargs: Dict[str, Any] = dict(
             shell=True,
+            executable=resolve_shell_executable(),
             cwd=request.cwd,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,

--- a/agentao/tools/shell.py
+++ b/agentao/tools/shell.py
@@ -11,7 +11,11 @@ IS_MACOS = sys.platform == "darwin"
 
 from .base import Tool
 from ..capabilities import BackgroundHandle, LocalShellExecutor, ShellRequest, ShellResult
-from ..capabilities.shell import _is_binary
+from ..capabilities.shell import (
+    _is_binary,
+    resolve_shell_executable,
+    shell_display_name,
+)
 from ..sandbox import SandboxProfile
 from ..security import PathPolicy, PathPolicyError
 
@@ -71,15 +75,22 @@ def _collapse_carriage_returns(text: str) -> str:
 def _wrap_with_sandbox(command: str, profile: SandboxProfile) -> str:
     """Prefix `command` with a sandbox-exec invocation.
 
-    The resulting string is a single POSIX shell expression that, when run
-    under `/bin/sh -c`, will exec `sandbox-exec` with the required -D /-f
-    flags and pass the original command to a fresh `/bin/sh -c` inside the
+    The resulting string is a single shell expression that, when run under
+    the outer shell, will exec `sandbox-exec` with the required -D /-f
+    flags and pass the original command to a fresh inner shell inside the
     sandbox. stdout / stderr / exit code propagate normally.
+
+    The inner shell is :func:`resolve_shell_executable`'s answer — the same
+    one the outer `Popen(shell=True, executable=...)` uses. Hardcoding
+    `/bin/sh` here would mean a sandboxed command silently got a different
+    dialect from an unsandboxed one, so the same command would parse on a
+    plain run and fail under `--sandbox`.
     """
     if not IS_MACOS:
         return command
+    inner = resolve_shell_executable() or "/bin/sh"
     prefix = " ".join(shlex.quote(a) for a in profile.as_args())
-    return f"{prefix} /bin/sh -c {shlex.quote(command)}"
+    return f"{prefix} {shlex.quote(inner)} -c {shlex.quote(command)}"
 
 
 _SANDBOX_DENIAL_MARKERS = (
@@ -142,7 +153,11 @@ class ShellTool(Tool):
             "- Signal: only included if the process was killed by a signal.\n"
             "- Background PGID: only included when is_background=true."
         )
-        shell_desc = "cmd /c <command>" if IS_WINDOWS else "bash -c <command>"
+        shell_desc = (
+            "cmd /c <command>"
+            if IS_WINDOWS
+            else f"{shell_display_name()} -c <command>"
+        )
         stop_desc = (
             "taskkill /F /PID <PID>" if IS_WINDOWS
             else "`kill -- -PGID` or signaled as `kill -s SIGNAL -- -PGID`"
@@ -164,10 +179,10 @@ class ShellTool(Tool):
                 "command": {
                     "type": "string",
                     "description": (
-                    "Exact command to execute. "
-                    "On Unix runs as `bash -c <command>`; "
-                    "on Windows runs as `cmd /c <command>`."
-                ),
+                        "Exact command to execute. On Unix runs as "
+                        f"`{shell_display_name()} -c <command>`; "
+                        "on Windows runs as `cmd /c <command>`."
+                    ),
                 },
                 "description": {
                     "type": "string",

--- a/docs/guides/macos-sandbox-exec.md
+++ b/docs/guides/macos-sandbox-exec.md
@@ -30,7 +30,11 @@ ToolRunner._execute_one()  (tool_runner.py:252)
   ShellTool.execute(_sandbox_profile=..., command=..., ...)
      │
      ├─► _wrap_with_sandbox(command, profile, cwd)
-     │   → "sandbox-exec -D _RW1=<cwd> -f <abs.sb> /bin/sh -c '<quoted>'"
+     │   → "sandbox-exec -D _RW1=<cwd> -f <abs.sb> <shell> -c '<quoted>'"
+     │     (<shell> = capabilities/shell.py::resolve_shell_executable() —
+     │      /bin/bash 正常情况，无 bash 时退回 /bin/sh；必须与外层
+     │      Popen(executable=) 一致，否则同一条命令加不加 --sandbox
+     │      会走两种方言)
      │
      ▼
   subprocess.Popen(wrapped_command, shell=True, ...)
@@ -154,7 +158,7 @@ to run `/sandbox off` or switch profile via `/sandbox profile <name>`.
 
 - **`sandbox-exec` 被标 deprecated**（自 macOS 10.12）**但仍在 macOS 15 / Darwin 25 上正常工作**。Bazel、Claude Code 等均在用，短期不会被移除。
 - 必须用 `-D _RW1=$(pwd)` 传工作区绝对路径；profile 里用 `(subpath (param "_RW1"))` 引用。
-- 对子 shell (`/bin/sh -c '...'`) 完全友好：stdout、stderr、exit code 透明传播。
+- 对子 shell (`<shell> -c '...'`) 完全友好：stdout、stderr、exit code 透明传播。
 - **无法按域名限制网络**——只能 all-or-nothing。要域名级控制仍需靠 `web_fetch` 的 `PermissionEngine`。
 - 进入沙箱前打开的 fd 仍可在沙箱内使用（不要在外面预开文件再传给子进程）。
 - SIP / TCC 是独立层，不会被 sandbox-exec 绕过，也不会绕过它。

--- a/tests/test_sandbox_policy.py
+++ b/tests/test_sandbox_policy.py
@@ -13,7 +13,19 @@ from agentao.sandbox import (
     SandboxProfile,
     load_sandbox_config,
 )
+from agentao.capabilities.shell import resolve_shell_executable
 from agentao.tools.shell import _wrap_with_sandbox, _annotate_sandbox_denial
+
+
+def _inner_shell() -> str:
+    """The shell `_wrap_with_sandbox` re-enters inside sandbox-exec.
+
+    Read from the resolver rather than written as a literal: neither
+    test below is about the dialect — they are about the sandbox-exec
+    argv shape and about quoting — so pinning `/bin/sh` here made them
+    fail when the dialect legitimately changed to bash.
+    """
+    return resolve_shell_executable() or "/bin/sh"
 
 
 MACOS_ONLY = pytest.mark.skipif(sys.platform != "darwin", reason="sandbox-exec is macOS only")
@@ -500,7 +512,7 @@ def test_wrap_with_sandbox_produces_correct_shell_string(tmp_path):
     assert wrapped.startswith("sandbox-exec")
     assert f"-D _RW1={tmp_path.resolve()}" in wrapped
     assert str(profile.path) in wrapped
-    assert "/bin/sh -c" in wrapped
+    assert f"{_inner_shell()} -c" in wrapped
     # The original command must be shell-quoted so && doesn't leak out.
     assert "'echo hello && ls -la'" in wrapped
 
@@ -533,7 +545,7 @@ def test_wrap_with_sandbox_handles_single_quotes(tmp_path):
     # sh's own quoting: 'it'\''s' is the POSIX-portable way to embed a '
     wrapped = _wrap_with_sandbox("echo 'it's'", profile)
     # Whatever shlex does, it must not leave the outer quoting ambiguous
-    assert wrapped.count("/bin/sh -c") == 1
+    assert wrapped.count(f"{_inner_shell()} -c") == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shell_tool_shell_dialect.py
+++ b/tests/test_shell_tool_shell_dialect.py
@@ -1,0 +1,205 @@
+"""``run_shell_command`` must run the shell its description names.
+
+``subprocess.Popen(command, shell=True)`` is hardcoded to ``/bin/sh`` on
+POSIX, but the tool description has always told the model ``bash -c``. On
+most Linux distributions ``/bin/sh`` is dash, so bashisms the model reaches
+for by default died with a syntax error; macOS hid it because ``/bin/sh``
+there is bash 3.2 in POSIX mode, which still rejects process substitution.
+``LocalShellExecutor`` now passes ``executable=`` so bash is what actually
+interprets the command.
+
+The first test asserts *consistency* rather than a literal: it asks the live
+interpreter what it is and requires the description to name that. A literal
+would only restate the belief that was already wrong once, and would keep
+passing if the executable were changed underneath it. Because bash is
+resolved rather than assumed — Alpine and distroless images have no bash —
+the description degrades with the resolver, and a test pins that too.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from agentao.capabilities import shell as shell_cap
+from agentao.tools.shell import ShellTool
+
+IS_WINDOWS = sys.platform == "win32"
+
+
+def _make_tool(tmp_path) -> ShellTool:
+    tool = ShellTool()
+    tool.working_directory = str(tmp_path)
+    return tool
+
+
+def _descriptions(tool: ShellTool):
+    return (
+        ("description", tool.description),
+        ("command param", tool.parameters["properties"]["command"]["description"]),
+    )
+
+
+# --------------------------------------------------------------------------
+# The invariant: description == what actually interprets the command
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="`$0` is meaningless under cmd.exe")
+def test_description_names_the_interpreter_that_actually_runs(tmp_path):
+    tool = _make_tool(tmp_path)
+    # Under `<shell> -c <command>` with no trailing operands, `$0` is the
+    # shell's own path — so this reports the interpreter, whatever it is.
+    out = tool.execute(command='printf %s "$0"', working_directory=".", timeout=10)
+    actual = shell_cap.shell_display_name()
+    assert actual in out, f"expected $0 == {actual!r}; got: {out!r}"
+    for label, text in _descriptions(tool):
+        assert actual in text, f"{label} does not name {actual}: {text!r}"
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="POSIX-only")
+def test_description_degrades_when_bash_is_absent(monkeypatch, tmp_path):
+    """A bash-less image (Alpine, distroless) falls back to Python's default
+    ``/bin/sh``. Nothing else exercises that branch, and a description still
+    promising bash there would be the original defect with a new value."""
+    monkeypatch.setattr(shell_cap, "resolve_shell_executable", lambda: None)
+    assert shell_cap.shell_display_name() == "/bin/sh"
+    tool = _make_tool(tmp_path)
+    for label, text in _descriptions(tool):
+        assert "/bin/sh -c" in text, f"{label} did not degrade: {text!r}"
+        assert "bash" not in text, f"{label} still promises bash: {text!r}"
+
+
+# --------------------------------------------------------------------------
+# The behaviour change itself
+# --------------------------------------------------------------------------
+
+
+class _PopenSpy:
+    instances: list = []
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.pid = 4242
+        self.stdout = _DummyStream()
+        self.stderr = _DummyStream()
+        self.returncode = 0
+        _PopenSpy.instances.append(self)
+
+    def poll(self):
+        return 0
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        pass
+
+
+class _DummyStream:
+    def read(self, n=-1):
+        return b""
+
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_spy():
+    _PopenSpy.instances = []
+    yield
+    _PopenSpy.instances = []
+
+
+@pytest.mark.parametrize("background", [False, True])
+def test_both_popen_sites_pass_the_resolved_executable(monkeypatch, tmp_path, background):
+    """Foreground and background are separate ``Popen`` calls. The ``$0``
+    test above only reaches the foreground one, so a background path left on
+    Python's default would run a different shell than the tool advertises."""
+    monkeypatch.setattr(subprocess, "Popen", _PopenSpy)
+    monkeypatch.setattr(os, "getpgid", lambda pid: pid)
+    tool = _make_tool(tmp_path)
+    tool.execute(
+        command="echo hi",
+        working_directory=".",
+        timeout=1,
+        is_background=background,
+    )
+    expected = shell_cap.resolve_shell_executable()
+    assert _PopenSpy.instances, "expected Popen to be invoked"
+    for inst in _PopenSpy.instances:
+        assert inst.kwargs.get("shell") is True, inst.kwargs
+        assert inst.kwargs.get("executable") == expected, (
+            f"{'background' if background else 'foreground'} Popen got "
+            f"executable={inst.kwargs.get('executable')!r}, expected {expected!r}"
+        )
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="POSIX-only shell dialect")
+def test_bash_only_syntax_now_runs(tmp_path):
+    """Process substitution is the concrete bashism the description has
+    always promised. Under ``/bin/sh`` it is a syntax error — on macOS too,
+    where ``/bin/sh`` is bash in POSIX mode."""
+    if shell_cap.resolve_shell_executable() is None:
+        pytest.skip("no bash on this system; the tool correctly advertises /bin/sh")
+    tool = _make_tool(tmp_path)
+    out = tool.execute(
+        command="diff <(echo a) <(echo a) && printf 'procsub_%s' ok",
+        working_directory=".",
+        timeout=10,
+    )
+    assert "procsub_ok" in out, f"process substitution still rejected: {out!r}"
+    assert "syntax error" not in out.lower(), out
+
+
+def test_windows_description_names_cmd(monkeypatch, tmp_path):
+    """The Windows wording is unconditional, so it can be checked anywhere:
+    ``shell=True`` there means ``%COMSPEC% /c`` and is deliberately left
+    alone — ``executable=`` would replace cmd.exe, not pick a dialect."""
+    monkeypatch.setattr("agentao.tools.shell.IS_WINDOWS", True)
+    tool = _make_tool(tmp_path)
+    for label, text in _descriptions(tool):
+        assert "cmd /c" in text, f"{label}: {text!r}"
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="POSIX-only")
+def test_windows_resolver_returns_none(monkeypatch):
+    """``executable=`` on Windows replaces cmd.exe rather than selecting a
+    dialect, so the resolver must decline there."""
+    monkeypatch.setattr(shell_cap, "IS_WINDOWS", True)
+    shell_cap.resolve_shell_executable.cache_clear()
+    try:
+        assert shell_cap.resolve_shell_executable() is None
+        assert shell_cap.shell_display_name() == "cmd"
+    finally:
+        shell_cap.resolve_shell_executable.cache_clear()
+
+
+# --------------------------------------------------------------------------
+# The sandbox path must not fork the dialect
+# --------------------------------------------------------------------------
+
+
+def test_sandbox_wrapper_reenters_the_same_shell(monkeypatch, tmp_path):
+    """``_wrap_with_sandbox`` spawns a *second* shell inside sandbox-exec.
+    Leaving that one on ``/bin/sh`` would mean the same command parses on a
+    plain run and fails under ``--sandbox`` — a dialect split that only
+    shows up on macOS with sandboxing on, which no other test covers."""
+    from agentao.sandbox.policy import SandboxProfile
+    from agentao.tools import shell as shell_tool
+
+    monkeypatch.setattr(shell_tool, "IS_MACOS", True)
+    profile = SandboxProfile(
+        name="workspace-write",
+        path=tmp_path / "p.sb",
+        workspace_root=tmp_path,
+        params={"_RW1": str(tmp_path)},
+    )
+    wrapped = shell_tool._wrap_with_sandbox("echo hi", profile)
+    expected = shell_cap.resolve_shell_executable() or "/bin/sh"
+    assert f"{expected} -c " in wrapped, wrapped
+    assert wrapped.startswith("sandbox-exec "), wrapped


### PR DESCRIPTION
## What

`run_shell_command` told the model it runs `bash -c` and ran `/bin/sh -c`. It runs bash now.

The tool executes through `subprocess.Popen(command, shell=True)`, and Python hardcodes `/bin/sh` on POSIX — there was no `executable=` anywhere in the tree. On most Linux distributions that is dash, so bashisms the model reaches for by default died with a syntax error. macOS hid most of it because `/bin/sh` there is bash 3.2 in POSIX mode — but process substitution fails on macOS too:

```
$ diff <(echo a) <(echo a)
/bin/sh: -c: line 0: syntax error near unexpected token `('
```

agentao already knew internally: `_wrap_with_sandbox`'s docstring has said `/bin/sh -c` all along, while the model-facing strings two functions away said bash.

## How

- **`capabilities/shell.py::resolve_shell_executable()`** — `/bin/bash` → `bash` on PATH → `None`. **bash is resolved, not assumed**: Alpine and distroless ship `/bin/sh` and no bash, where a hardcoded `executable` would turn every shell command into a `FileNotFoundError`. `/bin/bash` wins over the PATH lookup so the choice does not shift when a newer bash lands under `/opt/homebrew`.
- **Both `Popen` sites** get `executable=`. Foreground and background are separate calls; the background one would otherwise have run a different shell than the tool advertises, and the `$0` test cannot reach it.
- **Both model-facing descriptions are built from the resolver, not a literal**, so they degrade with it when there is no bash.
- **macOS `--sandbox` re-enters a second shell** inside `sandbox-exec`; that one moved too. Left on `/bin/sh` it would have meant the same command parsing on a plain run and failing under `--sandbox`.

## Deliberately unchanged

- **Windows.** `shell=True` there means `%COMSPEC% /c`, and `executable=` would replace cmd.exe rather than select a dialect. The resolver returns `None` on win32.
- **Plugin hooks.** `_dispatcher.py` keeps its own `shell=True` and stays on `/bin/sh`. Claude Code 2.1.251 was **measured** running command hooks under `sh` (`$0` = `/bin/sh`, `posix on` — `docs/reference/hooks-probe-2.1.251.md` §A), so agentao's baseline there is conformant and moving it would be a divergence, not a fix.
- **No new config knob.** The `ShellExecutor` protocol is already the injectable seam for a host that wants a different shell (`docs/guides/embedding.md:303`).

## Security note

The hardline scanner's known variable-indirection blind spot (`D=rm; $D -rf /etc`, already reachable under dash and recorded in the qm review) gains one more bash-only member on Linux: `${D//X/}`. Same class, not a new one. Probed before writing the change — `$'\x72m' -rf /` at top level, `eval $'...'`, and `cat <(rm -rf /)` are **all still blocked**.

## Tests

8 new in `tests/test_shell_tool_shell_dialect.py`. The lead test asserts **consistency, not a literal**: it asks the live interpreter what `$0` is and requires both descriptions to name that — so changing the executable later fails the test until the text moves with it. Also covered: both `Popen` sites carry the resolved executable, the description degrades when bash is absent, the sandbox wrapper re-enters the same shell, and the Windows resolver declines.

**Every test was falsified against the unfixed source**: removing the two `executable=` wirings fails 4; reverting the sandbox inner shell fails the 5th.

Two existing assertions in `test_sandbox_policy.py` pinned `/bin/sh` while actually testing the sandbox-exec argv shape and quoting — they now read the resolver instead of a literal.

`ruff check .` clean; full suite **4628 passed, 1 skipped**.