### PR TITLE
fix(compaction): the overflow ladder's last rung must not orphan a tool result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,39 @@ _Targeting 0.4.23. Add entries under the relevant heading as work lands._
 
 ### Fixed
 
+- **The overflow ladder's last rung no longer hands the provider an orphaned
+  tool result.** Rung 2 (`minimal_history`) kept the newest two messages by a
+  blind tail slice. Overflow is normally detected on the request *after* a
+  batch of tool results was appended, so that tail is routinely two results
+  whose `tool_calls` sat one message further back — a shape strict APIs reject
+  outright. The rung runs only after the provider has already refused the
+  request twice, so the malformed retry spent the turn's last attempt on a 400
+  that was no longer even a context-length error, and the ladder built to save
+  the turn ended it instead. The boundary is now repaired the way the
+  summarizing path has always repaired its own (`_find_split_index`): leading
+  results are dropped when a valid window survives without them, and otherwise
+  the window steps back to the assistant message that made the calls, which
+  re-admits that exchange's results for free. `messages_to_keep` on the
+  `CompactionDecisionContext` — the count a `compaction_controller` approves
+  or cancels against — now reports what the cut will actually keep rather than
+  the nominal `keep_tail`, so a host approving the cut is shown the cut. (The
+  `PreCompact` hook payload carries no such field, and is dispatched before
+  the transform besides.)
+
+- **The last rung now stands down instead of reporting a compaction it did not
+  perform.** A flat tail slice always shed something, so `success` used to
+  imply history changed. A repaired boundary does not: the smallest *valid*
+  window can be the whole history, which is what one assistant message and a
+  large batch of its results produces — the likeliest shape at this rung. It
+  can also be nothing at all, and it can be unfixable, when a call's result
+  was never appended and no window answers its own calls. All three now gate
+  to `skipped` alongside the existing no-target microcompact gate, so no
+  `CONTEXT_COMPRESSED` fires with `pre == post` and the token anchor is not
+  dropped for a rewrite that did not happen. The runner treats every
+  non-success at this rung the way it already treated a cancel: it returns the
+  provider's own context-length error rather than spending the turn's last
+  attempt on the request that just failed.
+
 ---
 
 ## [0.4.22] — 2026-09-07

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,33 @@ the turn it exists to save. A cancelled threshold compaction enters a
 coordinator-owned latch keyed `(kind, reason)`, cleared per turn in
 `runtime/turn.py`; `manual_cli` and both overflow reasons never enter it. A
 cancelled **overflow** returns the provider's context-length error rather than
-falling through to `messages[-2:]`.
+falling through to the last rung.
+
+**The last rung is not a plain tail slice, and must not be simplified back
+into one.** `apply_minimal_history` keeps the newest `keep_tail` messages, but
+`_minimal_history_start` first repairs the boundary so the window cannot *open
+on* a `role: "tool"` message — the same rule `_find_split_index` enforces for
+the summarizing path, and it bites harder here: overflow is normally detected
+on the request *after* a batch of results was appended, so a two-message tail
+is routinely two results whose `tool_calls` sit one message back, and this rung
+gets the turn's last attempt. Repair order is **drop the leading results, and
+only if that empties a window that had content, step back to the assistant that
+made the calls** (the window is a suffix, so admitting the call admits its
+results). `prepare_minimal_history` reports the **effective** count, so
+`messages_to_keep` on the decision context is the cut the host is being asked
+to approve.
+
+**And the rung stands down when there is no cut worth making.** Because the
+boundary is repaired, `success` no longer implies history changed:
+`minimal_history_would_help` gates the attempt to `skipped` in three cases —
+the smallest valid window is the whole history (one assistant message plus a
+large batch of its results, the likeliest shape here), it is empty, or it
+cannot answer its own calls (a call whose result was never appended; the
+repair closes result→call, never call→result). The gate sits next to the
+no-target microcompact gate for the same reason. The runner returns the
+provider's context-length error on **any** non-success at this rung, not only
+on a cancel: nothing shrank, so retrying spends the turn's last attempt on the
+request that just failed.
 
 **Two token units, deliberately named apart.** `CONTEXT_COMPRESSED`'s
 `pre_est_tokens` / `post_est_tokens` **include** the system prompt;

--- a/agentao/compaction/coordinator.py
+++ b/agentao/compaction/coordinator.py
@@ -136,7 +136,7 @@ class CompactionCoordinator:
         agent = self._agent
         cm = agent.context_manager
 
-        gate = self._gate(request)
+        gate = self._gate(request, keep_tail=keep_tail)
         if gate is not None:
             # ``skipped`` is silent by construction: three of the four
             # skipped cases re-trigger on *every* loop iteration, so emitting
@@ -248,7 +248,9 @@ class CompactionCoordinator:
     # Policy
     # ------------------------------------------------------------------
 
-    def _gate(self, request: CompactionRequest) -> Optional[CompactionOutcome]:
+    def _gate(
+        self, request: CompactionRequest, *, keep_tail: int,
+    ) -> Optional[CompactionOutcome]:
         """Return a ``skipped`` outcome when this attempt must not run.
 
         Nothing here counts against the circuit breaker: ``skipped`` means
@@ -302,6 +304,20 @@ class CompactionCoordinator:
             # left to shorten: once every old tool result is at or under the
             # limit, every further iteration in the band is a no-op.
             return self._skipped(request, "no_microcompact_targets")
+
+        if request.kind == "minimal_history" and not cm.minimal_history_would_help(
+            agent.messages, keep_tail=keep_tail
+        ):
+            # Same shape as the line above, and it became necessary for the
+            # same reason: the cut is no longer a flat tail slice that always
+            # sheds something. Once the boundary is repaired so it cannot
+            # orphan a tool result, the smallest *valid* window can be the
+            # whole history — one assistant message and a big batch of its
+            # results, which is the likeliest shape at this rung. Reporting
+            # ``success`` there would emit a compaction whose pre and post
+            # are equal and hand the retry the request the provider just
+            # refused. See ``ContextManager.minimal_history_would_help``.
+            return self._skipped(request, "no_valid_minimal_cut")
 
         return None
 
@@ -357,7 +373,14 @@ class CompactionCoordinator:
                 post_tokens=None,
             )
 
-        prep = cm.prepare_minimal_history(agent.messages, keep_tail=keep_tail)
+        # Bound once, and both halves read the same list object. ``_ask``
+        # runs arbitrary host code — the controller — between the count and
+        # the cut, so re-reading ``agent.messages`` afterwards would let a
+        # host that rebinds it be shown a count for one history and handed a
+        # cut of another. Boundary repair means the two are no longer
+        # trivially equal, which is what makes the gap worth closing.
+        msgs = agent.messages
+        prep = cm.prepare_minimal_history(msgs, keep_tail=keep_tail)
         cancelled = self._ask(
             request, decide, messages_to_keep=prep.keep_tail,
         )
@@ -368,7 +391,7 @@ class CompactionCoordinator:
             trigger=request.trigger,
             kind=request.kind,
             reason=request.reason,
-            messages=cm.apply_minimal_history(agent.messages, keep_tail=keep_tail),
+            messages=cm.apply_minimal_history(msgs, keep_tail=keep_tail),
             # This path makes no token estimate at all, and it is reached
             # only after the API has rejected the request twice.
             pre_tokens=None,

--- a/agentao/context_manager.py
+++ b/agentao/context_manager.py
@@ -133,12 +133,31 @@ class PreparedMicrocompact:
 
 @dataclass(frozen=True)
 class PreparedMinimalHistory:
-    """The ladder's last rung, in counts. Nothing is estimated here."""
+    """The ladder's last rung, in counts. Nothing is estimated here.
+
+    ``keep_tail`` is what the cut will actually keep, which is not always
+    what was asked for: the boundary is repaired so the window cannot open
+    on an orphaned tool result (``ContextManager._minimal_history_start``).
+    """
 
     keep_tail: int
 
 
 PrepareResult = Union[PreparedCompaction, PrepareRejected]
+
+
+def _is_tool_result(msg: Any) -> bool:
+    """True for a ``role: "tool"`` message — one half of the pairing rule."""
+    return isinstance(msg, dict) and msg.get("role") == "tool"
+
+
+def _made_tool_calls(msg: Any) -> bool:
+    """True for an assistant message that requested at least one tool call."""
+    return (
+        isinstance(msg, dict)
+        and msg.get("role") == "assistant"
+        and bool(msg.get("tool_calls"))
+    )
 
 
 def _is_pinned(msg: Any) -> bool:
@@ -1114,14 +1133,148 @@ class ContextManager:
             tool_results_to_clip=len(self._microcompactable_indices(messages)),
         )
 
+    @staticmethod
+    def _minimal_history_start(
+        messages: List[Dict[str, Any]], keep_tail: int
+    ) -> int:
+        """Index where the last rung's kept window opens.
+
+        The nominal boundary is ``len(messages) - keep_tail``, sliced from
+        the front rather than as ``messages[-keep_tail:]``: at
+        ``keep_tail == 0`` the negative form is ``messages[-0:]``, which is
+        the **whole list** — so the ladder's most destructive rung would
+        silently become a no-op and the turn would loop on the same overflow.
+
+        That boundary is then repaired so the window never *opens on* a
+        ``role: "tool"`` message. :meth:`_find_split_index` states the rule
+        for the summarizing path — a result cut from the ``tool_calls`` that
+        requested it is rejected by strict APIs — and this is the same rule
+        applied to the destructive one, where it costs more: this rung runs
+        only after the provider has already refused the request twice, so an
+        invalid retry spends the turn's last attempt on a 400 that is no
+        longer even a context-length error, and the ladder built to save the
+        turn ends it instead. The shape is not exotic: overflow is normally
+        detected on the call *after* a batch of tool results was appended, so
+        a two-message tail is routinely two results.
+
+        The repair is not symmetric with the summarizing path's, because the
+        two want opposite things from a boundary:
+
+        * **Drop the leading results.** The smallest window that is valid,
+          and shrinking is this rung's whole purpose. ``[tool, tool, user]``
+          keeps ``[user]``.
+        * **Unless that empties a window that had content.** Then step
+          *back* to the assistant that made the calls, which re-admits every
+          result of that one exchange for free — the window is a suffix, so
+          admitting the call admits everything after it. Returning nothing
+          would hand the model a system prompt and no conversation.
+
+        A window that was already empty stays empty: ``keep_tail == 0`` asks
+        for one, and that answer has to stay reachable.
+        """
+        start = max(0, len(messages) - max(0, keep_tail))
+        if start >= len(messages) or not _is_tool_result(messages[start]):
+            return start
+
+        ahead = start
+        while ahead < len(messages) and _is_tool_result(messages[ahead]):
+            ahead += 1
+        if ahead < len(messages):
+            return ahead
+
+        # Results all the way to the end. Walk back over the run they belong
+        # to and take the assistant that opened it.
+        first = start
+        while first > 0 and _is_tool_result(messages[first - 1]):
+            first -= 1
+        if first > 0 and _made_tool_calls(messages[first - 1]):
+            return first - 1
+
+        # No call in front of them anywhere: the history was already
+        # malformed, and keeping nothing is the only valid answer left.
+        return len(messages)
+
+    @staticmethod
+    def _window_answers_its_own_calls(window: List[Dict[str, Any]]) -> bool:
+        """True when every call in ``window`` is answered inside it, and vice versa.
+
+        :meth:`_minimal_history_start` closes the result → call direction:
+        the window cannot open on an orphaned result. It cannot close the
+        other one, and the docstring's "the window is a suffix, so admitting
+        the call admits everything after it" is only an argument about
+        *this* history — it says nothing about a call whose result was never
+        appended in the first place. A restored or truncated session can
+        hold an assistant message with three calls and one result, and
+        strict APIs reject that for the mirror reason.
+
+        Set equality rather than a positional walk: results follow their
+        call by construction everywhere agentao writes history, so a window
+        that holds both ends of every pair holds them in the right order.
+        """
+        declared: set = set()
+        answered: set = set()
+        for msg in window:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") == "tool":
+                answered.add(msg.get("tool_call_id"))
+            for call in msg.get("tool_calls") or ():
+                if isinstance(call, dict):
+                    declared.add(call.get("id"))
+        return declared == answered
+
+    def minimal_history_would_help(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        keep_tail: int = 2,
+    ) -> bool:
+        """True when the last rung's cut is worth applying.
+
+        The dual of :meth:`microcompact_would_mutate`, and it exists for the
+        same reason: being *at* a rung says nothing about that rung having
+        anything to do. Three ways the repaired cut is not worth making, all
+        of them reachable and none of them visible before the repair
+        existed, because a flat tail slice always shed something:
+
+        * **It sheds nothing.** One assistant message and a large batch of
+          its results is the single most likely shape at this rung, and the
+          smallest valid window over it is the whole history. Applying that
+          reports ``success``, invalidates the token anchor, emits a
+          compaction event with ``pre == post``, and hands the retry the
+          request the provider just refused.
+        * **It keeps nothing.** Valid, and useless: the turn's own request
+          is gone and the model is asked to answer a system prompt.
+        * **It cannot be made valid.** The window holds a call whose result
+          was never appended (:meth:`_window_answers_its_own_calls`).
+
+        In all three the honest answer is to change nothing and let the
+        provider's own context-length error reach the caller — which is
+        already what a *cancelled* overflow does.
+        """
+        start = self._minimal_history_start(messages, keep_tail)
+        if start <= 0 or start >= len(messages):
+            return False
+        return self._window_answers_its_own_calls(messages[start:])
+
     def prepare_minimal_history(
         self,
         messages: List[Dict[str, Any]],
         *,
         keep_tail: int = 2,
     ) -> "PreparedMinimalHistory":
-        """Describe the last rung. It makes no token estimate — nor does this."""
-        return PreparedMinimalHistory(keep_tail=keep_tail)
+        """Describe the last rung. It makes no token estimate — nor does this.
+
+        ``keep_tail`` on the result is the **effective** count, not the
+        requested one, because the boundary repair in
+        :meth:`_minimal_history_start` can move it either way. Both halves
+        read that one function, so the number a host sees in
+        ``messages_to_keep`` and the cut it is being asked to approve can
+        never disagree — the same reason :meth:`prepare_microcompact` wraps
+        the index set its transform rewrites.
+        """
+        start = self._minimal_history_start(messages, keep_tail)
+        return PreparedMinimalHistory(keep_tail=len(messages) - start)
 
     def apply_minimal_history(
         self,
@@ -1129,7 +1282,11 @@ class ContextManager:
         *,
         keep_tail: int = 2,
     ) -> List[Dict[str, Any]]:
-        """The overflow ladder's last rung: keep only the newest ``keep_tail``.
+        """The overflow ladder's last rung: cut history back to a short tail.
+
+        It is not simply the newest ``keep_tail`` messages in either
+        direction — the boundary repair below can shed more than was asked
+        for, or step back and keep more.
 
         One line, and it lived inline in the runner. It belongs here because
         rewriting history is this class's job and the coordinator's explicit
@@ -1137,12 +1294,10 @@ class ContextManager:
         named, unit-testable seam rather than a slice buried in an
         exception handler.
 
-        Sliced from the front rather than as ``messages[-keep_tail:]``: at
-        ``keep_tail == 0`` the negative form is ``messages[-0:]``, which is
-        the **whole list** — so the ladder's most destructive rung would
-        silently become a no-op and the turn would loop on the same overflow.
+        The boundary itself, and why it is not simply ``keep_tail`` messages
+        from the end, is :meth:`_minimal_history_start`.
         """
-        return messages[len(messages) - max(0, keep_tail):]
+        return messages[self._minimal_history_start(messages, keep_tail):]
 
     def _validate_host_summary(
         self,

--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -1278,17 +1278,27 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                         messages_with_system=messages_with_system,
                         measure_system_tokens=False,
                     )
-                    if run.outcome.status == "cancelled":
+                    if run.outcome.status != "success":
                         # A separate dispatch site from the rung above, and
                         # reachable only once that one was allowed, compacted
                         # successfully, and the request *still* overflowed —
                         # so it gets its own answer, with the same semantics:
                         # honoured and reported, never a quiet fall-through to
-                        # ``messages[-2:]``.
+                        # an unchanged history.
+                        #
+                        # Not just ``cancelled``: this rung also stands down
+                        # when the smallest *valid* window is the whole
+                        # history or none of it (``no_valid_minimal_cut``),
+                        # and retrying then means spending the turn's last
+                        # attempt on the request the provider just refused.
+                        # Every non-success here means history did not shrink,
+                        # so the provider's own error is the honest answer.
                         err_msg = f"[LLM API error: {e2}]"
                         agent.llm.logger.warning(
-                            "Minimal-history compaction cancelled by the host; "
-                            "returning the context-length error"
+                            "Minimal-history compaction did not shrink history "
+                            f"({run.outcome.status}"
+                            + (f": {run.outcome.detail}" if run.outcome.detail else "")
+                            + "); returning the context-length error"
                         )
                         agent.messages.append(
                             {"role": "assistant", "content": err_msg}

--- a/docs/design/compaction-orchestration-plan.md
+++ b/docs/design/compaction-orchestration-plan.md
@@ -327,6 +327,7 @@ missed.
 | Breaker already open (`:507`) | returns unchanged | `skipped` | no |
 | `len(messages) < 5` (`:517`) | returns unchanged | `skipped` | no |
 | Microcompaction has no targets (`microcompact_would_mutate` false) | stands down (`_compaction.py:32`) | `skipped` | no |
+| Last rung has no valid cut (`minimal_history_would_help` false) | added after this plan shipped — see §4.4.3's per-kind note | `skipped` | no |
 | Cancelled by host / hook | new | `cancelled` | no |
 | No safe split point (`:528`) | returns unchanged + increments (already `is_auto`-gated, `:540`) | `failed` | per PR-2's rule |
 | Summarization returned nothing (`:589`) | returns unchanged + increments **unconditionally** (`:590`) | `failed` | per PR-2's rule |
@@ -964,7 +965,7 @@ either. The three plans:
 |---|---|---|---|---|
 | `microcompact` | 1 | `prepare_microcompact()` → `PreparedMicrocompact`: `tool_results_to_clip`, `pre_tokens = None` (see below) | `allow` / `cancel` | Skip this pass; not re-dispatched for the rest of the turn; history byte-identical |
 | `full` | 2 / 3 / 5 | `PreparedCompaction` (above) | `allow` / `cancel` / `provide_summary` | See "Cancellation semantics" below |
-| `minimal_history` | 4 | `PreparedMinimalHistory`: `keep_tail = 2`, `pre_tokens = None` (this path makes no token estimate at all today — §4.2) | `allow` / `cancel` | Return the context-length error; no cut to `messages[-2:]` |
+| `minimal_history` | 4 | `PreparedMinimalHistory`: `keep_tail` = the **effective** kept count (planned as a flat `2`; see the note under the field table), `pre_tokens = None` (this path makes no token estimate at all today — §4.2) | `allow` / `cancel` | Return the context-length error; no cut to `messages[-2:]` |
 
 - **All three kinds share one request type**, `CompactionRequest(trigger, kind, reason)`. The
   difference lives entirely in what prepare produces and in `can_provide_summary`; the coordinator has
@@ -980,7 +981,7 @@ either. The three plans:
 |---|---|---|---|
 | `pre_tokens` | **`None`** (see below) | the value from `:587` | `None` (this path makes no estimate, §4.2) |
 | `messages_to_summarize` | `0` (nothing is summarized) | `len(to_summarize)` | `0` |
-| `messages_to_keep` | `len(messages)` (nothing dropped, only shortened) | `len(to_keep)` | `2` (`keep_tail`) |
+| `messages_to_keep` | `len(messages)` (nothing dropped, only shortened) | `len(to_keep)` | the **effective** kept count — see the note below |
 | `recently_read_files` | `()` | the result from `:574` | `()` |
 | `summary_input_budget` | `None` | `_summary_input_budget()` | `None` |
 | `max_summary_tokens` | `None` | half the budget | `None` |
@@ -990,6 +991,17 @@ either. The three plans:
   That last field exists for microcompaction specifically: `messages_to_summarize = 0` and
   `messages_to_keep = len(messages)` carry no information there, and a host deciding whether this pass
   is worth cancelling needs to know how many tool results are about to be clipped.
+
+- **`minimal_history`'s `messages_to_keep` was `2` (`keep_tail`) as planned, and is no longer.**
+  Shipped later: the rung's boundary is repaired so the kept window cannot *open on* a `role: "tool"`
+  message, which strict APIs reject — and this rung retries a request the provider has already
+  refused twice, so a malformed cut spends the turn's last attempt. The repair can move the boundary
+  either way, so `prepare_minimal_history` reports what the cut will actually keep. Both halves read
+  one boundary function (`ContextManager._minimal_history_start`), so the count a host approves and
+  the cut it approves cannot disagree. The same change cost this kind its exemption from a
+  would-mutate gate — a flat tail slice always shed something, a repaired boundary need not — so
+  `minimal_history` now has one next to microcompaction's (`minimal_history_would_help` →
+  `no_valid_minimal_cut`); see the row added to §2's status mapping.
 
 - **Microcompaction's `pre_tokens` is `None`, not `estimate_tokens(messages)` — the previous revision
   had this fighting §4.2.** §4.2 pins "this plan adds no new `estimate_tokens` call", and the **only**

--- a/docs/design/compaction-orchestration-plan.zh.md
+++ b/docs/design/compaction-orchestration-plan.zh.md
@@ -282,6 +282,7 @@ PreCompact 子进程——并发一条 pre == post 的 `CONTEXT_COMPRESSED`"）�
 | 熔断器已开（`:507`） | 原样返回 | `skipped` | 否 |
 | `len(messages) < 5`（`:517`） | 原样返回 | `skipped` | 否 |
 | 微压缩无可缩目标（`microcompact_would_mutate` 为假） | 退让（`_compaction.py:32`） | `skipped` | 否 |
+| 最后一级切不出有效窗口（`minimal_history_would_help` 为假） | 本计划落地之后才加——见 §4.4.3 的分 kind 说明 | `skipped` | 否 |
 | 宿主/hook 取消 | 新增 | `cancelled` | 否 |
 | 找不到安全切点（`:528`） | 原样返回 + 计数（已按 `is_auto` 门控，`:540`） | `failed` | 按 PR-2 规则 |
 | 摘要返回空（`:589`） | 原样返回 + **无条件**计数（`:590`） | `failed` | 按 PR-2 规则 |
@@ -819,7 +820,7 @@ class CompactionDecision:
 |---|---|---|---|---|
 | `microcompact` | 1 | `prepare_microcompact()` → `PreparedMicrocompact`：`tool_results_to_clip`、`pre_tokens = None`（见下） | `allow` / `cancel` | 跳过这一趟；本回合内不再派发；历史逐字节不变 |
 | `full` | 2 / 3 / 5 | `PreparedCompaction`（上文） | `allow` / `cancel` / `provide_summary` | 见下面的"取消语义" |
-| `minimal_history` | 4 | `PreparedMinimalHistory`：`keep_tail = 2`、`pre_tokens = None`（这条路径今天不做任何 token 估算，见 §4.2） | `allow` / `cancel` | 返回 context-length 错误，不裁 `messages[-2:]` |
+| `minimal_history` | 4 | `PreparedMinimalHistory`：`keep_tail` = **实际**保留条数（计划里是死的 `2`，见字段表下方说明）、`pre_tokens = None`（这条路径今天不做任何 token 估算，见 §4.2） | `allow` / `cancel` | 返回 context-length 错误，不裁 `messages[-2:]` |
 
 - **三种 kind 共用一个请求类型** `CompactionRequest(trigger, kind, reason)`。差异全落在 prepare 的产出
   与 `can_provide_summary` 上，coordinator 的骨架只有一份。
@@ -833,7 +834,7 @@ class CompactionDecision:
 |---|---|---|---|
 | `pre_tokens` | **`None`**（见下） | `:587` 的值 | `None`（该路径不做估算，§4.2） |
 | `messages_to_summarize` | `0`（不摘要） | `len(to_summarize)` | `0` |
-| `messages_to_keep` | `len(messages)`（一条不删，只缩内容） | `len(to_keep)` | `2`（`keep_tail`） |
+| `messages_to_keep` | `len(messages)`（一条不删，只缩内容） | `len(to_keep)` | **实际**保留条数——见下方说明 |
 | `recently_read_files` | `()` | `:574` 的结果 | `()` |
 | `summary_input_budget` | `None` | `_summary_input_budget()` | `None` |
 | `max_summary_tokens` | `None` | 预算的一半 | `None` |
@@ -842,6 +843,15 @@ class CompactionDecision:
 
   最后一个字段是为微压缩专门加的：`messages_to_summarize = 0` / `messages_to_keep = len(messages)` 对它
   没有任何信息量，宿主要判断"这一趟值不值得取消"，需要知道会裁掉几条工具结果。
+
+- **`minimal_history` 的 `messages_to_keep` 计划里是 `2`（`keep_tail`），现在不是了。** 这是后来才上的：
+  该级的边界会被修复，使保留窗口不会**开在**一条 `role: "tool"` 消息上——严格 API 会直接拒绝这种历史，
+  而这一级重试的是模型已经拒过两次的请求，切坏了就把这一轮最后一次机会花在报错上。修复可能把边界往两个
+  方向挪，所以 `prepare_minimal_history` 报的是这一刀实际会保留多少条。两半读的是同一个边界函数
+  （`ContextManager._minimal_history_start`），因此宿主批准的数字和它批准的那一刀不会对不上。同一个改动
+  也让这种 kind 失去了"不需要 would-mutate 闸门"的豁免——平切尾巴必然削掉点什么，修复过的边界不一定——
+  所以 `minimal_history` 现在有了自己的闸门，就挨着微压缩那道（`minimal_history_would_help` →
+  `no_valid_minimal_cut`）；见 §2 状态映射表里新增的那一行。
 
 - **微压缩的 `pre_tokens` 是 `None`，不是 `estimate_tokens(messages)`——上一版这里与 §4.2 打架。**
   §4.2 定死"本计划不新增任何一次 `estimate_tokens` 调用"，而微压缩今天**唯一**存在的那次估算算的是

--- a/tests/test_compaction_control_plane.py
+++ b/tests/test_compaction_control_plane.py
@@ -16,6 +16,7 @@ history to the last two messages.
 
 from __future__ import annotations
 
+import copy
 import json
 import stat
 from types import SimpleNamespace
@@ -163,7 +164,7 @@ def test_first_cancel_wins_and_stops_the_remaining_forks(tmp_path):
 def test_a_cancelled_compaction_leaves_history_byte_identical(tmp_path):
     cm = _make_cm()
     msgs = _history()
-    before = [dict(m) for m in msgs]
+    before = copy.deepcopy(msgs)
     rule = _hook(tmp_path, _emits({
         "hookSpecificOutput": {"compactionDecision": "cancel", "reason": "busy"}
     }))
@@ -277,11 +278,30 @@ def test_the_latch_is_cleared_at_the_start_of_the_next_turn(tmp_path):
 def test_the_other_two_kinds_are_cancellable_too(tmp_path, kind, reason):
     cm = _make_cm()
     # An oversized tool result, so microcompaction has something to clip and
-    # the "no targets" gate does not fire before the decision step.
+    # the "no targets" gate does not fire before the decision step. The
+    # results carry the assistant message that requested them because a
+    # result with no call in front of it is a history no provider accepts,
+    # and ``minimal_history`` now refuses to hand one back (see
+    # ``ContextManager._minimal_history_start``) — a fixture that skipped it
+    # was measuring the repair's give-up branch, not this test's subject.
+    _ids = [f"c{i}" for i in range(7)]
     msgs = _history() + [
-        {"role": "tool", "name": "read_file", "content": "z" * 50_000},
-    ] + [{"role": "tool", "name": "read_file", "content": "s"} for _ in range(6)]
-    before = [dict(m) for m in msgs]
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": i, "type": "function",
+                 "function": {"name": "read_file", "arguments": "{}"}}
+                for i in _ids
+            ],
+        },
+        {"role": "tool", "tool_call_id": _ids[0], "name": "read_file",
+         "content": "z" * 50_000},
+    ] + [
+        {"role": "tool", "tool_call_id": i, "name": "read_file", "content": "s"}
+        for i in _ids[1:]
+    ]
+    before = copy.deepcopy(msgs)
     seen = []
 
     def _controller(ctx):
@@ -301,7 +321,12 @@ def test_the_other_two_kinds_are_cancellable_too(tmp_path, kind, reason):
     if kind == "microcompact":
         assert ctx.tool_results_to_clip is not None
     else:
-        assert ctx.messages_to_keep == 2
+        # Not the nominal ``keep_tail`` of 2: this tail is all tool results,
+        # so the boundary steps back to the one assistant message that
+        # requested them and the window is that call plus its seven results.
+        # The host is shown the cut it is being asked to approve.
+        assert ctx.messages_to_keep == 8
+        assert ctx.messages_to_keep == len(cm.apply_minimal_history(msgs))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_compaction_coordinator.py
+++ b/tests/test_compaction_coordinator.py
@@ -293,6 +293,178 @@ def test_apply_minimal_history_is_a_named_seam():
 
 
 # ---------------------------------------------------------------------------
+# minimal_history: the boundary may not orphan a tool result
+#
+# The rung runs only after the provider refused the request twice, so an
+# invalid retry spends the turn's last attempt on a 400 that is no longer a
+# context-length error. ``_find_split_index`` has always enforced this rule
+# on the summarizing path; these pin it on the destructive one.
+# ---------------------------------------------------------------------------
+
+def _call(*ids):
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {"id": i, "type": "function",
+             "function": {"name": "read_file", "arguments": "{}"}}
+            for i in ids
+        ],
+    }
+
+
+def _result(call_id):
+    return {"role": "tool", "tool_call_id": call_id, "content": "x" * 50}
+
+
+def test_minimal_history_admits_the_call_when_the_tail_is_all_results():
+    """The routine shape: overflow is detected on the request *after* a batch
+    of results was appended, so ``messages[-2:]`` is two results whose
+    ``tool_calls`` sit one message further back."""
+    cm = _make_cm()
+    msgs = [
+        {"role": "user", "content": "do it"},
+        _call("c1", "c2"),
+        _result("c1"),
+        _result("c2"),
+    ]
+
+    kept = cm.apply_minimal_history(msgs, keep_tail=2)
+
+    assert [m["role"] for m in kept] == ["assistant", "tool", "tool"]
+    # Every call in the admitted assistant message is answered inside the
+    # window — the property the provider actually checks.
+    answered = {m["tool_call_id"] for m in kept if m["role"] == "tool"}
+    assert {tc["id"] for tc in kept[0]["tool_calls"]} == answered
+
+
+def test_minimal_history_drops_leading_results_when_something_follows():
+    """Shrinking wins whenever a valid window survives the drop: stepping
+    back to the call would re-admit the very results this rung is shedding."""
+    cm = _make_cm()
+    msgs = [_call("c1"), _result("c1"), {"role": "user", "content": "next"}]
+
+    assert cm.apply_minimal_history(msgs, keep_tail=2) == [msgs[-1]]
+
+
+def test_minimal_history_keeps_nothing_rather_than_orphan_a_stray_result():
+    """A history that opens on a result was already malformed. There is no
+    call to admit, so the only valid answer left is the empty one."""
+    cm = _make_cm()
+
+    assert cm.apply_minimal_history([_result("c1"), _result("c2")]) == []
+
+
+def test_minimal_history_repair_never_resurrects_a_zero_window():
+    """``keep_tail=0`` asks for nothing, and the ladder needs that answer to
+    stay reachable — the repair may not read it as a window to widen."""
+    cm = _make_cm()
+    msgs = [{"role": "user", "content": "do it"}, _call("c1"), _result("c1")]
+
+    assert cm.apply_minimal_history(msgs, keep_tail=0) == []
+
+
+def test_prepared_count_is_what_the_rung_actually_keeps():
+    """``messages_to_keep`` reaches the host control plane, which approves or
+    cancels this cut. Both halves read one boundary function so the number
+    and the cut cannot disagree."""
+    cm = _make_cm()
+    msgs = [
+        {"role": "user", "content": "do it"},
+        _call("c1", "c2"),
+        _result("c1"),
+        _result("c2"),
+    ]
+
+    prepared = cm.prepare_minimal_history(msgs, keep_tail=2)
+
+    assert prepared.keep_tail == 3
+    assert prepared.keep_tail == len(cm.apply_minimal_history(msgs, keep_tail=2))
+
+
+def test_minimal_history_stands_down_when_the_valid_window_is_everything():
+    """The likeliest shape at this rung: one assistant message and a big batch
+    of its results. The smallest window that is not orphaned is the whole
+    history, so there is no cut to make — and reporting ``success`` for it
+    would emit a compaction whose pre and post are equal, then hand the retry
+    the request the provider just refused."""
+    cm = _make_cm()
+    ids = [f"c{i}" for i in range(20)]
+    msgs = [_call(*ids)] + [_result(i) for i in ids]
+    before = list(msgs)
+    agent, events = _make_agent(cm, msgs)
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "minimal_history", "api_overflow_after_compression"),
+        system_prompt="sys",
+    )
+
+    assert run.outcome.status == "skipped"
+    assert run.outcome.detail == "no_valid_minimal_cut"
+    assert agent.messages == before
+    # ``skipped`` is silent, and the compaction event would have lied anyway.
+    assert _settled(events) == []
+    assert not [e for e in events if _kinds([e])[0] == "context_compressed"]
+
+
+def test_minimal_history_stands_down_rather_than_keep_nothing():
+    """Valid and useless: the turn's own request is gone and the model would
+    be asked to answer a system prompt."""
+    cm = _make_cm()
+    msgs = [{"role": "user", "content": "do it"}, _result("c1"), _result("c2")]
+    agent, _events = _make_agent(cm, msgs)
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "minimal_history", "api_overflow_after_compression"),
+        system_prompt="sys",
+    )
+
+    assert run.outcome.status == "skipped"
+    assert agent.messages == msgs
+
+
+def test_minimal_history_stands_down_on_a_call_whose_result_never_arrived():
+    """The mirror orphan. The boundary repair closes result -> call; it cannot
+    close call -> result, because a result that was never appended is not in
+    the history to admit. Strict APIs reject that window too."""
+    cm = _make_cm()
+    msgs = [{"role": "user", "content": "u"}, _call("c1", "c2", "c3"), _result("c1")]
+    agent, _events = _make_agent(cm, msgs)
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "minimal_history", "api_overflow_after_compression"),
+        system_prompt="sys",
+    )
+
+    assert run.outcome.status == "skipped"
+    assert agent.messages == msgs
+    # The predicate, directly: the window is the assistant plus one of three.
+    assert cm._window_answers_its_own_calls(msgs[1:]) is False
+    assert cm._window_answers_its_own_calls(msgs[1:] + [_result("c2"), _result("c3")])
+
+
+def test_minimal_history_run_leaves_no_orphan_in_agent_messages():
+    """End to end through the coordinator, which is what the runner retries."""
+    cm = _make_cm()
+    msgs = [
+        {"role": "user", "content": "do it"},
+        _call("c1", "c2"),
+        _result("c1"),
+        _result("c2"),
+    ]
+    agent, _events = _make_agent(cm, msgs)
+
+    run = agent.compaction_coordinator.run(
+        CompactionRequest("auto", "minimal_history", "api_overflow_after_compression"),
+        system_prompt="sys",
+    )
+
+    assert run.outcome.status == "success"
+    assert agent.messages[0]["role"] == "assistant"
+    assert run.messages_with_system[1]["role"] == "assistant"
+
+
+# ---------------------------------------------------------------------------
 # prepare / commit
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The defect

`apply_minimal_history` — the overflow recovery ladder's last rung — kept the newest two messages by a blind tail slice. Overflow is normally detected on the request *after* a batch of tool results was appended, so that tail is routinely two `role: "tool"` messages whose `tool_calls` sat one message further back. Strict APIs reject that outright.

The rung runs only once the provider has already refused the request twice, so the malformed retry spent the turn's last attempt on a 400 that was no longer even a context-length error. The ladder built to save the turn ended it instead.

Reproduced before the fix:

```
history: [user, assistant(tool_calls c1,c2), tool c1, tool c2]
kept:    ['tool', 'tool']          # both orphaned
```

`_find_split_index` has enforced this rule on the *summarizing* path all along — its docstring says cutting on a `role: "tool"` message "strands it from its `tool_calls` and strict APIs reject the result". It was never applied to the destructive path. Nothing repairs it downstream either: `_build_request_kwargs` passes the list through untouched, and `backfill_orphaned_tool_calls` only fills unanswered calls, at turn end.

## The fix

**`_minimal_history_start` repairs the boundary.** Drop the leading results when a valid window survives without them (shrinking is this rung's purpose). Otherwise step back to the assistant that made the calls, which re-admits that exchange's results for free because the window is a suffix.

**That costs this kind its exemption from a would-mutate gate.** A flat tail slice always shed something, so `success` implied history changed. A repaired boundary need not. `minimal_history_would_help` gates the attempt to `skipped` in the three cases where the cut is not worth making:

| Case | Why it is not worth making |
|---|---|
| Smallest valid window is the whole history | One assistant message plus a large batch of its results — the likeliest shape at this rung |
| Window is empty | Valid and useless: the turn's request is gone and the model answers a system prompt |
| Window cannot answer its own calls | A result was never appended; the repair closes result → call, never call → result |

So no `CONTEXT_COMPRESSED` fires with `pre == post`, and the token anchor is not dropped for a rewrite that did not happen. The gate sits beside the existing no-target microcompact gate.

**The runner returns the provider's context-length error on any non-success at this rung**, not only on a cancel. Nothing shrank in all three cases, so retrying spends the turn's last attempt on the request that just failed.

**`messages_to_keep` is now the effective count**, so a `compaction_controller` is shown the cut it is approving. The coordinator binds `agent.messages` once and hands the same list to both halves, since the controller runs between them and the boundary is no longer content-free.

## Fixture, not assertion

The control-plane test that pinned `messages_to_keep == 2` built its history from seven tool results with no assistant message in front of them. Under the repair that history has no call to admit, so the rung correctly keeps nothing and the pinned count went to zero. The fixture was fixed rather than the assertion: a history no provider would accept was never the right input for a test about cancellability.

## Not in this PR

In the shape where the smallest valid window is the whole history, the ladder still cannot save the turn. Escaping it needs a *content* transform, which this rung does not have. Two candidates, neither taken here: clip the re-admitted results via microcompaction (helps only when they are not already at the clip floor from rung 1), or drop results and rewrite the assistant's `tool_calls` to match (shrinks reliably, fabricates a message the model never sent).

The runner change is covered only through the coordinator contract it branches on. This repo has no runner-level tests for the overflow ladder.

## Verification

- `uv run python -m pytest tests/` — 4938 passed, 31 skipped
- `uv run ruff check .` — clean
- 9 new tests: the routine shape, the drop case, the unrepairable case, the zero window, prepare/apply agreement, all three stand-downs, and one end to end through the coordinator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHwWU5ZhiLBNCRHmSiWcjp
