### PR TITLE
chore(release): prepare 0.4.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased]
-
-_Targeting 0.4.23. Add entries under the relevant heading as work lands._
+## [0.4.23] — 2026-09-11
 
 ### Added
 
@@ -28,9 +26,17 @@ _Targeting 0.4.23. Add entries under the relevant heading as work lands._
   every later turn and the loop would spin on a dead provider forever. Purely
   host-side; the harness is untouched.
 
-### Changed
-
 ### Fixed
+
+- **`/replays show` reported no rule count for half the hook events, and
+  coloured a refusal as if it had succeeded.** The summary line read
+  `rule_count`, but `PreToolUse`, `Stop` and `PreCompact` send
+  `matched_rule_count` — there is no matched count in hand where the other
+  three emit — so those three rendered `rules=None` while the event carried
+  the number all along. The outcome colour map covered three of the ten
+  outcomes the six emit sites actually produce, so a `PreToolUse` `deny` and a
+  `PreCompact` `cancel` both rendered green, which is the colour the renderer
+  uses for "nothing happened". Both renderers now share one definition of each.
 
 - **A hook's notice now actually reaches the user.** Four of the eight hook
   events are dispatched by a caller that owns an output and consumed its return
@@ -132,9 +138,12 @@ _Targeting 0.4.23. Add entries under the relevant heading as work lands._
   that prevents `--resume` from starting the CLI at all, and an interactive
   resume no longer skips the memory-session archive, which had left the
   abandoned conversation's summaries bound to the resumed session. The values
-  agentao emits are now enumerated in `docs/reference/configuration.md` §11;
-  `compact` and `fork` are never emitted, and ACP dispatches neither event on
-  any path. Design and the two recorded gaps:
+  agentao emits are now enumerated in `docs/reference/configuration.md` §11.
+  This entry originally closed by saying that `compact` is never emitted and
+  that ACP dispatches neither event; both were true of this change and are
+  **superseded by the two entries above**, which were reviewed and landed
+  separately in the same cycle. `fork` is still never emitted — agentao has no
+  thread fork. Design and the recorded gaps:
   `docs/design/session-lifecycle-source-vs-codex.md`.
 
 - **The overflow ladder's last rung no longer hands the provider an orphaned

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.23.dev0"
+__version__ = "0.4.23"
 
 
 def _ensure_utf8() -> None:

--- a/agentao/cli/replay_render/_summary.py
+++ b/agentao/cli/replay_render/_summary.py
@@ -5,6 +5,50 @@ from __future__ import annotations
 from rich.markup import escape as markup_escape
 
 
+# ``plugin_hook_fired`` outcome → colour. The vocabulary is per ``hook_name``
+# and this has to cover the union of all six emit sites, not the three the
+# renderer was first written against: a ``PreToolUse`` ``deny``, a
+# ``PreCompact`` ``cancel`` and a ``PostToolUse*`` ``notice`` all fell through
+# to the default and rendered green, i.e. a refused tool call read as fine.
+_HOOK_OUTCOME_COLORS = {
+    "block": "error",
+    "deny": "error",
+    "stop": "warning",
+    "ask": "warning",
+    "cancel": "warning",
+    "reentry_capped": "warning",
+    "modify": "yellow",
+    "notice": "yellow",
+}
+
+
+def _hook_outcome_color(outcome: str) -> str:
+    """Colour for one ``plugin_hook_fired`` outcome. Unknown → green.
+
+    Green is the right default: a value this table does not know is either
+    ``allow`` or one of the ``continue`` family, and an unrecognised future
+    verdict should not be coloured as a failure on a guess.
+    """
+    return _HOOK_OUTCOME_COLORS.get(outcome, "green")
+
+
+def _hook_rule_count(payload: dict) -> object:
+    """The event's rule count, whichever of the two fields carries it.
+
+    ``PreToolUse`` / ``Stop`` / ``PreCompact`` send ``matched_rule_count``
+    (rules selected for dispatch); ``UserPromptSubmit`` / ``PostToolUse*`` /
+    the post-compaction ``SessionStart`` send ``rule_count`` (rules
+    configured), because at the point they emit there is no matched count in
+    hand. Reading only one of the two rendered ``rules=None`` for half the
+    hook events.
+    """
+    for key in ("matched_rule_count", "rule_count"):
+        value = payload.get(key)
+        if value is not None:
+            return value
+    return None
+
+
 def _summarize_replay_event(event: dict) -> str:
     """Return a short one-line summary for a replay event in /replays show.
 
@@ -213,11 +257,12 @@ def _summarize_replay_event(event: dict) -> str:
         )
     if kind == "plugin_hook_fired":
         outcome = str(payload.get("outcome", "allow"))
-        color = {"block": "error", "stop": "warning", "modify": "yellow"}.get(outcome, "green")
+        color = _hook_outcome_color(outcome)
+        count = _hook_rule_count(payload)
+        rules = f" rules={count}" if count is not None else ""
         return (
             f"[{color}]{outcome}[/{color}] "
-            f"[dim]{markup_escape(str(payload.get('hook_name', '')))} "
-            f"rules={payload.get('rule_count')}[/dim]"
+            f"[dim]{markup_escape(str(payload.get('hook_name', '')))}{rules}[/dim]"
         )
     # ── v1.2 host-projected audit kinds ─────────────────────────────
     # These mirror the public models in ``agentao.host.models``. They

--- a/agentao/cli/replay_render/_turn.py
+++ b/agentao/cli/replay_render/_turn.py
@@ -13,7 +13,7 @@ from ._fmt import (
     _preview,
 )
 from ._grouping import _collect_tool_rows
-from ._summary import _summarize_replay_event
+from ._summary import _hook_outcome_color, _summarize_replay_event
 
 
 def _print_turn(turn: dict, console_) -> None:
@@ -278,8 +278,8 @@ def _print_turn(turn: dict, console_) -> None:
                 console_.print(f"  [dim]perm[/dim]    {_summarize_replay_event(e)}")
         elif kind == "plugin_hook_fired":
             p = e.get("payload") or {}
-            outcome = p.get("outcome", "allow")
-            color = {"block": "error", "stop": "warning", "modify": "yellow"}.get(outcome, "green")
+            outcome = str(p.get("outcome", "allow"))
+            color = _hook_outcome_color(outcome)
             console_.print(
                 f"  [dim]hook[/dim]    "
                 f"[{color}]{outcome}[/{color}] "

--- a/docs/releases/v0.4.23.md
+++ b/docs/releases/v0.4.23.md
@@ -1,0 +1,141 @@
+# Agentao 0.4.23
+
+A **session-lifecycle release**. 0.4.21 established, by probing a real
+`claude` 2.1.251, that a `SessionStart` / `SessionEnd` matcher is compared
+against the payload's `source` and `reason` — and that returning the empty
+string for them made every non-wildcard matcher on those events silently dead.
+That fix routed the field to the matcher. This release gives the field a value.
+
+Both payloads had shipped a constant for as long as they existed: always
+`source: "startup"`, always `reason: "other"`. The adapter had taken the value
+as an argument since the profile landed, and no caller ever passed one. So a
+rule written `matcher: "clear"` or `matcher: "resume"` never ran, and a rule
+written `matcher: "startup"` ran on every `/clear`.
+
+The headline:
+
+- **The values are real, on every entry point.** `/clear` and `/new` report
+  `clear`, both resume paths report `resume`, an interactive exit reports
+  `prompt_input_exit`, and `agentao run` keeps `other` as upstream's own value
+  for an unnamed cause.
+- **`/sessions resume` used to dispatch neither event.** It now ends the
+  outgoing session and starts the incoming one, hooks only.
+- **ACP dispatched neither event on any path.** It now fires both, at the two
+  points that are actually a session starting and a session ending.
+- **A full compaction fires `SessionStart(source: "compact")`.** The session
+  survives; its context does not, which is the case this value exists for.
+- **A hook's notice now reaches the user.** Four of the eight events returned
+  their notices to a caller that printed them. The other four had a payload
+  field and no reader on any surface, so every notice they produced was
+  computed and dropped.
+- **A `/goal` that stops making progress now stops.** The budgets bound how
+  much a goal may do; nothing bounded how long it could do nothing.
+
+## The values, by entry point
+
+| Entry point | `SessionStart.source` | `SessionEnd.reason` |
+|---|---|---|
+| CLI startup | `startup` | — |
+| interactive exit (`/exit`, EOF) | — | `prompt_input_exit` |
+| `agentao --resume`, successful load | `resume` | — |
+| `agentao --resume`, failed load, CLI starts anyway | `startup` | — |
+| `/sessions resume`, successful load | `resume` | `resume` |
+| `/sessions resume`, failed load | — | — |
+| `/clear` and `/new` | `clear` | `clear` |
+| `agentao run` | `startup` | `other` |
+| ACP `session/new` | `startup` | — |
+| ACP `session/load` | `resume` | — |
+| ACP session closing | — | `other` |
+| after a successful full compaction | `compact` | — |
+
+`fork` is never emitted: agentao has no thread fork.
+
+The two load failures are deliberately not symmetric. An interactive resume
+that fails keeps the session the user is in and dispatches nothing — nothing
+started and nothing ended. A startup resume that fails still enters the CLI, so
+a real new session begins and reports `startup`. A startup `--resume` that
+succeeds leaves a one-shot marker for the dispatch the loop already makes,
+rather than adding its own; that is what keeps the path at one `SessionStart`
+instead of `resume` followed by `startup`.
+
+## ACP
+
+This is not three more dispatch calls. ACP holds several sessions at once, a
+client supplies its own id on `session/load` and can pipeline a prompt behind
+it, and a startup `--resume` turns the first `session/new` into a resume.
+
+`SessionStart` runs on session registration, inside the lock, **after** the
+duplicate check — so a load about to be rejected runs no user commands — and
+**before** the session is published, so no prompt can start a turn in front of
+the context a hook injected. It fires after history is restored, because
+injected context is appended to the message list and a restore would discard it.
+
+`SessionEnd` follows the real close path, behind the idempotence guard, so a
+double close dispatches once. Creating or loading a session ends nothing, and a
+cancelled turn is not a session ending.
+
+The dispatch itself moved to `agentao/plugins/hooks/lifecycle.py`, which is how
+ACP reaches it without importing the CLI. The CLI's two helpers are now aliases
+for the same functions and keep their printing.
+
+## Compaction
+
+Scope is narrow and it is agentao's own choice: a **successful** **full**
+compaction only. `microcompact` runs on most iterations inside its band and
+`minimal_history` is the overflow ladder's last rung; neither rebuilds a
+session, and firing there would re-inject the same context repeatedly on the one
+path where the request is already too large. That is also why this is not wired
+to `CONTEXT_COMPRESSED`, which is not gated by compaction kind.
+
+The dispatch sits between the history replacement and the assembly of the next
+request, so a hook's `additionalContext` is in the very request the compaction
+was performed for. The session id does not change, no `SessionEnd` is emitted,
+and a hook failure cannot undo a compaction that already succeeded.
+
+## A notice with no reader
+
+`SessionStart`, `SessionEnd`, `PostToolUse` and `PostToolUseFailure` hand their
+user notices back to whoever dispatched them. `UserPromptSubmit` and `Stop` fire
+inside the chat loop, the aggregated tool-hook notices inside a tool worker, and
+the post-compaction `SessionStart` inside the compaction coordinator — none of
+which owns an output. Those rode a `PLUGIN_HOOK_FIRED` payload field that no
+first-party surface read, so a `systemMessage`, an exit-2 stderr line or a
+profile field diagnostic from any of them was computed, capped, stored and
+dropped.
+
+All three surfaces read it now. The CLI prints through the same renderer the
+lifecycle notices use, `agentao run` folds it into its result warnings, and ACP
+maps it onto the same message chunk the direct notice writer produces, so a
+client cannot tell the two paths apart.
+
+`Stop`'s `systemMessage` joins that field gated on contract: under
+`claude-code@profile-1` it goes to the user and only the user, which is what the
+reference says the field is for, while `agentao-v1` keeps its documented
+double-write into the model's context.
+
+## Also in this release
+
+- **A `/goal` no-progress guard.** Three consecutive turns that produce no
+  answer and call no tools, or that fail at the provider, mark the goal
+  `blocked`. It is the only stop condition that survives `--unbounded`.
+  `llm_error` deliberately ignores the turn's tool count, which accumulates
+  across a turn's iterations — one call made before the provider started
+  failing would otherwise reset the streak forever.
+- **The overflow ladder's last rung no longer orphans a tool result.** Its
+  window could open on a `role: "tool"` message whose call sat one message
+  back, which strict APIs reject — on the turn's last attempt. It also now
+  stands down instead of reporting a compaction that changed nothing.
+- **Two failures a hook could cause on its way to the terminal.** A notice is a
+  hook's stderr, and it was interpolated raw at a markup boundary: one tag
+  rendered it invisible, another raised out of the dispatch and stopped the CLI
+  from starting. Separately, a session file that parsed but was not an object
+  raised past every corrupt-file handler in the store, taking down `--resume`
+  and the session list.
+
+## Compatibility
+
+`agentao-v1` rules match the same rules the same number of times. What changes
+is the input: the dispatcher hands v1 the full envelope verbatim, so a script
+reading `data.source` or `data.reason` can behave differently — correctly, for
+the first time. The one place a v1 behaviour change was possible, `Stop`'s
+`systemMessage`, is gated at the parser and keeps its old routing.

--- a/tests/test_replay_render_coverage.py
+++ b/tests/test_replay_render_coverage.py
@@ -403,3 +403,70 @@ def test_audit_events_land_in_their_turn_through_the_real_wiring(tmp_path):
     assert "deny" in out
     assert "PermissionDenied" in out
     assert "bg-7" in out
+
+
+# ---------------------------------------------------------------------------
+# `plugin_hook_fired` — the two rule-count fields and the outcome vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_the_summary_reports_a_rule_count_the_producer_actually_emits(tmp_path):
+    """Bind the summarizer to a real `Stop` emit, not to a hand-written dict.
+
+    The renderer read `rule_count` only. Three of the six emit sites send
+    `matched_rule_count` instead — there is no matched count in hand at the
+    other three — so `Stop`, `PreToolUse` and `PreCompact` all rendered
+    `rules=None` while the event carried the number the whole time.
+    """
+    from agentao.plugins.models import ParsedHookRule
+
+    from .support.stop_precompact import make_runner_with_rules
+
+    rule = ParsedHookRule(
+        event="Stop", hook_type="command", command="echo '{}'", plugin_name="t",
+    )
+    runner, transport = make_runner_with_rules(tmp_path, rules=[rule])
+    stop_result = runner._dispatch_stop(
+        turn_end_reason="final_response", last_assistant_message="answer",
+    )
+    runner._emit_stop_hook_fired(
+        outcome="allow", turn_end_reason="final_response", stop_result=stop_result,
+    )
+    fired = transport.hook_fired_events("Stop")
+    assert len(fired) == 1
+    assert "rule_count" not in fired[0].data, (
+        "Stop started sending rule_count — re-read the summarizer's two-field read"
+    )
+
+    summary = _summarize_replay_event(
+        {"kind": "plugin_hook_fired", "payload": dict(fired[0].data)}
+    )
+    assert "rules=1" in summary
+    assert "rules=None" not in summary
+
+
+def test_a_hook_event_with_no_count_at_all_omits_the_segment():
+    summary = _summarize_replay_event(
+        {"kind": "plugin_hook_fired", "payload": {"hook_name": "Stop", "outcome": "allow"}}
+    )
+    assert "rules" not in summary
+
+
+@pytest.mark.parametrize(
+    "outcome,color",
+    [
+        ("deny", "error"),           # PreToolUse refused the call
+        ("cancel", "warning"),       # PreCompact refused the compaction
+        ("notice", "yellow"),        # PostToolUse* has something to say
+        ("block", "error"),
+        ("allow", "green"),
+        ("continue", "green"),
+        ("some_future_verdict", "green"),
+    ],
+)
+def test_every_outcome_in_the_vocabulary_is_coloured_for_what_it_means(outcome, color):
+    """A refused tool call and a refused compaction used to render green,
+    because the map covered only the three outcomes the first hook events had."""
+    from agentao.cli.replay_render._summary import _hook_outcome_color
+
+    assert _hook_outcome_color(outcome) == color


### PR DESCRIPTION
Cuts 0.4.23: version to `0.4.23`, `[Unreleased]` promoted, and
`docs/releases/v0.4.23.md` written. The empty `### Changed` heading is dropped
rather than shipped blank.

## What the audit found

The both-directions check against `git log v0.4.22..main` came back complete:
three merges, of which the dev-cycle open takes no entry by convention, and nine
entries that each map to real merged work. The other two audit questions did not.

**An entry in this cycle was invalidated by two later entries in the same
cycle.** The lifecycle-values entry closed by saying `compact` is never emitted
and that ACP dispatches neither event. Both were true when it was written, and
both were made false inside the same `[Unreleased]` block by the ACP batch and
the compaction batch. Marked superseded rather than rewritten, so the reading
order still makes sense.

**Grepping for in-repo consumers of the changed event found a renderer that had
been wrong since the events it renders landed.** `/replays show` printed
`rules=` from `rule_count` alone, but `PreToolUse`, `Stop` and `PreCompact` send
`matched_rule_count` — there is no matched count in hand where the other three
emit — so those three rendered `rules=None` while the event carried the number
all along. Its outcome colour map knew three of the ten outcomes the six emit
sites produce, so a `PreToolUse` `deny` and a `PreCompact` `cancel`, a refused
tool call and a refused compaction, both rendered in the colour the renderer
uses for nothing having happened. Both renderers now share one definition of
each, and the summarizer is pinned to a real `Stop` emit rather than a
hand-written payload, so the next divergence between producer and consumer
fails a test.

Nothing from a previously shipped release was invalidated. 0.4.21's note that
`SessionStart` / `SessionEnd` matchers compare against `source` and `reason`
describes the probe finding, not agentao's routing, so this release completes it
rather than contradicting it.

## Testing

`ruff check .` clean. Full suite 5016 passed, 31 skipped. `uv build` followed by
`-m slow` green at 9 passed, which is the tier CI runs in the build job.

Release-notes pre-flight: zero relative links in `docs/releases/v0.4.23.md`, as
the convention requires — that file is also the published Release body, and
GitHub resolves relative links against the repository root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHwWU5ZhiLBNCRHmSiWcjp
