### PR TITLE
docs(developer-guide): ShellRequest carries a launch now, and permissions.json has a second key

### DIFF
--- a/developer-guide/en/appendix/a-api-reference.md
+++ b/developer-guide/en/appendix/a-api-reference.md
@@ -245,7 +245,16 @@ class ShellExecutor(Protocol):
     def run_background(self, request: ShellRequest) -> BackgroundHandle: ...
 ```
 
-Frozen dataclasses: `FileEntry(name, is_dir, is_file, size)`, `FileStat(size, mtime, is_dir, is_file)`, `ShellRequest(command, cwd, timeout, on_chunk, env)`, `ShellResult(returncode, stdout, stderr, timed_out)`, `BackgroundHandle(pid, pgid, command, cwd)`.
+Frozen dataclasses: `FileEntry(name, is_dir, is_file, size)`, `FileStat(size, mtime, is_dir, is_file)`, `ShellRequest(launch, timeout, on_chunk)`, `ShellResult(returncode, stdout, stderr, timed_out)`, `BackgroundHandle(pid, pgid, command, cwd)`.
+
+**A `ShellRequest` carries a launch, not a command** (changed in 0.4.22; it used to hold `command`, `cwd` and `env` directly). `request.launch` is one of two shapes, and an executor picks them apart with `isinstance`:
+
+| Shape | Fields | How to run it |
+|---|---|---|
+| `LegacyLaunch` | `command`, `cwd`, `env`, `executable` | `subprocess.Popen(command, shell=True, executable=executable or None, cwd=cwd, env=env)` — what every host got before, and still gets unless an interpreter is configured |
+| `WindowsLaunch` | `application_name`, `command_line`, `cwd`, `env` | start `application_name` with `command_line` and **no shell in between**; produced when a `shell` block names an interpreter |
+
+`request.command` and `request.cwd` survive as read-only properties, so an executor that only logs or audits them needs no change; **`request.env` is gone** — read it from the launch. An executor may additionally implement `ShellSpecProvider`, a `shell_spec` property answering `ShellSpec | Exhausted`, to declare which interpreter it will run; the command floor and the prompt's shell guidance both read that answer. Full contract: `docs/reference/host-api.md`.
 
 Hosts that cannot support real backgrounding may raise `NotImplementedError` from `run_background` — `ShellTool` surfaces that as a normal tool error string.
 

--- a/developer-guide/en/appendix/b-config-keys.md
+++ b/developer-guide/en/appendix/b-config-keys.md
@@ -115,9 +115,13 @@ All three MCP transports are supported: stdio, Streamable HTTP, and SSE. A bare 
       "domain": { "allowlist": [".github.com"], "url_arg": "url" },
       "action": "allow"
     }
-  ]
+  ],
+  "shell": { "dialect": "powershell" }
 }
 ```
+
+Two top-level keys, `rules` and `shell`. Anything else is a named error rather
+than an ignored key.
 
 **Rule fields**:
 
@@ -127,6 +131,19 @@ All three MCP transports are supported: stdio, Streamable HTTP, and SSE. A bare 
 | `args` | object | no | Map of `<arg_name>` → regex; **all** entries must `re.search`-match for the rule to fire |
 | `domain` | object | no | URL-tools only (`web_fetch`); keys `url_arg` (default `"url"`), `allowlist`, `blocklist`. Patterns starting with `.` do suffix matching (e.g. `.github.com` matches `api.github.com`); otherwise exact match |
 | `action` | string | yes | `"allow"` \| `"deny"` \| `"ask"` (case-insensitive) |
+
+**Shell block** (new in 0.4.22, user scope, Windows only):
+
+| Key | Type | Required | Notes |
+|-----|------|----------|-------|
+| `dialect` | string | no | `"posix"` \| `"cmd"` \| `"powershell"` — the syntax the interpreter reads. This is what the command floor scans with and what the prompt's shell guidance speaks. On its own it is enough: `{"dialect": "powershell"}` is the ordinary way to turn PowerShell on |
+| `path` | string | no | absolute path to a specific interpreter. **Requires `dialect`** — `path` alone is an error, because nothing can infer the syntax from a filename |
+
+`{"dialect": "powershell"}` discovers `pwsh.exe`, else `powershell.exe`, and is
+an **error if neither is installed** — never a silent fall back to cmd. Nothing
+configured leaves Windows on `%COMSPEC% /c` exactly as before. On macOS and
+Linux, asking for `powershell` or `cmd` is an unsupported-platform error. Full
+behaviour, including the launch and the encoding: `docs/reference/configuration.md` §4.
 
 The `mode` field is **not** stored in `permissions.json` — it lives in `settings.json` (B.3.5) and is changed at runtime via `/permissions`. Modes: `read-only`, `workspace-write`, `full-access`, `plan` (lowercase-hyphen; `plan` is internal).
 

--- a/developer-guide/en/cli/10-config-reference.md
+++ b/developer-guide/en/cli/10-config-reference.md
@@ -26,6 +26,7 @@ This is a CLI-centric **index** to every config file the CLI reads. The schema r
 | Default permission mode for fresh sessions | `.agentao/settings.json` → `mode` *(persisted-last-known, see [§3](https://github.com/jin-bo/agentao/blob/main/docs/reference/configuration.md#3-agentaosettingsjson--runtime-mode--builtin-agents))* |
 | Allow / deny extra shell commands | `~/.agentao/permissions.json` |
 | Allow / deny extra web domains | `~/.agentao/permissions.json` |
+| Use PowerShell instead of cmd (Windows) | `~/.agentao/permissions.json` → `shell` |
 | Default sandbox profile (macOS) | `.agentao/sandbox.json` or `~/.agentao/sandbox.json` → `default_profile` |
 | Default context window | `AGENTAO_CONTEXT_TOKENS` environment variable |
 | Default replay recording state | `.agentao/settings.json` → `replay.enabled` |

--- a/developer-guide/en/part-5/4-permissions.md
+++ b/developer-guide/en/part-5/4-permissions.md
@@ -75,9 +75,16 @@ A `<cwd>/.agentao/permissions.json` is **not** loaded — the engine logs a warn
     {"tool": "write_file", "action": "ask"},
     {"tool": "run_shell_command", "args": {"command": "rm\\s+-rf"}, "action": "deny"},
     {"tool": "*", "action": "ask"}
-  ]
+  ],
+  "shell": { "dialect": "powershell" }
 }
 ```
+
+The file has two top-level keys. `rules` is everything below; `shell` (new in
+0.4.22, Windows only) chooses the interpreter `run_shell_command` uses and the
+syntax the command floor scans with — see appendix B.3.2, or
+`docs/reference/configuration.md` §4 for the launch and the encoding. An
+unknown top-level key is a named error, not an ignored one.
 
 **Evaluation order** (first match wins):
 

--- a/developer-guide/zh/appendix/a-api-reference.md
+++ b/developer-guide/zh/appendix/a-api-reference.md
@@ -241,7 +241,16 @@ class ShellExecutor(Protocol):
     def run_background(self, request: ShellRequest) -> BackgroundHandle: ...
 ```
 
-冻结的 dataclass：`FileEntry(name, is_dir, is_file, size)`、`FileStat(size, mtime, is_dir, is_file)`、`ShellRequest(command, cwd, timeout, on_chunk, env)`、`ShellResult(returncode, stdout, stderr, timed_out)`、`BackgroundHandle(pid, pgid, command, cwd)`。
+冻结的 dataclass：`FileEntry(name, is_dir, is_file, size)`、`FileStat(size, mtime, is_dir, is_file)`、`ShellRequest(launch, timeout, on_chunk)`、`ShellResult(returncode, stdout, stderr, timed_out)`、`BackgroundHandle(pid, pgid, command, cwd)`。
+
+**`ShellRequest` 带的是一个 launch，不是一条命令**（0.4.22 改动；以前 `command`、`cwd`、`env` 直接挂在它上面）。`request.launch` 是两种形状之一，执行器用 `isinstance` 分开：
+
+| 形状 | 字段 | 怎么跑 |
+|---|---|---|
+| `LegacyLaunch` | `command`、`cwd`、`env`、`executable` | `subprocess.Popen(command, shell=True, executable=executable or None, cwd=cwd, env=env)` —— 这就是过去每个宿主拿到的东西，没配置解释器时仍然是它 |
+| `WindowsLaunch` | `application_name`、`command_line`、`cwd`、`env` | 用 `command_line` 启动 `application_name`，**中间不经过 shell**；`shell` 块点名解释器时产出这种 |
+
+`request.command` 与 `request.cwd` 作为只读属性保留，所以只是记录 / 审计它们的执行器无需改动；**`request.env` 没有了** —— 去 launch 上读。执行器还可以额外实现 `ShellSpecProvider`，即一个回答 `ShellSpec | Exhausted` 的 `shell_spec` 属性，来声明它将运行哪个解释器；命令地板扫描用的语法和提示词里的 shell 指引都读这个答案。完整契约见 `docs/reference/host-api.zh.md`。
 
 宿主无法支持真正的后台执行时，可以在 `run_background` 抛 `NotImplementedError`——`ShellTool` 会把它呈现为普通的工具错误字符串。
 

--- a/developer-guide/zh/appendix/b-config-keys.md
+++ b/developer-guide/zh/appendix/b-config-keys.md
@@ -115,9 +115,12 @@ JSON 配置文件位于 `.agentao/` 目录（项目位于 `<working_directory>/.
       "domain": { "allowlist": [".github.com"], "url_arg": "url" },
       "action": "allow"
     }
-  ]
+  ],
+  "shell": { "dialect": "powershell" }
 }
 ```
+
+两个顶层键：`rules` 与 `shell`。其余键会报出点名的错误，而不是被忽略。
 
 **规则字段**：
 
@@ -127,6 +130,18 @@ JSON 配置文件位于 `.agentao/` 目录（项目位于 `<working_directory>/.
 | `args` | object | 否 | `<arg_name>` → 正则的映射；**全部**条目都要 `re.search` 命中规则才生效 |
 | `domain` | object | 否 | 仅 URL 类工具（`web_fetch`）；键：`url_arg`（默认 `"url"`）、`allowlist`、`blocklist`。`.` 开头的模式做后缀匹配（如 `.github.com` 命中 `api.github.com`），否则精确匹配 |
 | `action` | string | 是 | `"allow"` \| `"deny"` \| `"ask"`（大小写不敏感） |
+
+**`shell` 块**（0.4.22 新增，用户级，仅 Windows）：
+
+| 键 | 类型 | 必填 | 说明 |
+|-----|------|------|------|
+| `dialect` | string | 否 | `"posix"` \| `"cmd"` \| `"powershell"` —— 该解释器读的语法。命令地板按它扫描，提示词里的 shell 指引也按它写。单独给它就够了：`{"dialect": "powershell"}` 就是打开 PowerShell 的常规写法 |
+| `path` | string | 否 | 指定解释器的绝对路径。**必须与 `dialect` 成对出现** —— 单独给 `path` 报错，因为没有谁能从文件名推出语法 |
+
+`{"dialect": "powershell"}` 会自动发现 `pwsh.exe`，其次 `powershell.exe`；**两者都没有则报错**，绝不静默回落到
+cmd。什么都不配置时，Windows 仍旧是 `%COMSPEC% /c`，与过去完全一致。在 macOS / Linux 上显式选择
+`powershell` 或 `cmd` 报不支持的平台配置错误。完整行为（含启动与编码）见
+`docs/reference/configuration.zh.md` §4。
 
 `mode` 字段**不**写在 `permissions.json` 里 — 它属于 `settings.json`（B.3.5），运行时通过 `/permissions` 切换。模式取值：`read-only`、`workspace-write`、`full-access`、`plan`（小写连字符；`plan` 为内部模式）。
 

--- a/developer-guide/zh/cli/10-config-reference.md
+++ b/developer-guide/zh/cli/10-config-reference.md
@@ -26,6 +26,7 @@
 | 新会话默认权限模式 | `.agentao/settings.json` → `mode`*（"上次记住的模式"，[§3](https://github.com/jin-bo/agentao/blob/main/docs/reference/configuration.zh.md#3-agentaosettingsjson--运行时模式--内置子代理)）* |
 | 加放行 / 拒绝的 shell 命令 | `~/.agentao/permissions.json` |
 | 加放行 / 拒绝的 web 域名 | `~/.agentao/permissions.json` |
+| Windows 上改用 PowerShell 而不是 cmd | `~/.agentao/permissions.json` → `shell` |
 | 默认沙箱 profile（macOS） | `.agentao/sandbox.json` 或 `~/.agentao/sandbox.json` → `default_profile` |
 | 默认上下文窗口大小 | 环境变量 `AGENTAO_CONTEXT_TOKENS` |
 | 默认是否录 replay | `.agentao/settings.json` → `replay.enabled` |

--- a/developer-guide/zh/part-5/4-permissions.md
+++ b/developer-guide/zh/part-5/4-permissions.md
@@ -75,9 +75,14 @@ agent.permission_engine.set_mode(PermissionMode.READ_ONLY)
     {"tool": "write_file", "action": "ask"},
     {"tool": "run_shell_command", "args": {"command": "rm\\s+-rf"}, "action": "deny"},
     {"tool": "*", "action": "ask"}
-  ]
+  ],
+  "shell": { "dialect": "powershell" }
 }
 ```
+
+文件有两个顶层键。`rules` 是下文的全部内容；`shell`（0.4.22 新增，仅 Windows）决定
+`run_shell_command` 用哪个解释器、以及命令地板按哪种语法扫描 —— 见附录 B.3.2，启动与编码见
+`docs/reference/configuration.zh.md` §4。未知的顶层键会报出点名的错误，不会被忽略。
 
 **评估顺序**（最先匹配者胜）：
 


### PR DESCRIPTION
Two gaps a pre-release sweep of `developer-guide/` found. Both language twins of every file.

## `ShellRequest(command, cwd, timeout, on_chunk, env)` is wrong as of this release

The real shape is `ShellRequest(launch, timeout, on_chunk)`. A host that followed the API appendix and constructed one with `command=` / `cwd=` / `env=` gets a `TypeError` — and the appendix was correct in 0.4.21, so this cycle is what broke it.

The entry now gives both launch shapes with their fields and how to spawn each, says that `command` and `cwd` survive as read-only properties so a logging or auditing executor needs no change, and says plainly that `env` is gone. It also names `ShellSpecProvider`, which an executor may implement to declare the interpreter it will run.

## The `shell` block was documented nowhere in the developer guide

The configuration reference has it in full; the guide still described `permissions.json` as a file with one top-level key. It is now in the config-keys appendix with both of its keys, in the permissions chapter's structure block, and as a row in the CLI reference's "what do I change to…" table.

## Verification

Every documented claim was measured against the loader rather than read off the source:

| Input | Result |
|---|---|
| `rules` + `shell` | accepted |
| `dialect` alone | accepted, `ShellDialect.POWERSHELL` |
| unknown top-level key | `PermissionConfigError` |
| `path` without `dialect` | `PermissionConfigError` |
| removed key `ladder` | `PermissionConfigError` |

Both new JSON examples parse. Suite 4929 passed, ruff clean.

Documentation only, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYdKi4MGNBiqq7aHHNTRA5