### PR TITLE
chore: open 0.4.23 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+_Targeting 0.4.23. Add entries under the relevant heading as work lands._
+
+### Added
+
+### Changed
+
+### Fixed
+
+---
+
 ## [0.4.22] — 2026-09-07
 
 ### Added

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.22"
+__version__ = "0.4.23.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Bumps `__version__` to `0.4.23.dev0` and restores the `[Unreleased]` block.

The 0.4.22 cut removed the block outright rather than emptying its headings, the same shape as the 0.4.20 and 0.4.21 cuts, so this restores the header and the `_Targeting_` line as well as the three `###` headings. Reading what the cut actually left is the point: a cycle-open diff copied from a cycle whose cut only emptied the headings would leave the file with no `[Unreleased]` header at all.

PEP 440 canonical `.dev0` rather than the hyphenated `X.Y.Z-dev`. Hatchling normalizes the hyphen to `.dev0` in the distribution metadata either way, so the hyphen form leaves `agentao.__version__` exposing a string that differs from the version PyPI reports. Verified with `packaging.version.Version`.

0.4.22 is published: the Release was created at 2026-09-07T03:34Z pointing at `26a4b81`, the publish workflow is green, and PyPI serves both the wheel and the sdist with provenance attestations.

Two files, 13 insertions. Suite 4929 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYdKi4MGNBiqq7aHHNTRA5